### PR TITLE
feat(core): optimize block cache performance for high-spec node

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -287,8 +287,8 @@ class ReplicaManager(val config: KafkaConfig,
     fetchExecutorQueueSizeGaugeMap
   })
 
-  private val fastFetchLimiter = new FairLimiter(100 * 1024 * 1024) // 100MiB
-  private val slowFetchLimiter = new FairLimiter(100 * 1024 * 1024) // 100MiB
+  private val fastFetchLimiter = new FairLimiter(200 * 1024 * 1024) // 200MiB
+  private val slowFetchLimiter = new FairLimiter(200 * 1024 * 1024) // 200MiB
   private val fetchLimiterGaugeMap = new util.HashMap[String, Integer]()
   S3StreamKafkaMetricsManager.setFetchLimiterPermitNumSupplier(() => {
     fetchLimiterGaugeMap.put(FETCH_LIMITER_FAST_NAME, fastFetchLimiter.availablePermits())

--- a/metadata/src/main/java/org/apache/kafka/image/NodeS3StreamSetObjectMetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/NodeS3StreamSetObjectMetadataImage.java
@@ -36,6 +36,7 @@ public class NodeS3StreamSetObjectMetadataImage {
     private final int nodeId;
     private final long nodeEpoch;
     private final DeltaMap<Long/*objectId*/, S3StreamSetObject> s3Objects;
+    private final StreamOffsetIndexMap offsetIndexMap = new StreamOffsetIndexMap(2500000);
     private List<S3StreamSetObject> orderIndex;
 
     public NodeS3StreamSetObjectMetadataImage(int nodeId, long nodeEpoch, DeltaMap<Long, S3StreamSetObject> streamSetObjects) {
@@ -80,6 +81,14 @@ public class NodeS3StreamSetObjectMetadataImage {
             orderIndex = objects;
         }
         return orderIndex;
+    }
+
+    public int floorStreamSetObjectIndex(long streamId, long startOffset) {
+        return offsetIndexMap.floorIndex(streamId, startOffset);
+    }
+
+    public void recordStreamSetObjectIndex(long streamId, long startOffset, int index) {
+        offsetIndexMap.put(streamId, startOffset, index);
     }
 
     public int getNodeId() {

--- a/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
+++ b/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
@@ -13,7 +13,6 @@ package org.apache.kafka.image;
 
 import com.automq.stream.s3.cache.LRUCache;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -21,7 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 
-@NotThreadSafe
+/**
+ * NotThreadSafe, the caller should ensure the thread safety
+ */
 public class StreamOffsetIndexMap {
     private final int maxSize;
     private final LRUCache<StreamOffset, Void> streamOffsetCache;

--- a/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
+++ b/metadata/src/main/java/org/apache/kafka/image/StreamOffsetIndexMap.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.image;
+
+import com.automq.stream.s3.cache.LRUCache;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+@NotThreadSafe
+public class StreamOffsetIndexMap {
+    private final int maxSize;
+    private final LRUCache<StreamOffset, Void> streamOffsetCache;
+    private final Map<Long, NavigableMap<Long, Integer>> streamOffsetIndexMap;
+
+    public StreamOffsetIndexMap(int maxSize) {
+        this.maxSize = maxSize;
+        this.streamOffsetCache = new LRUCache<>();
+        this.streamOffsetIndexMap = new HashMap<>();
+    }
+
+    public void put(long streamId, long startOffset, int index) {
+        if (streamOffsetIndexMap.containsKey(streamId) && streamOffsetIndexMap.get(streamId).containsKey(startOffset)) {
+            return;
+        }
+        while (streamOffsetCache.size() >= maxSize) {
+            Optional.ofNullable(streamOffsetCache.pop()).ifPresent(entry -> {
+                StreamOffset streamOffset = entry.getKey();
+                NavigableMap<Long, Integer> map = streamOffsetIndexMap.get(streamOffset.streamId);
+                if (map != null) {
+                    map.remove(streamOffset.startOffset);
+                }
+            });
+        }
+        streamOffsetCache.put(new StreamOffset(streamId, startOffset), null);
+        streamOffsetIndexMap.compute(streamId, (k, v) -> {
+            if (v == null) {
+                v = new TreeMap<>();
+            }
+            v.put(startOffset, index);
+            return v;
+        });
+    }
+
+    public int floorIndex(long streamId, long offset) {
+        NavigableMap<Long, Integer> map = streamOffsetIndexMap.get(streamId);
+        if (map == null) {
+            return 0;
+        }
+        Map.Entry<Long, Integer> entry = map.floorEntry(offset);
+        if (entry == null) {
+            return 0;
+        }
+        return entry.getValue();
+    }
+
+    int cacheSize() {
+        return streamOffsetCache.size();
+    }
+
+    int entrySize() {
+        return streamOffsetIndexMap.values().stream().mapToInt(NavigableMap::size).sum();
+    }
+
+    private static class StreamOffset {
+        long streamId;
+        long startOffset;
+
+        public StreamOffset(long streamId, long startOffset) {
+            this.streamId = streamId;
+            this.startOffset = startOffset;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            StreamOffset that = (StreamOffset) o;
+            return streamId == that.streamId && startOffset == that.startOffset;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(streamId, startOffset);
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/StreamOffsetIndexMapTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/StreamOffsetIndexMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.image;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StreamOffsetIndexMapTest {
+
+    @Test
+    public void testPutAndEvict() {
+        StreamOffsetIndexMap map = new StreamOffsetIndexMap(10);
+        for (int i = 0; i < 20; i++) {
+            map.put(i % 2, i, i * i);
+        }
+        Assertions.assertEquals(10, map.cacheSize());
+        Assertions.assertEquals(10, map.entrySize());
+        Assertions.assertEquals(0, map.floorIndex(0, 5));
+        Assertions.assertEquals(100, map.floorIndex(0, 11));
+        Assertions.assertEquals(225, map.floorIndex(1, 15));
+    }
+}


### PR DESCRIPTION
1. add stream set object index to speed up sso lookup
2. increased fetch limiter quota in ReplicaManager