### PR TITLE
chore(core): upgrade "netty-tcnative-boringssl-static" from 2.0.48 to…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -988,7 +988,7 @@ project(':core') {
 
     // https://github.com/netty/netty-tcnative/issues/716
     // After 2.0.48, gradle project need explicitly declare the tcnative dependencies with classifiers
-    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.48.Final'
+    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.65.Final'
 
     compileOnly libs.log4j
 


### PR DESCRIPTION
This is required by software.amazon.awssdk:s3:2.20.127