### PR TITLE
fix(s3Stream): fix object range in compaction

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUtils.java
@@ -17,7 +17,6 @@
 
 package com.automq.stream.s3.compact;
 
-import com.automq.stream.s3.compact.objects.CompactedObject;
 import com.automq.stream.s3.compact.objects.StreamDataBlock;
 import com.automq.stream.s3.compact.operator.DataBlockReader;
 import com.automq.stream.s3.objects.ObjectStreamRange;
@@ -34,10 +33,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class CompactionUtils {
-    public static List<ObjectStreamRange> buildObjectStreamRange(CompactedObject compactedObject) {
+    public static List<ObjectStreamRange> buildObjectStreamRange(List<StreamDataBlock> streamDataBlocks) {
         List<ObjectStreamRange> objectStreamRanges = new ArrayList<>();
         ObjectStreamRange currObjectStreamRange = null;
-        for (StreamDataBlock streamDataBlock : compactedObject.streamDataBlocks()) {
+        for (StreamDataBlock streamDataBlock : streamDataBlocks) {
             if (currObjectStreamRange == null) {
                 currObjectStreamRange = new ObjectStreamRange(streamDataBlock.getStreamId(), -1L,
                         streamDataBlock.getStartOffset(), streamDataBlock.getEndOffset());

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionUtilTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionUtilTest.java
@@ -41,7 +41,7 @@ public class CompactionUtilTest extends CompactionTestBase {
                 new StreamDataBlock(STREAM_2, 40, 120, 0, 2, 25, 80, 1),
                 new StreamDataBlock(STREAM_2, 120, 150, 1, 3, 105, 30, 1));
         CompactedObject compactedObject = new CompactedObject(CompactionType.COMPACT, streamDataBlocks);
-        List<ObjectStreamRange> result = CompactionUtils.buildObjectStreamRange(compactedObject);
+        List<ObjectStreamRange> result = CompactionUtils.buildObjectStreamRange(compactedObject.streamDataBlocks());
         assertEquals(2, result.size());
         assertEquals(STREAM_0, result.get(0).getStreamId());
         assertEquals(0, result.get(0).getStartOffset());


### PR DESCRIPTION
merge continous object range that's been split during compaction due to cache limit

