### PR TITLE
feat(s3): remove range concept in MemoryMetadataManager

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/stream/S3WALObject.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/stream/S3WALObject.java
@@ -17,11 +17,11 @@
 
 package org.apache.kafka.metadata.stream;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.metadata.WALObjectRecord;
-import org.apache.kafka.common.metadata.WALObjectRecord.StreamIndex;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 public class S3WALObject {
@@ -29,22 +29,24 @@ public class S3WALObject {
     private final long objectId;
 
     private final int brokerId;
-    private final Map<Long/*streamId*/, S3ObjectStreamIndex> streamsIndex;
+    private final Map<Long/*streamId*/, List<S3ObjectStreamIndex>> streamsIndex;
 
     private final S3ObjectType objectType = S3ObjectType.UNKNOWN;
 
-    public S3WALObject(long objectId, int brokerId, final Map<Long, S3ObjectStreamIndex> streamsIndex) {
+    public S3WALObject(long objectId, int brokerId, final Map<Long, List<S3ObjectStreamIndex>> streamsIndex) {
         this.objectId = objectId;
         this.brokerId = brokerId;
         this.streamsIndex = streamsIndex;
     }
 
     public boolean intersect(long streamId, long startOffset, long endOffset) {
-        S3ObjectStreamIndex streamIndex = streamsIndex.get(streamId);
-        if (streamIndex == null) {
+        List<S3ObjectStreamIndex> indices = streamsIndex.get(streamId);
+        if (indices == null || indices.isEmpty()) {
             return false;
         }
-        if (endOffset <= streamIndex.getStartOffset() || startOffset >= streamIndex.getEndOffset()) {
+        S3ObjectStreamIndex firstIndex = indices.get(0);
+        S3ObjectStreamIndex lastIndex = indices.get(indices.size() - 1);
+        if (endOffset <= firstIndex.getStartOffset() || startOffset >= lastIndex.getEndOffset()) {
             return false;
         }
         return true;
@@ -55,24 +57,22 @@ public class S3WALObject {
             .setObjectId(objectId)
             .setBrokerId(brokerId)
             .setStreamsIndex(
-                streamsIndex.values().stream()
+                streamsIndex.values().stream().flatMap(List::stream)
                     .map(S3ObjectStreamIndex::toRecordStreamIndex)
                     .collect(Collectors.toList())), (short) 0);
     }
 
     public static S3WALObject of(WALObjectRecord record) {
+        Map<Long, List<S3ObjectStreamIndex>> collect = record.streamsIndex().stream()
+            .map(index -> new S3ObjectStreamIndex(index.streamId(), index.startOffset(), index.endOffset()))
+            .collect(Collectors.groupingBy(S3ObjectStreamIndex::getStreamId));
         S3WALObject s3WalObject = new S3WALObject(record.objectId(), record.brokerId(),
-            record.streamsIndex().stream().collect(Collectors.toMap(
-                StreamIndex::streamId, S3ObjectStreamIndex::of)));
+            collect);
         return s3WalObject;
     }
 
     public Integer getBrokerId() {
         return brokerId;
-    }
-
-    public Map<Long, S3ObjectStreamIndex> getStreamsIndex() {
-        return streamsIndex;
     }
 
     public Long objectId() {

--- a/metadata/src/test/java/org/apache/kafka/image/BrokerS3WALMetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/BrokerS3WALMetadataImageTest.java
@@ -77,10 +77,10 @@ public class BrokerS3WALMetadataImageTest {
         // verify delta and check image's write
         BrokerS3WALMetadataImage image1 = new BrokerS3WALMetadataImage(BROKER0, List.of(
             new S3WALObject(0L, BROKER0, Map.of(
-                STREAM0, new S3ObjectStreamIndex(STREAM0, 0L, 100L),
-                STREAM1, new S3ObjectStreamIndex(STREAM1, 0L, 200L))),
+                STREAM0, List.of(new S3ObjectStreamIndex(STREAM0, 0L, 100L)),
+                STREAM1, List.of(new S3ObjectStreamIndex(STREAM1, 0L, 200L)))),
             new S3WALObject(1L, BROKER0, Map.of(
-                STREAM0, new S3ObjectStreamIndex(STREAM0, 101L, 200L)))));
+                STREAM0, List.of(new S3ObjectStreamIndex(STREAM0, 101L, 200L))))));
         assertEquals(image1, delta0.apply());
         testToImageAndBack(image1);
 
@@ -93,7 +93,7 @@ public class BrokerS3WALMetadataImageTest {
         // verify delta and check image's write
         BrokerS3WALMetadataImage image2 = new BrokerS3WALMetadataImage(BROKER0, List.of(
             new S3WALObject(1L, BROKER0, Map.of(
-                STREAM0, new S3ObjectStreamIndex(STREAM0, 101L, 200L)))));
+                STREAM0, List.of(new S3ObjectStreamIndex(STREAM0, 101L, 200L))))));
         assertEquals(image2, delta1.apply());
         testToImageAndBack(image2);
     }


### PR DESCRIPTION
1.  remove range concept in MemoryMetadataManager
2. support multi indies of same stream in one object