### PR TITLE
feat(core): optimize block cache performance for high-spec node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2006,6 +2006,7 @@ project(':s3stream') {
 
   dependencies {
     implementation libs.awsSdk
+    implementation libs.awsSdkNetty
     implementation libs.nettyTcnativeBoringSsl
     implementation libs.nettyBuffer
     implementation libs.bucket4j

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
@@ -107,8 +107,8 @@ class ElasticReplicaManager(
     fetchExecutorQueueSizeGaugeMap
   })
 
-  private val fastFetchLimiter = new FairLimiter(100 * 1024 * 1024) // 100MiB
-  private val slowFetchLimiter = new FairLimiter(100 * 1024 * 1024) // 100MiB
+  private val fastFetchLimiter = new FairLimiter(200 * 1024 * 1024) // 200MiB
+  private val slowFetchLimiter = new FairLimiter(200 * 1024 * 1024) // 200MiB
   private val fetchLimiterGaugeMap = new util.HashMap[String, Integer]()
   S3StreamKafkaMetricsManager.setFetchLimiterPermitNumSupplier(() => {
     fetchLimiterGaugeMap.put(FETCH_LIMITER_FAST_NAME, fastFetchLimiter.availablePermits())

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -289,6 +289,7 @@ libs += [
   commonMath3: "org.apache.commons:commons-math3:$versions.commonMath3",
   awsSdkAuth: "software.amazon.awssdk:auth:$versions.awsSdk",
   awsSdk: "software.amazon.awssdk:s3:$versions.awsSdk",
+  awsSdkNetty: "software.amazon.awssdk:netty-nio-client:$versions.awsSdk",
   opentelemetryJava8: "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:$versions.opentelemetryAlpha",
   opentelemetryOshi: "io.opentelemetry.instrumentation:opentelemetry-oshi:$versions.opentelemetryAlpha",
   opentelemetrySdk: "io.opentelemetry:opentelemetry-sdk:$versions.opentelemetry",

--- a/metadata/src/main/java/org/apache/kafka/image/NodeS3StreamSetObjectMetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/NodeS3StreamSetObjectMetadataImage.java
@@ -36,6 +36,7 @@ public class NodeS3StreamSetObjectMetadataImage {
     private final int nodeId;
     private final long nodeEpoch;
     private final DeltaMap<Long/*objectId*/, S3StreamSetObject> s3Objects;
+    private final StreamOffsetIndexMap offsetIndexMap = new StreamOffsetIndexMap(2500000);
     private List<S3StreamSetObject> orderIndex;
 
     public NodeS3StreamSetObjectMetadataImage(int nodeId, long nodeEpoch, DeltaMap<Long, S3StreamSetObject> streamSetObjects) {
@@ -80,6 +81,14 @@ public class NodeS3StreamSetObjectMetadataImage {
             orderIndex = objects;
         }
         return orderIndex;
+    }
+
+    public int floorStreamSetObjectIndex(long streamId, long startOffset) {
+        return offsetIndexMap.floorIndex(streamId, startOffset);
+    }
+
+    public void recordStreamSetObjectIndex(long streamId, long startOffset, int index) {
+        offsetIndexMap.put(streamId, startOffset, index);
     }
 
     public int getNodeId() {

--- a/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
+++ b/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
@@ -13,7 +13,6 @@ package org.apache.kafka.image;
 
 import com.automq.stream.s3.cache.LRUCache;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -21,7 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 
-@NotThreadSafe
+/**
+ * NotThreadSafe, the caller should ensure the thread safety
+ */
 public class StreamOffsetIndexMap {
     private final int maxSize;
     private final LRUCache<StreamOffset, Void> streamOffsetCache;

--- a/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
+++ b/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.image;
+
+import com.automq.stream.s3.cache.LRUCache;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+@NotThreadSafe
+public class StreamOffsetIndexMap {
+    private final int maxSize;
+    private final LRUCache<StreamOffset, Void> streamOffsetCache;
+    private final Map<Long, NavigableMap<Long, Integer>> streamOffsetIndexMap;
+
+    public StreamOffsetIndexMap(int maxSize) {
+        this.maxSize = maxSize;
+        this.streamOffsetCache = new LRUCache<>();
+        this.streamOffsetIndexMap = new HashMap<>();
+    }
+
+    public void put(long streamId, long startOffset, int index) {
+        if (streamOffsetIndexMap.containsKey(streamId) && streamOffsetIndexMap.get(streamId).containsKey(startOffset)) {
+            return;
+        }
+        while (streamOffsetCache.size() >= maxSize) {
+            Optional.ofNullable(streamOffsetCache.pop()).ifPresent(entry -> {
+                StreamOffset streamOffset = entry.getKey();
+                NavigableMap<Long, Integer> map = streamOffsetIndexMap.get(streamOffset.streamId);
+                if (map != null) {
+                    map.remove(streamOffset.startOffset);
+                }
+            });
+        }
+        streamOffsetCache.put(new StreamOffset(streamId, startOffset), null);
+        streamOffsetIndexMap.compute(streamId, (k, v) -> {
+            if (v == null) {
+                v = new TreeMap<>();
+            }
+            v.put(startOffset, index);
+            return v;
+        });
+    }
+
+    public int floorIndex(long streamId, long offset) {
+        NavigableMap<Long, Integer> map = streamOffsetIndexMap.get(streamId);
+        if (map == null) {
+            return 0;
+        }
+        Map.Entry<Long, Integer> entry = map.floorEntry(offset);
+        if (entry == null) {
+            return 0;
+        }
+        return entry.getValue();
+    }
+
+    int cacheSize() {
+        return streamOffsetCache.size();
+    }
+
+    int entrySize() {
+        return streamOffsetIndexMap.values().stream().mapToInt(NavigableMap::size).sum();
+    }
+
+    private static class StreamOffset {
+        long streamId;
+        long startOffset;
+
+        public StreamOffset(long streamId, long startOffset) {
+            this.streamId = streamId;
+            this.startOffset = startOffset;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            StreamOffset that = (StreamOffset) o;
+            return streamId == that.streamId && startOffset == that.startOffset;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(streamId, startOffset);
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/stream/S3StreamSetObject.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/stream/S3StreamSetObject.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ExecutionException;
 public class S3StreamSetObject implements Comparable<S3StreamSetObject> {
     private static final Cache<Long, List<StreamOffsetRange>> RANGES_CACHE = CacheBuilder.newBuilder()
             .expireAfterAccess(Duration.ofMinutes(1))
-            .maximumWeight(500000) // expected max heap occupied size is 15MiB
+            .maximumWeight(2500000) // expected max heap occupied size is 75MiB
             .weigher((Weigher<Long, List<StreamOffsetRange>>) (key, value) -> value.size())
             .build();
     public static final byte MAGIC = 0x01;

--- a/metadata/src/test/java/org/apache/kafka/image/StreamOffsetIndexMapTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/StreamOffsetIndexMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.image;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StreamOffsetIndexMapTest {
+
+    @Test
+    public void testPutAndEvict() {
+        StreamOffsetIndexMap map = new StreamOffsetIndexMap(10);
+        for (int i = 0; i < 20; i++) {
+            map.put(i % 2, i, i * i);
+        }
+        Assertions.assertEquals(10, map.cacheSize());
+        Assertions.assertEquals(10, map.entrySize());
+        Assertions.assertEquals(0, map.floorIndex(0, 5));
+        Assertions.assertEquals(100, map.floorIndex(0, 11));
+        Assertions.assertEquals(225, map.floorIndex(1, 15));
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
@@ -170,9 +170,9 @@ public class ByteBufAlloc {
             sb.append(allocatedMemory);
             sb.append(", detail=");
             for (Map.Entry<String, Long> entry : detail.entrySet()) {
-                sb.append(entry.getKey()).append("=").append(entry.getValue()).append(",");
+                sb.append(entry.getKey()).append("=").append(entry.getValue()).append(", ");
             }
-            sb.append(", pooled=");
+            sb.append("pooled=");
             sb.append(policy.isPooled());
             sb.append(", direct=");
             sb.append(policy.isDirect());

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/DefaultS3BlockCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/DefaultS3BlockCache.java
@@ -154,7 +154,9 @@ public class DefaultS3BlockCache implements S3BlockCache {
 
         // 1. get from cache
         context.setStatus(ReadBlockCacheStatus.GET_FROM_CACHE);
+        TimerUtil timer = new TimerUtil();
         BlockCache.GetCacheResult cacheRst = cache.get(traceContext, streamId, nextStartOffset, endOffset, nextMaxBytes);
+        StorageOperationStats.getInstance().readBlockCacheTimeStats.record(timer.elapsedAs(TimeUnit.NANOSECONDS));
         List<StreamRecordBatch> cacheRecords = cacheRst.getRecords();
         if (!cacheRecords.isEmpty()) {
             asyncReadAhead(streamId, agent, cacheRst.getReadAheadRecords());

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/DefaultS3BlockCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/DefaultS3BlockCache.java
@@ -44,6 +44,7 @@ public class DefaultS3BlockCache implements S3BlockCache {
     private final Map<ReadTaskKey, ReadTaskContext> inflightReadStatusMap = new ConcurrentHashMap<>();
     private final BlockCache cache;
     private final ExecutorService mainExecutor;
+    private final ExecutorService callBackExecutor;
     private final ReadAheadManager readAheadManager;
     private final StreamReader streamReader;
     private final InflightReadThrottle inflightReadThrottle;
@@ -59,6 +60,11 @@ public class DefaultS3BlockCache implements S3BlockCache {
             "s3-block-cache-main",
             false,
             LOGGER);
+        this.callBackExecutor = Threads.newFixedThreadPoolWithMonitor(
+                2,
+                "s3-block-cache-callback",
+                false,
+                LOGGER);
         this.inflightReadThrottle = new InflightReadThrottle(cacheSizeSet.inflightReadSize);
         this.streamReader = new StreamReader(s3Operator, objectManager, cache, inflightReadAheadTasks, inflightReadThrottle);
         LOGGER.info("Init s3 block cache, block cache size: {}, inflight read size: {}", cacheSizeSet.blockCacheSize, cacheSizeSet.inflightReadSize);
@@ -105,7 +111,7 @@ public class DefaultS3BlockCache implements S3BlockCache {
         // submit read task to mainExecutor to avoid read slower the caller thread.
         mainExecutor.execute(() -> {
             try {
-                FutureUtil.propagate(read0(finalTraceContext, streamId, startOffset, endOffset, maxBytes, uuid, context).whenComplete((ret, ex) -> {
+                FutureUtil.propagateAsync(read0(finalTraceContext, streamId, startOffset, endOffset, maxBytes, uuid, context).whenComplete((ret, ex) -> {
                     if (ex != null) {
                         LOGGER.error("read {} [{}, {}), maxBytes: {} from block cache fail", streamId, startOffset, endOffset, maxBytes, ex);
                         this.inflightReadThrottle.release(uuid);
@@ -119,6 +125,7 @@ public class DefaultS3BlockCache implements S3BlockCache {
                     long timeElapsed = timerUtil.elapsedAs(TimeUnit.NANOSECONDS);
                     boolean isCacheHit = ret.getCacheAccessType() == CacheAccessType.BLOCK_CACHE_HIT;
                     StorageOperationStats.getInstance().readBlockCacheStats(isCacheHit).record(timeElapsed);
+                    recordStageTime(isCacheHit, context);
                     Span.fromContext(finalTraceContext.currentContext()).setAttribute("cache_hit", isCacheHit);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("[S3BlockCache] read data complete, cache hit: {}, stream={}, {}-{}, total bytes: {}",
@@ -126,7 +133,7 @@ public class DefaultS3BlockCache implements S3BlockCache {
                     }
                     this.inflightReadThrottle.release(uuid);
                     this.inflightReadStatusMap.remove(key);
-                }), readCf);
+                }), readCf, callBackExecutor);
             } catch (Exception e) {
                 LOGGER.error("read {} [{}, {}), maxBytes: {} from block cache fail, {}", streamId, startOffset, endOffset, maxBytes, e);
                 this.inflightReadThrottle.release(uuid);
@@ -135,6 +142,20 @@ public class DefaultS3BlockCache implements S3BlockCache {
             }
         });
         return readCf;
+    }
+
+    private void recordStageTime(boolean isCacheHit, ReadTaskContext context) {
+        if (isCacheHit) {
+            StorageOperationStats.getInstance().readBlockCacheStageHitWaitInflightTimeStats.record(context.waitInflightTime);
+            StorageOperationStats.getInstance().readBlockCacheStageHitReadCacheTimeStats.record(context.readBlockCacheTime);
+            StorageOperationStats.getInstance().readBlockCacheStageHitReadAheadTimeStats.record(context.readAheadTime);
+            StorageOperationStats.getInstance().readBlockCacheStageHitReadS3TimeStats.record(context.readS3Time);
+        } else {
+            StorageOperationStats.getInstance().readBlockCacheStageMissWaitInflightTimeStats.record(context.waitInflightTime);
+            StorageOperationStats.getInstance().readBlockCacheStageMissReadCacheTimeStats.record(context.readBlockCacheTime);
+            StorageOperationStats.getInstance().readBlockCacheStageMissReadAheadTimeStats.record(context.readAheadTime);
+            StorageOperationStats.getInstance().readBlockCacheStageMissReadS3TimeStats.record(context.readS3Time);
+        }
     }
 
     @WithSpan
@@ -157,12 +178,17 @@ public class DefaultS3BlockCache implements S3BlockCache {
         long nextStartOffset = startOffset;
         int nextMaxBytes = maxBytes;
 
+        TimerUtil inflightTimer = new TimerUtil();
         ReadAheadTaskContext inflightReadAheadTaskContext = inflightReadAheadTasks.get(new ReadAheadTaskKey(streamId, nextStartOffset));
         if (inflightReadAheadTaskContext != null) {
             CompletableFuture<ReadDataBlock> readCf = new CompletableFuture<>();
             context.setStatus(ReadBlockCacheStatus.WAIT_INFLIGHT_RA);
-            inflightReadAheadTaskContext.cf.whenComplete((nil, ex) -> FutureUtil.exec(() -> FutureUtil.propagate(
-                read0(traceContext, streamId, startOffset, endOffset, maxBytes, uuid, context), readCf), readCf, LOGGER, "read0"));
+            inflightReadAheadTaskContext.cf.whenComplete((nil, ex) -> {
+                context.waitInflightTime += inflightTimer.elapsedAs(TimeUnit.NANOSECONDS);
+                FutureUtil.exec(() -> FutureUtil.propagate(
+                        read0(traceContext, streamId, startOffset, endOffset, maxBytes, uuid, context), readCf), readCf, LOGGER, "read0");
+
+            });
             return readCf;
         }
 
@@ -170,12 +196,13 @@ public class DefaultS3BlockCache implements S3BlockCache {
         context.setStatus(ReadBlockCacheStatus.GET_FROM_CACHE);
         TimerUtil timer = new TimerUtil();
         BlockCache.GetCacheResult cacheRst = cache.get(traceContext, streamId, nextStartOffset, endOffset, nextMaxBytes);
-        StorageOperationStats.getInstance().readBlockCacheTimeStats.record(timer.elapsedAs(TimeUnit.NANOSECONDS));
+        context.readBlockCacheTime += timer.elapsedAndResetAs(TimeUnit.NANOSECONDS);
         List<StreamRecordBatch> cacheRecords = cacheRst.getRecords();
         if (!cacheRecords.isEmpty()) {
             asyncReadAhead(streamId, agent, cacheRst.getReadAheadRecords());
             nextStartOffset = cacheRecords.get(cacheRecords.size() - 1).getLastOffset();
             nextMaxBytes -= Math.min(nextMaxBytes, cacheRecords.stream().mapToInt(StreamRecordBatch::size).sum());
+            context.readAheadTime += timer.elapsedAs(TimeUnit.NANOSECONDS);
             if (nextStartOffset >= endOffset || nextMaxBytes == 0) {
                 // cache hit
                 if (LOGGER.isDebugEnabled()) {
@@ -200,8 +227,10 @@ public class DefaultS3BlockCache implements S3BlockCache {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("[S3BlockCache] read data cache miss, stream={}, {}-{}, total bytes: {} ", streamId, startOffset, endOffset, maxBytes);
         }
+        TimerUtil s3Timer = new TimerUtil();
         return streamReader.syncReadAhead(traceContext, streamId, startOffset, endOffset, maxBytes, agent, uuid)
             .thenCompose(rst -> {
+                context.readS3Time += s3Timer.elapsedAs(TimeUnit.NANOSECONDS);
                 if (!rst.isEmpty()) {
                     int remainBytes = maxBytes - rst.stream().mapToInt(StreamRecordBatch::size).sum();
                     long lastOffset = rst.get(rst.size() - 1).getLastOffset();
@@ -379,6 +408,10 @@ public class DefaultS3BlockCache implements S3BlockCache {
     public static class ReadTaskContext {
         final ReadAheadAgent agent;
         ReadBlockCacheStatus status;
+        long waitInflightTime;
+        long readBlockCacheTime;
+        long readAheadTime;
+        long readS3Time;
 
         public ReadTaskContext(ReadAheadAgent agent, ReadBlockCacheStatus status) {
             this.agent = agent;

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/ReadAheadAgent.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/ReadAheadAgent.java
@@ -92,7 +92,6 @@ public class ReadAheadAgent {
             lock.lock();
             this.readAheadEndOffset = readAheadEndOffset;
             this.lastReadAheadSize = readAheadSize;
-            StorageOperationStats.getInstance().readAheadSizeStats.record(readAheadSize);
             if (logger.isDebugEnabled()) {
                 logger.debug("update read ahead offset {}, size: {}, lastReadOffset: {}", readAheadEndOffset, readAheadSize, lastReadOffset);
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/ReadAheadManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/ReadAheadManager.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 
 public class ReadAheadManager implements BlockCache.CacheEvictListener {
     private static final Logger LOGGER = new LogContext("[S3BlockCache] ").logger(ReadAheadManager.class);
-    private static final Integer MAX_READ_AHEAD_AGENT_NUM = 1024;
+    private static final Integer MAX_READ_AHEAD_AGENT_NUM = 4096;
     // <streamId, <lastReadOffset, ReadAheadAgent>>
     private final Map<Long, NavigableMap<Long, ReadAheadAgent>> readAheadAgentMap;
     private final LRUCache<ReadAheadAgent, Void> readAheadAgentLRUCache = new LRUCache<>();

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/StreamReader.java
@@ -119,7 +119,7 @@ public class StreamReader {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("[S3BlockCache] sync read ahead, stream={}, {}-{}, maxBytes={}", streamId, startOffset, endOffset, maxBytes);
         }
-        ReadContext context = new ReadContext(startOffset, maxBytes, true);
+        ReadContext context = new ReadContext(startOffset, maxBytes);
         TimerUtil timer = new TimerUtil();
         DefaultS3BlockCache.ReadAheadTaskKey readAheadTaskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, startOffset);
         // put a placeholder task at start offset to prevent next cache miss request spawn duplicated read ahead task
@@ -286,7 +286,7 @@ public class StreamReader {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("[S3BlockCache] async read ahead, stream={}, {}-{}, maxBytes={}", streamId, startOffset, endOffset, maxBytes);
         }
-        ReadContext context = new ReadContext(startOffset, maxBytes, false);
+        ReadContext context = new ReadContext(startOffset, maxBytes);
         TimerUtil timer = new TimerUtil();
         DefaultS3BlockCache.ReadAheadTaskKey readAheadTaskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, startOffset);
         // put a placeholder task at start offset to prevent next cache miss request spawn duplicated read ahead task
@@ -555,12 +555,11 @@ public class StreamReader {
         int totalReadSize;
         long lastOffset;
         TimerUtil timer;
-        boolean isSync;
         long getObjectsTime = 0;
         long findIndexTime = 0;
         long computeTime = 0;
 
-        public ReadContext(long startOffset, int maxBytes, boolean isSync) {
+        public ReadContext(long startOffset, int maxBytes) {
             this.objects = new LinkedList<>();
             this.objectIndex = 0;
             this.streamDataBlocksPair = new LinkedList<>();
@@ -568,7 +567,6 @@ public class StreamReader {
             this.taskKeySet = new HashSet<>();
             this.nextStartOffset = startOffset;
             this.nextMaxBytes = maxBytes;
-            this.isSync = isSync;
             this.timer = new TimerUtil();
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/AttributesUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/AttributesUtils.java
@@ -32,6 +32,18 @@ public class AttributesUtils {
             .build();
     }
 
+    public static Attributes buildAttributesStage(String stage) {
+        return Attributes.builder()
+                .put(S3StreamMetricsConstant.LABEL_STAGE, stage)
+                .build();
+    }
+
+    public static Attributes buildAttributes(String status) {
+        return Attributes.builder()
+                .put(S3StreamMetricsConstant.LABEL_STATUS, status)
+                .build();
+    }
+
     public static Attributes buildAttributes(S3Stage stage) {
         return Attributes.builder()
             .putAll(buildAttributes(stage.getOperation()))

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/AttributesUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/AttributesUtils.java
@@ -44,6 +44,13 @@ public class AttributesUtils {
                 .build();
     }
 
+    public static Attributes buildStatusStageAttributes(String status, String stage) {
+        return Attributes.builder()
+                .put(S3StreamMetricsConstant.LABEL_STATUS, status)
+                .put(S3StreamMetricsConstant.LABEL_STAGE, stage)
+                .build();
+    }
+
     public static Attributes buildAttributes(S3Stage stage) {
         return Attributes.builder()
             .putAll(buildAttributes(stage.getOperation()))

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -101,7 +101,7 @@ public class S3StreamMetricsConstant {
     public static final String READ_S3_LIMITER_TIME_METRIC_NAME = "read_s3_limiter_time";
     public static final String WRITE_S3_LIMITER_TIME_METRIC_NAME = "write_s3_limiter_time";
     public static final String GET_INDEX_TIME_METRIC_NAME = "get_index_time";
-    public static final String READ_BLOCK_CACHE_METRIC_NAME = "read_block_cache_time";
+    public static final String READ_BLOCK_CACHE_METRIC_NAME = "read_block_cache_stage_time";
     public static final AttributeKey<String> LABEL_OPERATION_TYPE = AttributeKey.stringKey("operation_type");
     public static final AttributeKey<String> LABEL_OPERATION_NAME = AttributeKey.stringKey("operation_name");
     public static final AttributeKey<String> LABEL_SIZE_NAME = AttributeKey.stringKey("size");
@@ -120,4 +120,10 @@ public class S3StreamMetricsConstant {
     public static final String LABEL_STAGE_THROTTLE = "throttle";
     public static final String LABEL_STAGE_READ_S3 = "read_s3";
     public static final String LABEL_STAGE_PUT_BLOCK_CACHE = "put_block_cache";
+    public static final String LABEL_STAGE_WAIT_INFLIGHT = "wait_inflight";
+    public static final String LABEL_STAGE_READ_CACHE = "read_cache";
+    public static final String LABEL_STAGE_READ_AHEAD = "read_ahead";
+    public static final String LABEL_STAGE_GET_OBJECTS = "get_objects";
+    public static final String LABEL_STAGE_FIND_INDEX = "find_index";
+    public static final String LABEL_STAGE_COMPUTE = "compute";
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -78,6 +78,7 @@ public class S3StreamMetricsConstant {
     public static final String NETWORK_INBOUND_LIMITER_QUEUE_TIME_METRIC_NAME = "network_inbound_limiter_queue_time";
     public static final String NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRIC_NAME = "network_outbound_limiter_queue_time";
     public static final String READ_AHEAD_SIZE_METRIC_NAME = "read_ahead_size";
+    public static final String READ_AHEAD_STAGE_TIME_METRIC_NAME = "read_ahead_stage_time";
     public static final String SUM_METRIC_NAME_SUFFIX = "_sum";
     public static final String COUNT_METRIC_NAME_SUFFIX = "_count";
     public static final String P50_METRIC_NAME_SUFFIX = "_50p";
@@ -97,12 +98,17 @@ public class S3StreamMetricsConstant {
     public static final String COMPACTION_WRITE_SIZE_METRIC_NAME = "compaction_write_size";
     public static final String BUFFER_ALLOCATED_MEMORY_SIZE_METRIC_NAME = "buffer_allocated_memory_size";
     public static final String BUFFER_USED_MEMORY_SIZE_METRIC_NAME = "buffer_used_memory_size";
+    public static final String READ_S3_LIMITER_TIME_METRIC_NAME = "read_s3_limiter_time";
+    public static final String WRITE_S3_LIMITER_TIME_METRIC_NAME = "write_s3_limiter_time";
+    public static final String GET_INDEX_TIME_METRIC_NAME = "get_index_time";
+    public static final String READ_BLOCK_CACHE_METRIC_NAME = "read_block_cache_time";
     public static final AttributeKey<String> LABEL_OPERATION_TYPE = AttributeKey.stringKey("operation_type");
     public static final AttributeKey<String> LABEL_OPERATION_NAME = AttributeKey.stringKey("operation_name");
     public static final AttributeKey<String> LABEL_SIZE_NAME = AttributeKey.stringKey("size");
     public static final AttributeKey<String> LABEL_STAGE = AttributeKey.stringKey("stage");
     public static final AttributeKey<String> LABEL_STATUS = AttributeKey.stringKey("status");
     public static final AttributeKey<String> LABEL_ALLOC_TYPE = AttributeKey.stringKey("type");
+    public static final AttributeKey<String> LABEL_INDEX = AttributeKey.stringKey("index");
     public static final String LABEL_STATUS_SUCCESS = "success";
     public static final String LABEL_STATUS_FAILED = "failed";
     public static final String LABEL_STATUS_HIT = "hit";
@@ -110,4 +116,8 @@ public class S3StreamMetricsConstant {
     public static final String LABEL_STATUS_SYNC = "sync";
     public static final String LABEL_STATUS_ASYNC = "async";
 
+    public static final String LABEL_STAGE_GET_INDICES = "get_indices";
+    public static final String LABEL_STAGE_THROTTLE = "throttle";
+    public static final String LABEL_STAGE_READ_S3 = "read_s3";
+    public static final String LABEL_STAGE_PUT_BLOCK_CACHE = "put_block_cache";
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -475,9 +475,10 @@ public class S3StreamMetricsManager {
 
     }
 
-    public static YammerHistogramMetric buildReadBlockCacheTime(MetricName metricName, MetricsLevel metricsLevel) {
+    public static YammerHistogramMetric buildReadBlockCacheStageTime(MetricName metricName, MetricsLevel metricsLevel, String status, String stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig);
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+                    AttributesUtils.buildStatusStageAttributes(status, stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_BLOCK_CACHE_TIME_METRICS.add(metric);
             return metric;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -29,6 +29,7 @@ import io.opentelemetry.api.metrics.ObservableLongGauge;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
@@ -40,7 +41,11 @@ public class S3StreamMetricsManager {
     public static final List<YammerHistogramMetric> NETWORK_INBOUND_LIMITER_QUEUE_TIME_METRICS = new CopyOnWriteArrayList<>();
     public static final List<YammerHistogramMetric> NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRICS = new CopyOnWriteArrayList<>();
     public static final List<YammerHistogramMetric> READ_AHEAD_SIZE_METRICS = new CopyOnWriteArrayList<>();
-    public static final List<YammerHistogramMetric> READ_AHEAD_LIMITER_QUEUE_TIME_METRICS = new CopyOnWriteArrayList<>();
+    public static final List<YammerHistogramMetric> READ_AHEAD_STAGE_TIME_METRICS = new CopyOnWriteArrayList<>();
+    public static final List<YammerHistogramMetric> READ_S3_METRICS = new CopyOnWriteArrayList<>();
+    public static final List<YammerHistogramMetric> WRITE_S3_METRICS = new CopyOnWriteArrayList<>();
+    public static final List<YammerHistogramMetric> GET_INDEX_METRICS = new CopyOnWriteArrayList<>();
+    public static final List<YammerHistogramMetric> READ_BLOCK_CACHE_TIME_METRICS = new CopyOnWriteArrayList<>();
     private static LongCounter s3DownloadSizeInTotal = new NoopLongCounter();
     private static LongCounter s3UploadSizeInTotal = new NoopLongCounter();
     private static HistogramInstrument operationLatency;
@@ -55,7 +60,11 @@ public class S3StreamMetricsManager {
     private static HistogramInstrument networkInboundLimiterQueueTime;
     private static HistogramInstrument networkOutboundLimiterQueueTime;
     private static HistogramInstrument readAheadSize;
-    private static HistogramInstrument readAheadLimierQueueTime;
+    private static HistogramInstrument readAheadStageTime;
+    private static HistogramInstrument readS3LimiterTime;
+    private static HistogramInstrument writeS3LimiterTime;
+    private static HistogramInstrument getIndexTime;
+    private static HistogramInstrument readBlockCacheTime;
     private static ObservableLongGauge deltaWalStartOffset = new NoopObservableLongGauge();
     private static ObservableLongGauge deltaWalTrimmedOffset = new NoopObservableLongGauge();
     private static ObservableLongGauge deltaWalCacheSize = new NoopObservableLongGauge();
@@ -77,15 +86,19 @@ public class S3StreamMetricsManager {
     private static Supplier<Long> deltaWalTrimmedOffsetSupplier = () -> 0L;
     private static Supplier<Long> deltaWALCacheSizeSupplier = () -> 0L;
     private static Supplier<Long> blockCacheSizeSupplier = () -> 0L;
-    private static Supplier<Integer> availableInflightS3ReadQuotaSupplier = () -> 0;
-    private static Supplier<Integer> availableInflightS3WriteQuotaSupplier = () -> 0;
+    private static Map<Integer, Supplier<Integer>> availableInflightS3ReadQuotaSupplier = new ConcurrentHashMap<>();
+    private static Map<Integer, Supplier<Integer>> availableInflightS3WriteQuotaSupplier = new ConcurrentHashMap<>();
     private static Supplier<Integer> inflightWALUploadTasksCountSupplier = () -> 0;
     private static MetricsConfig metricsConfig = new MetricsConfig(MetricsLevel.INFO, Attributes.empty());
     private static final MultiAttributes<String> ALLOC_TYPE_ATTRIBUTES = new MultiAttributes<>(Attributes.empty(),
         S3StreamMetricsConstant.LABEL_ALLOC_TYPE);
+    private static final MultiAttributes<String> OPERATOR_INDEX_ATTRIBUTES = new MultiAttributes<>(Attributes.empty(),
+            S3StreamMetricsConstant.LABEL_INDEX);
+
 
     static {
         BASE_ATTRIBUTES_LISTENERS.add(ALLOC_TYPE_ATTRIBUTES);
+        BASE_ATTRIBUTES_LISTENERS.add(OPERATOR_INDEX_ATTRIBUTES);
     }
 
     public static void configure(MetricsConfig metricsConfig) {
@@ -165,8 +178,16 @@ public class S3StreamMetricsManager {
             "Network outbound limiter queue time", "nanoseconds", () -> NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRICS);
         readAheadSize = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.READ_AHEAD_SIZE_METRIC_NAME,
             "Read ahead size", "bytes", () -> READ_AHEAD_SIZE_METRICS);
-        readAheadLimierQueueTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.READ_AHEAD_QUEUE_TIME_METRIC_NAME,
-            "Read ahead limiter queue time", "nanoseconds", () -> READ_AHEAD_LIMITER_QUEUE_TIME_METRICS);
+        readAheadStageTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.READ_AHEAD_STAGE_TIME_METRIC_NAME,
+                "Read ahead stage time", "nanoseconds", () -> READ_AHEAD_STAGE_TIME_METRICS);
+        readS3LimiterTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.READ_S3_LIMITER_TIME_METRIC_NAME,
+                "Time blocked on waiting for inflight read quota", "nanoseconds", () -> READ_S3_METRICS);
+        writeS3LimiterTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.WRITE_S3_LIMITER_TIME_METRIC_NAME,
+                "Time blocked on waiting for inflight write quota", "nanoseconds", () -> WRITE_S3_METRICS);
+        getIndexTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.GET_INDEX_TIME_METRIC_NAME,
+                "Get index time", "nanoseconds", () -> GET_INDEX_METRICS);
+        readBlockCacheTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.READ_BLOCK_CACHE_METRIC_NAME,
+                "Read block cache time", "nanoseconds", () -> READ_BLOCK_CACHE_TIME_METRICS);
         deltaWalStartOffset = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.WAL_START_OFFSET)
             .setDescription("Delta WAL start offset")
             .ofLongs()
@@ -215,7 +236,9 @@ public class S3StreamMetricsManager {
             .ofLongs()
             .buildWithCallback(result -> {
                 if (MetricsLevel.DEBUG.isWithin(metricsConfig.getMetricsLevel())) {
-                    result.record((long) availableInflightS3ReadQuotaSupplier.get(), metricsConfig.getBaseAttributes());
+                    for (Map.Entry<Integer, Supplier<Integer>> entry : availableInflightS3ReadQuotaSupplier.entrySet()) {
+                        result.record((long) entry.getValue().get(), OPERATOR_INDEX_ATTRIBUTES.get(String.valueOf(entry.getKey())));
+                    }
                 }
             });
         availableInflightS3WriteQuota = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.AVAILABLE_S3_INFLIGHT_WRITE_QUOTA_METRIC_NAME)
@@ -223,7 +246,9 @@ public class S3StreamMetricsManager {
             .ofLongs()
             .buildWithCallback(result -> {
                 if (MetricsLevel.DEBUG.isWithin(metricsConfig.getMetricsLevel())) {
-                    result.record((long) availableInflightS3WriteQuotaSupplier.get(), metricsConfig.getBaseAttributes());
+                    for (Map.Entry<Integer, Supplier<Integer>> entry : availableInflightS3WriteQuotaSupplier.entrySet()) {
+                        result.record((long) entry.getValue().get(), OPERATOR_INDEX_ATTRIBUTES.get(String.valueOf(entry.getKey())));
+                    }
                 }
             });
         inflightWALUploadTasksCount = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.INFLIGHT_WAL_UPLOAD_TASKS_COUNT_METRIC_NAME)
@@ -294,12 +319,12 @@ public class S3StreamMetricsManager {
         S3StreamMetricsManager.blockCacheSizeSupplier = blockCacheSizeSupplier;
     }
 
-    public static void registerInflightS3ReadQuotaSupplier(Supplier<Integer> inflightS3ReadQuotaSupplier) {
-        S3StreamMetricsManager.availableInflightS3ReadQuotaSupplier = inflightS3ReadQuotaSupplier;
+    public static void registerInflightS3ReadQuotaSupplier(Supplier<Integer> inflightS3ReadQuotaSupplier, int index) {
+        S3StreamMetricsManager.availableInflightS3ReadQuotaSupplier.putIfAbsent(index, inflightS3ReadQuotaSupplier);
     }
 
-    public static void registerInflightS3WriteQuotaSupplier(Supplier<Integer> inflightS3WriteQuotaSupplier) {
-        S3StreamMetricsManager.availableInflightS3WriteQuotaSupplier = inflightS3WriteQuotaSupplier;
+    public static void registerInflightS3WriteQuotaSupplier(Supplier<Integer> inflightS3WriteQuotaSupplier, int index) {
+        S3StreamMetricsManager.availableInflightS3WriteQuotaSupplier.putIfAbsent(index, inflightS3WriteQuotaSupplier);
     }
 
     public static void registerInflightReadSizeLimiterSupplier(
@@ -362,9 +387,19 @@ public class S3StreamMetricsManager {
     public static YammerHistogramMetric buildOperationMetric(MetricName metricName, MetricsLevel metricsLevel, S3Operation operation, String status) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
             YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
-                AttributesUtils.buildAttributes(operation, status));
+                    AttributesUtils.buildAttributes(operation, status));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OPERATION_LATENCY_METRICS.add(metric);
+            return metric;
+        }
+    }
+
+    public static YammerHistogramMetric buildReadAheadStageTimeMetric(MetricName metricName, MetricsLevel metricsLevel, String stage) {
+        synchronized (BASE_ATTRIBUTES_LISTENERS) {
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+                    AttributesUtils.buildAttributesStage(stage));
+            BASE_ATTRIBUTES_LISTENERS.add(metric);
+            READ_AHEAD_STAGE_TIME_METRICS.add(metric);
             return metric;
         }
     }
@@ -430,9 +465,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildReadAheadSizeMetric(MetricName metricName, MetricsLevel metricsLevel) {
+    public static YammerHistogramMetric buildReadAheadSizeMetric(MetricName metricName, MetricsLevel metricsLevel, String status) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig);
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig, AttributesUtils.buildAttributes(status));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_AHEAD_SIZE_METRICS.add(metric);
             return metric;
@@ -440,11 +475,40 @@ public class S3StreamMetricsManager {
 
     }
 
-    public static YammerHistogramMetric buildReadAheadLimiterQueueTimeMetric(MetricName metricName, MetricsLevel metricsLevel) {
+    public static YammerHistogramMetric buildReadBlockCacheTime(MetricName metricName, MetricsLevel metricsLevel) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
             YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig);
             BASE_ATTRIBUTES_LISTENERS.add(metric);
-            READ_AHEAD_LIMITER_QUEUE_TIME_METRICS.add(metric);
+            READ_BLOCK_CACHE_TIME_METRICS.add(metric);
+            return metric;
+        }
+    }
+
+    public static YammerHistogramMetric buildReadS3LimiterTimeMetric(MetricName metricName, MetricsLevel metricsLevel, int index) {
+        synchronized (BASE_ATTRIBUTES_LISTENERS) {
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+                    Attributes.of(S3StreamMetricsConstant.LABEL_INDEX, String.valueOf(index)));
+            BASE_ATTRIBUTES_LISTENERS.add(metric);
+            READ_S3_METRICS.add(metric);
+            return metric;
+        }
+    }
+
+    public static YammerHistogramMetric buildWriteS3LimiterTimeMetric(MetricName metricName, MetricsLevel metricsLevel, int index) {
+        synchronized (BASE_ATTRIBUTES_LISTENERS) {
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+                    Attributes.of(S3StreamMetricsConstant.LABEL_INDEX, String.valueOf(index)));
+            BASE_ATTRIBUTES_LISTENERS.add(metric);
+            WRITE_S3_METRICS.add(metric);
+            return metric;
+        }
+    }
+
+    public static YammerHistogramMetric buildGetIndexTimeMetric(MetricName metricName, MetricsLevel metricsLevel, String stage) {
+        synchronized (BASE_ATTRIBUTES_LISTENERS) {
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig, Attributes.of(S3StreamMetricsConstant.LABEL_STAGE, stage));
+            BASE_ATTRIBUTES_LISTENERS.add(metric);
+            GET_INDEX_METRICS.add(metric);
             return metric;
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
@@ -79,20 +79,28 @@ public class StorageOperationStats {
     private final YammerHistogramMetric readAheadAsyncTimeStats = S3StreamMetricsManager.buildOperationMetric(
             new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_ASYNC),
             MetricsLevel.INFO, S3Operation.BLOCK_CACHE_READ_AHEAD, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
-    private final YammerHistogramMetric readAheadGetIndicesTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
+    public final YammerHistogramMetric readAheadGetIndicesTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
         new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES),
         MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES);
-    private final YammerHistogramMetric readAheadThrottleTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
+    public final YammerHistogramMetric readAheadThrottleTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
             new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_THROTTLE),
             MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_THROTTLE);
-    private final YammerHistogramMetric readAheadReadS3TimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
+    public final YammerHistogramMetric readAheadReadS3TimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
             new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_READ_S3),
             MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
-    private final YammerHistogramMetric readAheadPutBlockCacheTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
+    public final YammerHistogramMetric readAheadPutBlockCacheTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
             new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_PUT_BLOCK_CACHE),
             MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_PUT_BLOCK_CACHE);
 
-    private final Map<String, YammerHistogramMetric> getIndexTimeStatsMap = new ConcurrentHashMap<>();
+    public final YammerHistogramMetric getIndicesTimeGetObjectStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
+                new MetricName(StorageOperationStats.class, "GetIndexTime-" + S3StreamMetricsConstant.LABEL_STAGE_GET_OBJECTS),
+            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_OBJECTS);
+    public final YammerHistogramMetric getIndicesTimeFindIndexStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
+            new MetricName(StorageOperationStats.class, "GetIndexTime-" + S3StreamMetricsConstant.LABEL_STAGE_FIND_INDEX),
+            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_FIND_INDEX);
+    public final YammerHistogramMetric getIndicesTimeComputeStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
+            new MetricName(StorageOperationStats.class, "GetIndexTime-" + S3StreamMetricsConstant.LABEL_STAGE_COMPUTE),
+            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_COMPUTE);
     private final Map<Integer, YammerHistogramMetric> readS3LimiterStatsMap = new ConcurrentHashMap<>();
     private final Map<Integer, YammerHistogramMetric> writeS3LimiterStatsMap = new ConcurrentHashMap<>();
     public final YammerHistogramMetric readAheadSyncSizeStats = S3StreamMetricsManager.buildReadAheadSizeMetric(
@@ -102,8 +110,38 @@ public class StorageOperationStats {
             new MetricName(StorageOperationStats.class, "ReadAheadSize-" + S3StreamMetricsConstant.LABEL_STATUS_ASYNC),
             MetricsLevel.INFO, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
 
-    public final YammerHistogramMetric readBlockCacheTimeStats = S3StreamMetricsManager.buildReadBlockCacheTime(
-            new MetricName(StorageOperationStats.class, "ReadBlockCacheTime"), MetricsLevel.INFO);
+    public final YammerHistogramMetric readBlockCacheStageMissWaitInflightTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_MISS
+            + S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
+            S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
+    public final YammerHistogramMetric readBlockCacheStageMissReadCacheTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_MISS
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
+    public final YammerHistogramMetric readBlockCacheStageMissReadAheadTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_MISS
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
+    public final YammerHistogramMetric readBlockCacheStageMissReadS3TimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_MISS
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_S3), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
+    public final YammerHistogramMetric readBlockCacheStageHitWaitInflightTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_HIT
+                    + S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
+            S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
+    public final YammerHistogramMetric readBlockCacheStageHitReadCacheTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_HIT
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
+    public final YammerHistogramMetric readBlockCacheStageHitReadAheadTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_HIT
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
+    public final YammerHistogramMetric readBlockCacheStageHitReadS3TimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
+            new MetricName(StorageOperationStats.class, "ReadBlockStageTime" + S3StreamMetricsConstant.LABEL_STATUS_HIT
+                    + S3StreamMetricsConstant.LABEL_STAGE_READ_S3), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
+            S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
 
     private StorageOperationStats() {
     }
@@ -129,24 +167,6 @@ public class StorageOperationStats {
 
     public YammerHistogramMetric readAheadTimeStats(boolean isSync) {
         return isSync ? readAheadSyncTimeStats : readAheadAsyncTimeStats;
-    }
-
-    public YammerHistogramMetric readAheadStageTimeStats(String stage) {
-        switch (stage) {
-            case S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES:
-                return readAheadGetIndicesTimeStats;
-            case S3StreamMetricsConstant.LABEL_STAGE_THROTTLE:
-                return readAheadThrottleTimeStats;
-            case S3StreamMetricsConstant.LABEL_STAGE_READ_S3:
-                return readAheadReadS3TimeStats;
-            default:
-                return readAheadPutBlockCacheTimeStats;
-        }
-    }
-
-    public YammerHistogramMetric getIndexTimeStats(String stage) {
-        return this.getIndexTimeStatsMap.computeIfAbsent(stage, k -> S3StreamMetricsManager.buildGetIndexTimeMetric(
-                new MetricName(StorageOperationStats.class, "GetIndexTime-" + stage), MetricsLevel.DEBUG, stage));
     }
 
     public YammerHistogramMetric readS3LimiterStats(int index) {

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DefaultS3Operator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DefaultS3Operator.java
@@ -117,7 +117,7 @@ public class DefaultS3Operator implements S3Operator {
         "s3-read-limiter-cb-executor", true, LOGGER);
     private final ExecutorService writeLimiterCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(1,
         "s3-write-limiter-cb-executor", true, LOGGER);
-    private final ExecutorService readCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(1,
+    private final ExecutorService readCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(8,
         "s3-read-cb-executor", true, LOGGER);
     private final ExecutorService writeCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(1,
         "s3-write-cb-executor", true, LOGGER);

--- a/s3stream/src/main/java/com/automq/stream/utils/FutureUtil.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/FutureUtil.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 
@@ -44,6 +45,16 @@ public class FutureUtil {
                 dest.complete(rst);
             }
         });
+    }
+
+    public static <T> void propagateAsync(CompletableFuture<T> source, CompletableFuture<T> dest, ExecutorService executor) {
+        source.whenCompleteAsync((rst, ex) -> {
+            if (ex != null) {
+                dest.completeExceptionally(ex);
+            } else {
+                dest.complete(rst);
+            }
+        }, executor);
     }
 
     /**

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/StreamReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/StreamReaderTest.java
@@ -167,7 +167,7 @@ public class StreamReaderTest {
         Mockito.when(reader.read(index1)).thenReturn(CompletableFuture.completedFuture(dataBlockGroup1));
         context.objectReaderMap = new HashMap<>(Map.of(1L, reader));
         CompletableFuture<List<StreamRecordBatch>> cf = streamReader.handleSyncReadAhead(TraceContext.DEFAULT, 233L, 0,
-            999, 64, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), new TimerUtil(), context);
+            999, 64, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), context);
 
         cf.whenComplete((rst, ex) -> {
             Assertions.assertNull(ex);
@@ -229,7 +229,7 @@ public class StreamReaderTest {
         context.taskKeySet.add(key);
         inflightReadAheadTasks.put(key, new DefaultS3BlockCache.ReadAheadTaskContext(new CompletableFuture<>(), DefaultS3BlockCache.ReadBlockCacheStatus.INIT));
         CompletableFuture<List<StreamRecordBatch>> cf = streamReader.handleSyncReadAhead(TraceContext.DEFAULT, 233L, startOffset,
-            999, 64, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), new TimerUtil(), context);
+            999, 64, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), context);
 
         cf.whenComplete((rst, ex) -> {
             Assertions.assertNull(ex);
@@ -290,7 +290,7 @@ public class StreamReaderTest {
         Mockito.when(reader.read(index2)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("exception")));
         context.objectReaderMap = new HashMap<>(Map.of(1L, reader));
         CompletableFuture<List<StreamRecordBatch>> cf = streamReader.handleSyncReadAhead(TraceContext.DEFAULT, 233L, 0,
-            512, 1024, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), new TimerUtil(), context);
+            512, 1024, Mockito.mock(ReadAheadAgent.class), UUID.randomUUID(), context);
 
         Threads.sleep(1000);
 
@@ -354,7 +354,7 @@ public class StreamReaderTest {
         Mockito.when(reader.read(index1)).thenReturn(CompletableFuture.completedFuture(dataBlockGroup1));
         context.objectReaderMap = new HashMap<>(Map.of(1L, reader));
 
-        CompletableFuture<Void> cf = streamReader.handleAsyncReadAhead(233L, 0, 999, 1024, Mockito.mock(ReadAheadAgent.class), new TimerUtil(), context);
+        CompletableFuture<Void> cf = streamReader.handleAsyncReadAhead(233L, 0, 999, 1024, Mockito.mock(ReadAheadAgent.class), context);
 
         cf.whenComplete((rst, ex) -> {
             Assertions.assertNull(ex);
@@ -412,7 +412,7 @@ public class StreamReaderTest {
         Mockito.when(reader.read(index2)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("exception")));
         context.objectReaderMap = new HashMap<>(Map.of(1L, reader));
 
-        CompletableFuture<Void> cf = streamReader.handleAsyncReadAhead(233L, 0, 999, 1024, Mockito.mock(ReadAheadAgent.class), new TimerUtil(), context);
+        CompletableFuture<Void> cf = streamReader.handleAsyncReadAhead(233L, 0, 999, 1024, Mockito.mock(ReadAheadAgent.class), context);
 
         try {
             cf.whenComplete((rst, ex) -> {


### PR DESCRIPTION
1. adjust block cache memory limit and s3 r/w concurrency adaptively
2. add stream set object index to speed up sso lookup
3. increased fetch limiter quota in ReplicaManager
4. increased s3 operator read callback thread pool size
5. increased read ahead agent cache size
6. use seperated thread pool for block cache callback
7. add more comprehensive metrics to trace block cache performance (debug level)