### PR TITLE
perf(server): always ack local to gain better latency

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -774,7 +774,7 @@ class ReplicaManager(val config: KafkaConfig,
     })
 
     maybeAddDelayedProduce(
-      requiredAcks,
+      1,
       delayedProduceLock,
       timeout,
       entriesPerPartition,


### PR DESCRIPTION
for automq ack local is enough. no need goto delayedProducePurgatory. and this reduce write latency ( test via ack=1, ack=-1 )

