### PR TITLE
fix(tools): controllerOnlyMode is false no extra commands will be output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/automq/GenerateStartCmdCmd.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/GenerateStartCmdCmd.java
@@ -34,7 +34,7 @@ import static org.apache.kafka.tools.automq.AutoMQKafkaAdminTool.GENERATE_S3_URL
 public class GenerateStartCmdCmd {
     private final Parameter parameter;
 
-    public GenerateStartCmdCmd(GenerateStartCmdCmd.Parameter parameter) {
+    public GenerateStartCmdCmd(Parameter parameter) {
         this.parameter = parameter;
     }
 


### PR DESCRIPTION
When a node is both a broker and a controller, it will output the startup command if it is a broker+controller, and it will output the startup command if it is only a broker
当节点即使broker又是controller时，会输出其是broker+controller的启动命令，又会输出其仅是broker的启动命令

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
