### PR TITLE
fix(s3Stream): fix data corruption after compaction

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
+++ b/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
@@ -74,7 +74,7 @@ public class DefaultS3Client implements Client {
         this.objectManager = new ControllerObjectManager(this.requestSender, this.metadataManager, kafkaConfig);
         this.blockCache = new DefaultS3BlockCache(this.config.s3CacheSize(), objectManager, operator);
         this.compactionManager = new CompactionManager(this.config, this.objectManager, this.operator);
-//        this.compactionManager.start();
+        this.compactionManager.start();
         this.writeAheadLog = BlockWALService.builder(this.config.s3WALPath(), this.config.s3WALCapacity()).config(this.config).build();
         this.storage = new S3Storage(this.config, writeAheadLog, streamManager, objectManager, blockCache, operator);
         this.storage.startup();

--- a/s3stream/src/main/java/com/automq/stream/s3/ObjectReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ObjectReader.java
@@ -306,7 +306,13 @@ public class ObjectReader implements AutoCloseable {
             ByteBuf buf = this.buf.duplicate();
             AtomicInteger remainingRecordCount = new AtomicInteger(recordCount);
             // skip magic and flag
-            buf.skipBytes(2);
+            byte magicCode = buf.readByte();
+            buf.readByte();
+
+            if (magicCode != ObjectWriter.DATA_BLOCK_MAGIC) {
+                LOGGER.error("magic code mismatch, expected {}, actual {}", ObjectWriter.DATA_BLOCK_MAGIC, magicCode);
+                throw new RuntimeException("[FATAL] magic code mismatch, data is corrupted");
+            }
             // TODO: check flag, use uncompressed stream or compressed stream.
 //            DataInputStream in = new DataInputStream(ZstdFactory.wrapForInput(buf.nioBuffer(), (byte) 0, BufferSupplier.NO_CACHING));
             DataInputStream in = new DataInputStream(new ByteBufferInputStream(buf.nioBuffer()));

--- a/s3stream/src/main/java/com/automq/stream/s3/StreamRecordBatchCodec.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/StreamRecordBatchCodec.java
@@ -53,7 +53,10 @@ public class StreamRecordBatchCodec {
      */
     public static StreamRecordBatch decode(DataInputStream in) {
         try {
-            in.readByte(); // magic
+            byte magic = in.readByte(); // magic
+            if (magic != MAGIC_V0) {
+                throw new RuntimeException("Invalid magic byte " + magic);
+            }
             long streamId = in.readLong();
             long epoch = in.readLong();
             long baseOffset = in.readLong();

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUtils.java
@@ -72,7 +72,7 @@ public class CompactionUtils {
                         S3ObjectMetadata objectMetadata = objectMetadataMap.get(streamDataBlocks.get(0).getObjectId());
                         // filter out invalid stream data blocks in case metadata is inconsistent with S3 index block
                         for (StreamDataBlock streamDataBlock : streamDataBlocks) {
-                            if (objectMetadata.intersect(streamDataBlock.getStreamId(), streamDataBlock.getStartOffset())) {
+                            if (objectMetadata.intersect(streamDataBlock.getStreamId(), streamDataBlock.getStartOffset(), streamDataBlock.getEndOffset())) {
                                 validStreamDataBlocks.add(streamDataBlock);
                             }
                         }

--- a/s3stream/src/main/java/com/automq/stream/s3/metadata/S3ObjectMetadata.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metadata/S3ObjectMetadata.java
@@ -137,12 +137,12 @@ public class S3ObjectMetadata {
         return offsetRanges.get(offsetRanges.size() - 1).getEndOffset();
     }
 
-    public boolean intersect(long streamId, long startOffset) {
+    public boolean intersect(long streamId, long startOffset, long endOffset) {
         if (offsetRanges == null || offsetRanges.isEmpty()) {
             return false;
         }
         for (StreamOffsetRange offsetRange : offsetRanges) {
-            if (offsetRange.getStreamId() == streamId && offsetRange.intersect(startOffset)) {
+            if (offsetRange.getStreamId() == streamId && offsetRange.intersect(startOffset, endOffset)) {
                 return true;
             }
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/metadata/StreamOffsetRange.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metadata/StreamOffsetRange.java
@@ -51,8 +51,10 @@ public class StreamOffsetRange implements Comparable<StreamOffsetRange> {
         return endOffset;
     }
 
-    public boolean intersect(long startOffset) {
-        return startOffset >= this.startOffset && startOffset <= this.endOffset;
+    public boolean intersect(long startOffset, long endOffset) {
+        return startOffset <= endOffset
+                && startOffset >= this.startOffset && startOffset <= this.endOffset
+                && endOffset <= this.endOffset;
     }
 
     @Override

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionTestBase.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionTestBase.java
@@ -65,15 +65,18 @@ public class CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_0, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(objectId, s3Operator, 1024, 1024);
-            StreamRecordBatch r1 = new StreamRecordBatch(STREAM_0, 0, 0, 20, TestUtils.random(20));
-            StreamRecordBatch r2 = new StreamRecordBatch(STREAM_1, 0, 30, 30, TestUtils.random(30));
-            StreamRecordBatch r3 = new StreamRecordBatch(STREAM_2, 0, 30, 30, TestUtils.random(30));
+            StreamRecordBatch r1 = new StreamRecordBatch(STREAM_0, 0, 0, 15, TestUtils.random(10));
+            StreamRecordBatch r2 = new StreamRecordBatch(STREAM_1, 0, 25, 5, TestUtils.random(10));
+            StreamRecordBatch r3 = new StreamRecordBatch(STREAM_1, 0, 30, 30, TestUtils.random(30));
+            StreamRecordBatch r4 = new StreamRecordBatch(STREAM_2, 0, 30, 30, TestUtils.random(30));
             objectWriter.write(STREAM_0, List.of(r1));
             objectWriter.write(STREAM_1, List.of(r2));
-            objectWriter.write(STREAM_2, List.of(r3));
+            objectWriter.write(STREAM_1, List.of(r3));
+            objectWriter.write(STREAM_2, List.of(r4));
             objectWriter.close().join();
             List<StreamOffsetRange> streamsIndices = List.of(
-                    new StreamOffsetRange(STREAM_0, 0, 20),
+                    new StreamOffsetRange(STREAM_0, 0, 15),
+                    new StreamOffsetRange(STREAM_1, 25, 30),
                     new StreamOffsetRange(STREAM_1, 30, 60),
                     new StreamOffsetRange(STREAM_2, 30, 60)
             );
@@ -86,13 +89,13 @@ public class CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_1, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_1, s3Operator, 1024, 1024);
-            StreamRecordBatch r4 = new StreamRecordBatch(STREAM_0, 0, 20, 5, TestUtils.random(5));
+            StreamRecordBatch r4 = new StreamRecordBatch(STREAM_0, 0, 15, 5, TestUtils.random(5));
             StreamRecordBatch r5 = new StreamRecordBatch(STREAM_1, 0, 60, 60, TestUtils.random(60));
             objectWriter.write(STREAM_0, List.of(r4));
             objectWriter.write(STREAM_1, List.of(r5));
             objectWriter.close().join();
             List<StreamOffsetRange> streamsIndices = List.of(
-                    new StreamOffsetRange(STREAM_0, 20, 25),
+                    new StreamOffsetRange(STREAM_0, 15, 20),
                     new StreamOffsetRange(STREAM_1, 60, 120)
             );
             S3ObjectMetadata objectMetadata = new S3ObjectMetadata(OBJECT_1, S3ObjectType.WAL, streamsIndices, System.currentTimeMillis(),


### PR DESCRIPTION
make sure to read continuous data blocks when data is trimmed on compaction
