### PR TITLE
feat: make sure all logs are closed when shutting down

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -589,7 +589,7 @@ class BrokerServer(
       // Note that logs are closed in logManager.shutdown().
       // Make sure these thread pools are shutdown after the log manager's shutdown.
       CoreUtils.swallow(replicaManager.shutdownAdditionalThreadPools(), this)
-      ElasticLogManager.shutdownNow()
+      CoreUtils.swallow(ElasticLogManager.shutdownNow(), this)
       // elastic stream inject end
 
       if (quotaManagers != null)


### PR DESCRIPTION
When a broker is shutting down, it will wait for logs' closure if they are handled by 'stopPartitions'