### PR TITLE
feat(s3stream): add S3 API compatibility for BOS DeleteObjects

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/ConfigUtils.java
+++ b/core/src/main/scala/kafka/log/stream/s3/ConfigUtils.java
@@ -50,7 +50,8 @@ public class ConfigUtils {
                 .networkBaselineBandwidth(s.s3NetworkBaselineBandwidthProp())
                 .refillPeriodMs(s.s3RefillPeriodMsProp())
                 .objectRetentionTimeInSecond(s.s3ObjectDeleteRetentionTimeInSecond())
-                .forcePathStyle(s.s3PathStyle());
+                .forcePathStyle(s.s3PathStyle())
+                .deleteObjectsCompatibilityHandlerClassName(s.s3DeleteObjectsCompatibilityHandlerClassName());
     }
 
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -558,6 +558,7 @@ object KafkaConfig {
   val S3SpanScheduledDelayMsDoc = "The delay in milliseconds to export queued spans"
   val S3SpanMaxQueueSizeDoc = "The max number of spans that can be queued before dropped"
   val S3SpanMaxBatchSizeDoc = "The max number of spans that can be exported in a single batch"
+  val S3DeleteObjectsCompatibilityHandlerClassDoc = "The S3 API compatibility handler for DeleteObjects"
   val EnableAutoBalancerDoc = AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_ENABLE_DOC;
   // AutoMQ inject end
 
@@ -1479,6 +1480,7 @@ object KafkaConfig {
       .define(S3SpanMaxQueueSizeProp, INT, Defaults.S3_SPAN_MAX_QUEUE_SIZE, MEDIUM, S3SpanMaxQueueSizeDoc)
       .define(S3SpanMaxBatchSizeProp, INT, Defaults.S3_SPAN_MAX_BATCH_SIZE, MEDIUM, S3SpanMaxBatchSizeDoc)
       .define(EnableAutoBalancerProp, BOOLEAN, false, HIGH, EnableAutoBalancerDoc)
+      .define(S3DeleteObjectsCompatibilityHandlerClassProp, STRING, "", MEDIUM, S3DeleteObjectsCompatibilityHandlerClassDoc)
       // AutoMQ inject end
 
       /** Internal Configurations **/

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -506,6 +506,7 @@ object KafkaConfig {
   val S3SpanScheduledDelayMsProp = "s3.telemetry.tracer.span.scheduled.delay.ms"
   val S3SpanMaxQueueSizeProp = "s3.telemetry.tracer.span.max.queue.size"
   val S3SpanMaxBatchSizeProp = "s3.telemetry.tracer.span.max.batch.size"
+  val S3DeleteObjectsCompatibilityHandlerClassProp = "s3.api.compatibility.delete.objects.handler.classname"
   val EnableAutoBalancerProp = AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_ENABLE
 
   val S3EndpointDoc = "The S3 endpoint, ex. <code>https://s3.{region}.amazonaws.com</code>."
@@ -2201,6 +2202,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val s3SpanScheduledDelayMs = getInt(KafkaConfig.S3SpanScheduledDelayMsProp)
   val s3SpanMaxQueueSize = getInt(KafkaConfig.S3SpanMaxQueueSizeProp)
   val s3SpanMaxBatchSize = getInt(KafkaConfig.S3SpanMaxBatchSizeProp)
+  val s3DeleteObjectsCompatibilityHandlerClassName = getString(KafkaConfig.S3DeleteObjectsCompatibilityHandlerClassProp)
   // AutoMQ inject end
 
   /** Internal Configurations **/

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1088,6 +1088,7 @@ class KafkaConfigTest {
         case KafkaConfig.S3SpanScheduledDelayMsProp => // ignore string
         case KafkaConfig.S3SpanMaxQueueSizeProp => // ignore string
         case KafkaConfig.S3SpanMaxBatchSizeProp => // ignore string
+        case KafkaConfig.S3DeleteObjectsCompatibilityHandlerClassProp => // ignore string
         // AutoMQ inject end
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")

--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -56,6 +56,8 @@ public class Config {
     private long objectRetentionTimeInSecond = 10 * 60; // 10min
     private boolean failoverEnable = false;
 
+    private String deleteObjectsCompatibilityHandlerClassName = "";
+
     public int nodeId() {
         return nodeId;
     }
@@ -425,4 +427,12 @@ public class Config {
         return failoverEnable;
     }
 
+    public String deleteObjectsCompatibilityHandlerClassName() {
+        return deleteObjectsCompatibilityHandlerClassName;
+    }
+
+    public Config deleteObjectsCompatibilityHandlerClassName(String deleteObjectsCompatibilityHandlerClassName) {
+        this.deleteObjectsCompatibilityHandlerClassName = deleteObjectsCompatibilityHandlerClassName;
+        return this;
+    }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/CompatibilityHandler.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/CompatibilityHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator.compatibility;
+
+
+import com.automq.stream.s3.Config;
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompatibilityHandler {
+    public static final CompatibilityHandler NOOP = new CompatibilityHandler();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompatibilityHandler.class);
+    public final DeleteObjectsCompatibilityHandler deleteObjectsCompatibilityHandler;
+
+    public CompatibilityHandler() {
+        this(null);
+    }
+
+    public CompatibilityHandler(Config c) {
+        if (c == null) {
+            deleteObjectsCompatibilityHandler = null;
+            return;
+        }
+
+        if (Strings.isNullOrEmpty(c.deleteObjectsCompatibilityHandlerClassName())) {
+            deleteObjectsCompatibilityHandler = null;
+        } else {
+            try {
+                deleteObjectsCompatibilityHandler = (DeleteObjectsCompatibilityHandler) Class.forName(c.deleteObjectsCompatibilityHandlerClassName()).getDeclaredConstructor().newInstance();
+                LOGGER.info("[CompatibilityHandler] create deleteObjectsCompatibilityHandler {}", c.deleteObjectsCompatibilityHandlerClassName());
+            } catch (Exception e) {
+                LOGGER.error("[CompatibilityHandler] error when create new deleteObjectsCompatibilityHandler name {}", c.deleteObjectsCompatibilityHandlerClassName(), e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}
+

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/DeleteObjectsCompatibilityHandler.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/DeleteObjectsCompatibilityHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator.compatibility;
+
+import com.automq.stream.s3.metrics.TimerUtil;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+
+import java.util.List;
+
+public interface DeleteObjectsCompatibilityHandler {
+    List<String> handleDeleteObjectsResponse(List<String> objectKeys, TimerUtil timerUtil, DeleteObjectsResponse response);
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/bos/BOSDeleteObjectsCompatibilityHandler.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/bos/BOSDeleteObjectsCompatibilityHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator.compatibility.bos;
+
+import com.automq.stream.s3.metrics.TimerUtil;
+import com.automq.stream.s3.metrics.stats.S3OperationStats;
+import com.automq.stream.s3.operator.compatibility.DeleteObjectsCompatibilityHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Error;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+/**
+ * OSSProvider: BOS
+ * DOC: https://cloud.baidu.com/doc/BOS/s/tkc5twspg
+ * API: DeleteMultipleObjects
+ * Description: BOS default deleteObjects works in quiet mode which won't return success keys.
+ * and if object not exist errors will occur in response.
+ */
+public class BOSDeleteObjectsCompatibilityHandler implements DeleteObjectsCompatibilityHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BOSDeleteObjectsCompatibilityHandler.class);
+
+    /**
+     * handleDeleteObjectsResponse which will handle deleteObjects response from oss provider and return success delete object keys.
+     * @param objectKeys need to delete object keys in request.
+     * @param timerUtil use for record metrics.
+     * @param response origin response return from aws s3 sdk
+     * @return success delete object keys.
+     */
+    @Override
+    public List<String> handleDeleteObjectsResponse(List<String> objectKeys, TimerUtil timerUtil, DeleteObjectsResponse response) {
+        List<String> ans = null;
+        int errDeleteCount = 0;
+
+        if (!response.hasErrors()) {
+            ans = objectKeys;
+        } else {
+            Set<String> successDeleteKeys = new HashSet<>(objectKeys);
+            Set<String> errorDeleteKeys = null;
+            for (S3Error error : response.errors()) {
+                if (!error.code().equals("NoSuchKey")) {
+                    successDeleteKeys.remove(error.key());
+                } else {
+                    LOGGER.error("[ControllerS3Operator]: Delete objects for key {} error code {} message {}", error.key(), error.code(), error.message());
+                    if (errorDeleteKeys == null) {
+                        errorDeleteKeys = new HashSet<>();
+                    }
+                    errorDeleteKeys.add(error.key());
+                }
+            }
+
+            ans = new ArrayList<>(successDeleteKeys);
+            errDeleteCount = errorDeleteKeys == null ? 0 : errorDeleteKeys.size();
+        }
+
+        LOGGER.info("[ControllerS3Operator]: Delete objects finished, count: {}, errCount: {}, cost: {}", ans.size(), errDeleteCount, timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+
+        S3OperationStats.getInstance().deleteObjectsStats(true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+
+        return ans;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/bos/BOSDeleteObjectsCompatibilityHandler.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/compatibility/bos/BOSDeleteObjectsCompatibilityHandler.java
@@ -52,15 +52,15 @@ public class BOSDeleteObjectsCompatibilityHandler implements DeleteObjectsCompat
         } else {
             Set<String> successDeleteKeys = new HashSet<>(objectKeys);
             Set<String> errorDeleteKeys = null;
+
             for (S3Error error : response.errors()) {
                 if (!error.code().equals("NoSuchKey")) {
-                    successDeleteKeys.remove(error.key());
-                } else {
                     LOGGER.error("[ControllerS3Operator]: Delete objects for key {} error code {} message {}", error.key(), error.code(), error.message());
                     if (errorDeleteKeys == null) {
                         errorDeleteKeys = new HashSet<>();
                     }
                     errorDeleteKeys.add(error.key());
+                    successDeleteKeys.remove(error.key());
                 }
             }
 


### PR DESCRIPTION
BOS baiduyun default DeleteObjects won't return the success deleted object in deleted response. the logic for remove object need this response to mark object success deleted and delete metadata for this object.

So if oss provider not return this fields which will cause object metadata leak and the object status is always in MARK_DESTROYED status and won't be cleaned.


