### PR TITLE
refactor(s3): remove useless `sourceObjectIds` in `CommitWALObjectRequest`

### DIFF
--- a/clients/src/main/resources/common/message/CommitWALObjectRequest.json
+++ b/clients/src/main/resources/common/message/CommitWALObjectRequest.json
@@ -118,12 +118,6 @@
           "type": "int64",
           "versions": "0+",
           "about": "The end offset of the stream range"
-        },
-        {
-          "name": "sourceObjectIds",
-          "type": "[]int64",
-          "versions": "0+",
-          "about": "The IDs of the source S3 objects"
         }
       ]
     },

--- a/core/src/main/scala/kafka/log/s3/objects/StreamObject.java
+++ b/core/src/main/scala/kafka/log/s3/objects/StreamObject.java
@@ -86,8 +86,7 @@ public class StreamObject {
             .setObjectId(objectId)
             .setObjectSize(objectSize)
             .setStartOffset(startOffset)
-            .setEndOffset(endOffset)
-            .setSourceObjectIds(sourceObjectIds);
+            .setEndOffset(endOffset);
     }
 
     @Override


### PR DESCRIPTION
fix #62 
1. remove useless `sourceObjectIds` in `CommitWALObjectRequest`
