### PR TITLE
feat: directly split one stream WAL

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -311,6 +311,8 @@
               files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager).java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+    <suppress checks="NPathComplexity"
+              files="(StreamControlManager).java"/>
     <suppress checks="BooleanExpressionComplexity"
               files="(MetadataImage).java"/>
     <suppress checks="ImportControl"

--- a/core/src/main/scala/kafka/log/s3/ObjectWriter.java
+++ b/core/src/main/scala/kafka/log/s3/ObjectWriter.java
@@ -27,6 +27,7 @@ import kafka.log.s3.operator.Writer;
 import org.apache.kafka.metadata.stream.ObjectUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,149 +39,220 @@ import static kafka.log.s3.operator.Writer.MIN_PART_SIZE;
 /**
  * Write stream records to a single object.
  */
-public class ObjectWriter {
+public interface ObjectWriter {
 
-    private static final byte DATA_BLOCK_MAGIC = 0x01;
+    byte DATA_BLOCK_MAGIC = 0x01;
     // TODO: first n bit is the compressed flag
-    private static final byte DATA_BLOCK_DEFAULT_FLAG = 0x02;
-    private final int blockSizeThreshold;
-    private final int partSizeThreshold;
-    private final List<DataBlock> waitingUploadBlocks;
-    private final List<DataBlock> completedBlocks;
-    private IndexBlock indexBlock;
-    private final Writer writer;
-    private final long objectId;
+    byte DATA_BLOCK_DEFAULT_FLAG = 0x02;
 
-    private long size;
+    void write(long streamId, List<StreamRecordBatch> records);
 
-    /**
-     * Create a new object writer.
-     * @param objectId object id
-     * @param s3Operator S3 operator
-     * @param blockSizeThreshold the max size of a block
-     * @param partSizeThreshold the max size of a part. If it is smaller than {@link Writer#MIN_PART_SIZE}, it will be set to {@link Writer#MIN_PART_SIZE}.
-     */
-    public ObjectWriter(long objectId, S3Operator s3Operator, int blockSizeThreshold, int partSizeThreshold) {
-        this.objectId = objectId;
-        // TODO: use a better clusterName
-        String objectKey = ObjectUtils.genKey(0, "todocluster", objectId);
-        this.blockSizeThreshold = blockSizeThreshold;
-        this.partSizeThreshold = Math.max(MIN_PART_SIZE, partSizeThreshold);
-        waitingUploadBlocks = new LinkedList<>();
-        completedBlocks = new LinkedList<>();
-        writer = s3Operator.writer(objectKey);
+    CompletableFuture<Void> close();
+
+    List<ObjectStreamRange> getStreamRanges();
+
+    long objectId();
+
+    long size();
+
+    static ObjectWriter writer(long objectId, S3Operator s3Operator, int blockSizeThreshold, int partSizeThreshold) {
+        return new DefaultObjectWriter(objectId, s3Operator, blockSizeThreshold, partSizeThreshold);
     }
 
-    public void write(long streamId, List<StreamRecordBatch> records) {
-        List<List<StreamRecordBatch>> blocks = groupByBlock(records);
-        List<CompletableFuture<Void>> closeCf = new ArrayList<>(blocks.size());
-        blocks.forEach(blockRecords -> {
-            DataBlock block = new DataBlock(streamId, blockRecords);
-            waitingUploadBlocks.add(block);
-            closeCf.add(block.close());
-        });
-        CompletableFuture.allOf(closeCf.toArray(new CompletableFuture[0])).whenComplete((nil, ex) -> tryUploadPart());
-
+    static ObjectWriter noop(long objectId) {
+        return new NoopObjectWriter(objectId);
     }
 
-    private List<List<StreamRecordBatch>> groupByBlock(List<StreamRecordBatch> records) {
-        List<List<StreamRecordBatch>> blocks = new LinkedList<>();
-        List<StreamRecordBatch> blockRecords = new ArrayList<>(records.size());
-        for (StreamRecordBatch record : records) {
-            size += record.size();
-            blockRecords.add(record);
-            if (size >= blockSizeThreshold) {
+    class DefaultObjectWriter implements ObjectWriter {
+
+        private final int blockSizeThreshold;
+        private final int partSizeThreshold;
+        private final List<DataBlock> waitingUploadBlocks;
+        private final List<DataBlock> completedBlocks;
+        private IndexBlock indexBlock;
+        private final Writer writer;
+        private final long objectId;
+
+        private long size;
+
+        /**
+         * Create a new object writer.
+         *
+         * @param objectId           object id
+         * @param s3Operator         S3 operator
+         * @param blockSizeThreshold the max size of a block
+         * @param partSizeThreshold  the max size of a part. If it is smaller than {@link Writer#MIN_PART_SIZE}, it will be set to {@link Writer#MIN_PART_SIZE}.
+         */
+        public DefaultObjectWriter(long objectId, S3Operator s3Operator, int blockSizeThreshold, int partSizeThreshold) {
+            this.objectId = objectId;
+            // TODO: use a better clusterName
+            String objectKey = ObjectUtils.genKey(0, "todocluster", objectId);
+            this.blockSizeThreshold = blockSizeThreshold;
+            this.partSizeThreshold = Math.max(MIN_PART_SIZE, partSizeThreshold);
+            waitingUploadBlocks = new LinkedList<>();
+            completedBlocks = new LinkedList<>();
+            writer = s3Operator.writer(objectKey);
+        }
+
+        public void write(long streamId, List<StreamRecordBatch> records) {
+            List<List<StreamRecordBatch>> blocks = groupByBlock(records);
+            List<CompletableFuture<Void>> closeCf = new ArrayList<>(blocks.size());
+            blocks.forEach(blockRecords -> {
+                DataBlock block = new DataBlock(streamId, blockRecords);
+                waitingUploadBlocks.add(block);
+                closeCf.add(block.close());
+            });
+            CompletableFuture.allOf(closeCf.toArray(new CompletableFuture[0])).whenComplete((nil, ex) -> tryUploadPart());
+
+        }
+
+        private List<List<StreamRecordBatch>> groupByBlock(List<StreamRecordBatch> records) {
+            List<List<StreamRecordBatch>> blocks = new LinkedList<>();
+            List<StreamRecordBatch> blockRecords = new ArrayList<>(records.size());
+            for (StreamRecordBatch record : records) {
+                size += record.size();
+                blockRecords.add(record);
+                if (size >= blockSizeThreshold) {
+                    blocks.add(blockRecords);
+                    blockRecords = new ArrayList<>(records.size());
+                    size = 0;
+                }
+            }
+            if (!blockRecords.isEmpty()) {
                 blocks.add(blockRecords);
-                blockRecords = new ArrayList<>(records.size());
-                size = 0;
             }
+            return blocks;
         }
-        if (!blockRecords.isEmpty()) {
-            blocks.add(blockRecords);
-        }
-        return blocks;
-    }
 
-    private synchronized void tryUploadPart() {
-        for (; ; ) {
-            List<DataBlock> uploadBlocks = new ArrayList<>(32);
-            boolean partFull = false;
-            int size = 0;
-            for (DataBlock block : waitingUploadBlocks) {
-                if (!block.close().isDone()) {
+        private synchronized void tryUploadPart() {
+            for (; ; ) {
+                List<DataBlock> uploadBlocks = new ArrayList<>(32);
+                boolean partFull = false;
+                int size = 0;
+                for (DataBlock block : waitingUploadBlocks) {
+                    if (!block.close().isDone()) {
+                        break;
+                    }
+                    uploadBlocks.add(block);
+                    size += block.size();
+                    if (size >= partSizeThreshold) {
+                        partFull = true;
+                        break;
+                    }
+                }
+                if (partFull) {
+                    CompositeByteBuf partBuf = ByteBufAlloc.ALLOC.compositeBuffer();
+                    for (DataBlock block : uploadBlocks) {
+                        partBuf.addComponent(true, block.buffer());
+                    }
+                    writer.write(partBuf);
+                    completedBlocks.addAll(uploadBlocks);
+                    waitingUploadBlocks.removeIf(uploadBlocks::contains);
+                } else {
                     break;
                 }
-                uploadBlocks.add(block);
-                size += block.size();
-                if (size >= partSizeThreshold) {
-                    partFull = true;
-                    break;
+            }
+        }
+
+        public CompletableFuture<Void> close() {
+            CompletableFuture<Void> waitBlocksCloseCf = CompletableFuture.allOf(waitingUploadBlocks.stream().map(DataBlock::close).toArray(CompletableFuture[]::new));
+            return waitBlocksCloseCf.thenCompose(nil -> {
+                CompositeByteBuf buf = ByteBufAlloc.ALLOC.compositeBuffer();
+                for (DataBlock block : waitingUploadBlocks) {
+                    buf.addComponent(true, block.buffer());
+                    completedBlocks.add(block);
+                }
+                waitingUploadBlocks.clear();
+                indexBlock = new IndexBlock();
+                buf.addComponent(true, indexBlock.buffer());
+                Footer footer = new Footer(indexBlock.position(), indexBlock.size());
+                buf.addComponent(true, footer.buffer());
+                writer.write(buf.duplicate());
+                size = indexBlock.position() + indexBlock.size() + footer.size();
+                return writer.close();
+            });
+        }
+
+        public List<ObjectStreamRange> getStreamRanges() {
+            List<ObjectStreamRange> streamRanges = new LinkedList<>();
+            ObjectStreamRange lastStreamRange = null;
+            for (DataBlock block : completedBlocks) {
+                ObjectStreamRange streamRange = block.getStreamRange();
+                if (lastStreamRange == null || lastStreamRange.getStreamId() != streamRange.getStreamId()) {
+                    if (lastStreamRange != null) {
+                        streamRanges.add(lastStreamRange);
+                    }
+                    lastStreamRange = new ObjectStreamRange();
+                    lastStreamRange.setStreamId(streamRange.getStreamId());
+                    lastStreamRange.setEpoch(streamRange.getEpoch());
+                    lastStreamRange.setStartOffset(streamRange.getStartOffset());
+                }
+                lastStreamRange.setEndOffset(streamRange.getEndOffset());
+            }
+            if (lastStreamRange != null) {
+                streamRanges.add(lastStreamRange);
+            }
+            return streamRanges;
+        }
+
+        public long objectId() {
+            return objectId;
+        }
+
+        public long size() {
+            return size;
+        }
+
+
+        class IndexBlock {
+            private final ByteBuf buf;
+            private final long position;
+
+            public IndexBlock() {
+                long nextPosition = 0;
+                buf = Unpooled.buffer(1024 * 1024);
+                buf.writeInt(completedBlocks.size()); // block count
+                // block index
+                for (DataBlock block : completedBlocks) {
+                    // start position in the object
+                    buf.writeLong(nextPosition);
+                    // byte size of the block
+                    buf.writeInt(block.size());
+                    // how many ranges in the block
+                    buf.writeInt(block.recordCount());
+                    nextPosition += block.size();
+                }
+                position = nextPosition;
+                // object stream range
+                for (int blockIndex = 0; blockIndex < completedBlocks.size(); blockIndex++) {
+                    DataBlock block = completedBlocks.get(blockIndex);
+                    ObjectStreamRange range = block.getStreamRange();
+                    // stream id of this range
+                    buf.writeLong(range.getStreamId());
+                    // start offset of the related stream
+                    buf.writeLong(range.getStartOffset());
+                    // record count of the related stream in this range
+                    buf.writeInt((int) (range.getEndOffset() - range.getStartOffset()));
+                    // the index of block where this range is in
+                    buf.writeInt(blockIndex);
                 }
             }
-            if (partFull) {
-                CompositeByteBuf partBuf = ByteBufAlloc.ALLOC.compositeBuffer();
-                for (DataBlock block : uploadBlocks) {
-                    partBuf.addComponent(true, block.buffer());
-                }
-                writer.write(partBuf);
-                completedBlocks.addAll(uploadBlocks);
-                waitingUploadBlocks.removeIf(uploadBlocks::contains);
-            } else {
-                break;
+
+            public ByteBuf buffer() {
+                return buf.duplicate();
+            }
+
+            public long position() {
+                return position;
+            }
+
+            public int size() {
+                return buf.readableBytes();
             }
         }
     }
 
-    public CompletableFuture<Void> close() {
-        CompletableFuture<Void> waitBlocksCloseCf = CompletableFuture.allOf(waitingUploadBlocks.stream().map(DataBlock::close).toArray(CompletableFuture[]::new));
-        return waitBlocksCloseCf.thenCompose(nil -> {
-            CompositeByteBuf buf = ByteBufAlloc.ALLOC.compositeBuffer();
-            for (DataBlock block : waitingUploadBlocks) {
-                buf.addComponent(true, block.buffer());
-                completedBlocks.add(block);
-            }
-            waitingUploadBlocks.clear();
-            indexBlock = new IndexBlock();
-            buf.addComponent(true, indexBlock.buffer());
-            Footer footer = new Footer(indexBlock.position(), indexBlock.size());
-            buf.addComponent(true, footer.buffer());
-            writer.write(buf.duplicate());
-            size = indexBlock.position() + indexBlock.size() + footer.size();
-            return writer.close();
-        });
-    }
-
-    public List<ObjectStreamRange> getStreamRanges() {
-        List<ObjectStreamRange> streamRanges = new LinkedList<>();
-        ObjectStreamRange lastStreamRange = null;
-        for (DataBlock block : completedBlocks) {
-            ObjectStreamRange streamRange = block.getStreamRange();
-            if (lastStreamRange == null || lastStreamRange.getStreamId() != streamRange.getStreamId()) {
-                if (lastStreamRange != null) {
-                    streamRanges.add(lastStreamRange);
-                }
-                lastStreamRange = new ObjectStreamRange();
-                lastStreamRange.setStreamId(streamRange.getStreamId());
-                lastStreamRange.setEpoch(streamRange.getEpoch());
-                lastStreamRange.setStartOffset(streamRange.getStartOffset());
-            }
-            lastStreamRange.setEndOffset(streamRange.getEndOffset());
-        }
-        if (lastStreamRange != null) {
-            streamRanges.add(lastStreamRange);
-        }
-        return streamRanges;
-    }
-
-    public long objectId() {
-        return objectId;
-    }
-
-    public long size() {
-        return size;
-    }
-
-    static class DataBlock {
+    class DataBlock {
         private final ByteBuf encodedBuf;
         private final ObjectStreamRange streamRange;
         private final int recordCount;
@@ -218,54 +290,7 @@ public class ObjectWriter {
         }
     }
 
-    class IndexBlock {
-        private final ByteBuf buf;
-        private final long position;
-
-        public IndexBlock() {
-            long nextPosition = 0;
-            buf = Unpooled.buffer(1024 * 1024);
-            buf.writeInt(completedBlocks.size()); // block count
-            // block index
-            for (DataBlock block : completedBlocks) {
-                // start position in the object
-                buf.writeLong(nextPosition);
-                // byte size of the block
-                buf.writeInt(block.size());
-                // how many ranges in the block
-                buf.writeInt(block.recordCount());
-                nextPosition += block.size();
-            }
-            position = nextPosition;
-            // object stream range
-            for (int blockIndex = 0; blockIndex < completedBlocks.size(); blockIndex++) {
-                DataBlock block = completedBlocks.get(blockIndex);
-                ObjectStreamRange range = block.getStreamRange();
-                // stream id of this range
-                buf.writeLong(range.getStreamId());
-                // start offset of the related stream
-                buf.writeLong(range.getStartOffset());
-                // record count of the related stream in this range
-                buf.writeInt((int) (range.getEndOffset() - range.getStartOffset()));
-                // the index of block where this range is in
-                buf.writeInt(blockIndex);
-            }
-        }
-
-        public ByteBuf buffer() {
-            return buf.duplicate();
-        }
-
-        public long position() {
-            return position;
-        }
-
-        public int size() {
-            return buf.readableBytes();
-        }
-    }
-
-    static class Footer {
+    class Footer {
         public static final int FOOTER_SIZE = 48;
         private static final long MAGIC = 0x88e241b785f4cff7L;
         private final ByteBuf buf;
@@ -290,4 +315,37 @@ public class ObjectWriter {
         }
 
     }
+
+    class NoopObjectWriter implements ObjectWriter {
+        private final long objectId;
+
+        public NoopObjectWriter(long objectId) {
+            this.objectId = objectId;
+        }
+
+        @Override
+        public void write(long streamId, List<StreamRecordBatch> records) {
+        }
+
+        @Override
+        public CompletableFuture<Void> close() {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public List<ObjectStreamRange> getStreamRanges() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public long objectId() {
+            return objectId;
+        }
+
+        @Override
+        public long size() {
+            return 0;
+        }
+    }
+
 }

--- a/core/src/main/scala/kafka/log/s3/S3Storage.java
+++ b/core/src/main/scala/kafka/log/s3/S3Storage.java
@@ -111,7 +111,6 @@ public class S3Storage implements Storage {
         cacheBlock.records().forEach((streamId, records) -> {
             if (!records.isEmpty()) {
                 streamEndOffsets.put(streamId, records.get(records.size() - 1).getLastOffset());
-                long startOffset = records.get(records.size() - 1).getBaseOffset();
             }
         });
 
@@ -160,8 +159,8 @@ public class S3Storage implements Storage {
                 long startOffset = records.get(0).getBaseOffset();
                 long expectedStartOffset = streamEndOffsets.getOrDefault(streamId, startOffset);
                 if (startOffset > expectedStartOffset) {
-                    throw new IllegalStateException(String.format("[BUG] WAL data may lost, streamId %s endOffset=%s" +
-                            "but WAL recovered records startOffset=%s", streamId, startOffset, expectedStartOffset));
+                    throw new IllegalStateException(String.format("[BUG] WAL data may lost, streamId %s endOffset=%s from controller" +
+                            "but WAL recovered records startOffset=%s", streamId, expectedStartOffset, startOffset));
                 }
             }
 

--- a/core/src/test/java/kafka/log/s3/DefaultS3BlockCacheTest.java
+++ b/core/src/test/java/kafka/log/s3/DefaultS3BlockCacheTest.java
@@ -52,7 +52,7 @@ public class DefaultS3BlockCacheTest {
 
     @Test
     public void testRead() throws Exception {
-        ObjectWriter objectWriter = new ObjectWriter(0, s3Operator, 1024, 1024);
+        ObjectWriter objectWriter = ObjectWriter.writer(0, s3Operator, 1024, 1024);
         objectWriter.write(233, List.of(
                 newRecord(233, 10, 5, 512),
                 newRecord(233, 15, 10, 512),
@@ -62,12 +62,12 @@ public class DefaultS3BlockCacheTest {
         objectWriter.close();
         S3ObjectMetadata metadata1 = new S3ObjectMetadata(0, objectWriter.size(), S3ObjectType.WAL);
 
-        objectWriter = new ObjectWriter(1, s3Operator, 1024, 1024);
+        objectWriter = ObjectWriter.writer(1, s3Operator, 1024, 1024);
         objectWriter.write(233, List.of(newRecord(233, 30, 10, 512)));
         objectWriter.close();
         S3ObjectMetadata metadata2 = new S3ObjectMetadata(1, objectWriter.size(), S3ObjectType.WAL);
 
-        objectWriter = new ObjectWriter(2, s3Operator, 1024, 1024);
+        objectWriter = ObjectWriter.writer(2, s3Operator, 1024, 1024);
         objectWriter.write(233, List.of(newRecord(233, 40, 20, 512)));
         objectWriter.close();
         S3ObjectMetadata metadata3 = new S3ObjectMetadata(2, objectWriter.size(), S3ObjectType.WAL);

--- a/core/src/test/java/kafka/log/s3/ObjectWriterTest.java
+++ b/core/src/test/java/kafka/log/s3/ObjectWriterTest.java
@@ -41,7 +41,7 @@ public class ObjectWriterTest {
         S3ObjectMetadata metadata = new S3ObjectMetadata(1, 0, S3ObjectType.WAL);
 
         S3Operator s3Operator = new MemoryS3Operator();
-        ObjectWriter objectWriter = new ObjectWriter(1, s3Operator, 1024, 1024);
+        ObjectWriter objectWriter = ObjectWriter.writer(1, s3Operator, 1024, 1024);
         StreamRecordBatch r1 = newRecord(233, 10, 5, 512);
         StreamRecordBatch r2 = newRecord(233, 15, 10, 512);
         StreamRecordBatch r3 = newRecord(233, 25, 5, 512);

--- a/core/src/test/java/kafka/log/s3/S3StorageTest.java
+++ b/core/src/test/java/kafka/log/s3/S3StorageTest.java
@@ -145,11 +145,13 @@ public class S3StorageTest {
 
         LogCache.LogCacheBlock logCacheBlock1 = new LogCache.LogCacheBlock(1024);
         logCacheBlock1.put(newRecord(233L, 10L));
+        logCacheBlock1.put(newRecord(234L, 10L));
         logCacheBlock1.confirmOffset(10L);
         CompletableFuture<Void> cf1 = storage.uploadWALObject(logCacheBlock1);
 
         LogCache.LogCacheBlock logCacheBlock2 = new LogCache.LogCacheBlock(1024);
         logCacheBlock2.put(newRecord(233L, 20L));
+        logCacheBlock2.put(newRecord(234L, 20L));
         logCacheBlock2.confirmOffset(20L);
         CompletableFuture<Void> cf2 = storage.uploadWALObject(logCacheBlock2);
 
@@ -166,7 +168,7 @@ public class S3StorageTest {
         objectIdCfList.get(0).complete(1L);
         // trigger next upload prepare objectId
         verify(objectManager, timeout(1000).times(2)).prepareObject(anyInt(), anyLong());
-        verify(objectManager, times(1)).commitWALObject(any());
+        verify(objectManager, timeout(1000).times(1)).commitWALObject(any());
 
         objectIdCfList.get(1).complete(2L);
         Thread.sleep(10);

--- a/core/src/test/java/kafka/log/s3/StreamObjectCopierTest.java
+++ b/core/src/test/java/kafka/log/s3/StreamObjectCopierTest.java
@@ -41,13 +41,13 @@ public class StreamObjectCopierTest {
 
         S3Operator s3Operator = new MemoryS3Operator();
 
-        ObjectWriter objectWriter1 = new ObjectWriter(1, s3Operator, 1024, 1024);
+        ObjectWriter objectWriter1 = ObjectWriter.writer(1, s3Operator, 1024, 1024);
         StreamRecordBatch r1 = newRecord(streamId, 10, 5, 512);
         StreamRecordBatch r2 = newRecord(streamId, 15, 10, 512);
         objectWriter1.write(streamId, List.of(r1, r2));
         objectWriter1.close().get();
 
-        ObjectWriter objectWriter2 = new ObjectWriter(2, s3Operator, 1024, 1024);
+        ObjectWriter objectWriter2 = ObjectWriter.writer(2, s3Operator, 1024, 1024);
         StreamRecordBatch r3 = newRecord(streamId, 25, 8, 512);
         StreamRecordBatch r4 = newRecord(streamId, 33, 6, 512);
         objectWriter2.write(streamId, List.of(r3, r4));

--- a/core/src/test/java/kafka/log/s3/StreamObjectsCompactionTaskTest.java
+++ b/core/src/test/java/kafka/log/s3/StreamObjectsCompactionTaskTest.java
@@ -192,7 +192,7 @@ class StreamObjectsCompactionTaskTest {
             Map<Long, List<StreamRecordBatch>> map = Map.of(streamId,
                 List.of(new StreamRecordBatch(streamId, 0, startOffset, Math.toIntExact(endOffset - startOffset), random(recordsSize))));
             WALObjectUploadTask walObjectUploadTask = new WALObjectUploadTask(map, objectManager, s3Operator, 16 * 1024 * 1024, 16 * 1024 * 1024,
-                recordsSize - 1);
+                recordsSize - 1, false);
 
             walObjectUploadTask.prepare().get();
             walObjectUploadTask.upload().get();

--- a/core/src/test/java/kafka/log/s3/WALObjectUploadTaskTest.java
+++ b/core/src/test/java/kafka/log/s3/WALObjectUploadTaskTest.java
@@ -27,6 +27,7 @@ import kafka.log.s3.operator.S3Operator;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.metadata.stream.S3ObjectMetadata;
 import org.apache.kafka.metadata.stream.S3ObjectType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -60,7 +61,7 @@ public class WALObjectUploadTaskTest {
     }
 
     @Test
-    public void testTryCompact() throws Exception {
+    public void testUpload() throws Exception {
         AtomicLong objectIdAlloc = new AtomicLong(10);
         doAnswer(invocation -> CompletableFuture.completedFuture(objectIdAlloc.getAndIncrement())).when(objectManager).prepareObject(anyInt(), anyLong());
         when(objectManager.commitWALObject(any())).thenReturn(CompletableFuture.completedFuture(new CommitWALObjectResponse()));
@@ -128,4 +129,30 @@ public class WALObjectUploadTaskTest {
         }
     }
 
+    @Test
+    public void testUpload_oneStream() throws Exception {
+        AtomicLong objectIdAlloc = new AtomicLong(10);
+        doAnswer(invocation -> CompletableFuture.completedFuture(objectIdAlloc.getAndIncrement())).when(objectManager).prepareObject(anyInt(), anyLong());
+        when(objectManager.commitWALObject(any())).thenReturn(CompletableFuture.completedFuture(new CommitWALObjectResponse()));
+
+        Map<Long, List<StreamRecordBatch>> map = new HashMap<>();
+        map.put(233L, List.of(
+                new StreamRecordBatch(233, 0, 10, 2, random(512)),
+                new StreamRecordBatch(233, 0, 12, 2, random(128)),
+                new StreamRecordBatch(233, 0, 14, 2, random(512))
+        ));
+        walObjectUploadTask = new WALObjectUploadTask(map, objectManager, s3Operator, 16 * 1024 * 1024, 16 * 1024 * 1024, 16 * 1024 * 1024);
+
+        walObjectUploadTask.prepare().get();
+        walObjectUploadTask.upload().get();
+        walObjectUploadTask.commit().get();
+
+
+        ArgumentCaptor<CommitWALObjectRequest> reqArg = ArgumentCaptor.forClass(CommitWALObjectRequest.class);
+        verify(objectManager, times(1)).commitWALObject(reqArg.capture());
+        CommitWALObjectRequest request = reqArg.getValue();
+        Assertions.assertEquals(0, request.getObjectSize());
+        Assertions.assertEquals(0, request.getStreamRanges().size());
+        Assertions.assertEquals(1, request.getStreamObjects().size());
+    }
 }

--- a/core/src/test/java/kafka/log/s3/compact/CompactionTestBase.java
+++ b/core/src/test/java/kafka/log/s3/compact/CompactionTestBase.java
@@ -62,7 +62,7 @@ public class CompactionTestBase {
         // stream data for object 0
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             Assertions.assertEquals(OBJECT_0, objectId);
-            ObjectWriter objectWriter = new ObjectWriter(objectId, s3Operator, 1024, 1024);
+            ObjectWriter objectWriter = ObjectWriter.writer(objectId, s3Operator, 1024, 1024);
             StreamRecordBatch r1 = new StreamRecordBatch(STREAM_0, 0, 0, 20, TestUtils.random(20));
             StreamRecordBatch r2 = new StreamRecordBatch(STREAM_1, 0, 30, 30, TestUtils.random(30));
             StreamRecordBatch r3 = new StreamRecordBatch(STREAM_2, 0, 30, 30, TestUtils.random(30));
@@ -83,7 +83,7 @@ public class CompactionTestBase {
         // stream data for object 1
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             Assertions.assertEquals(OBJECT_1, objectId);
-            ObjectWriter objectWriter = new ObjectWriter(OBJECT_1, s3Operator, 1024, 1024);
+            ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_1, s3Operator, 1024, 1024);
             StreamRecordBatch r4 = new StreamRecordBatch(STREAM_0, 0, 20, 5, TestUtils.random(5));
             StreamRecordBatch r5 = new StreamRecordBatch(STREAM_1, 0, 60, 60, TestUtils.random(60));
             objectWriter.write(STREAM_0, List.of(r4));
@@ -101,7 +101,7 @@ public class CompactionTestBase {
         // stream data for object 2
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             Assertions.assertEquals(OBJECT_2, objectId);
-            ObjectWriter objectWriter = new ObjectWriter(OBJECT_2, s3Operator, 1024, 1024);
+            ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_2, s3Operator, 1024, 1024);
             // redundant record
             StreamRecordBatch r6 = new StreamRecordBatch(STREAM_1, 0, 260, 20, TestUtils.random(20));
             StreamRecordBatch r7 = new StreamRecordBatch(STREAM_1, 0, 400, 100, TestUtils.random(100));

--- a/metadata/src/main/java/org/apache/kafka/controller/stream/S3ObjectControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/S3ObjectControlManager.java
@@ -50,6 +50,8 @@ import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineLong;
 import org.slf4j.Logger;
 
+import static org.apache.kafka.metadata.stream.ObjectUtils.NOOP_OBJECT_ID;
+
 /**
  * The S3ObjectControlManager manages all S3Object's lifecycle, such as apply, create, destroy, etc.
  */
@@ -156,6 +158,9 @@ public class S3ObjectControlManager {
     }
 
     public ControllerResult<Errors> commitObject(long objectId, long objectSize, long committedTs) {
+        if (objectId == NOOP_OBJECT_ID) {
+            return ControllerResult.of(Collections.emptyList(), Errors.NONE);
+        }
         S3Object object = this.objectsMetadata.get(objectId);
         if (object == null) {
             log.error("object {} not exist when commit wal object", objectId);

--- a/metadata/src/main/java/org/apache/kafka/metadata/stream/ObjectUtils.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/stream/ObjectUtils.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.metadata.stream;
 
 public class ObjectUtils {
+    public static final long NOOP_OBJECT_ID = -1L;
 
     public static String genKey(int version, String clusterName, long objectId) {
         if (version == 0) {


### PR DESCRIPTION
Support https://github.com/AutoMQ/kafka-on-s3/issues/111 and skip generating empty WAL objects.