### PR TITLE
[WIP] perf(s3stream): remove lock in streamMetadataManager

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/metadata/StreamMetadataManager.java
+++ b/core/src/main/scala/kafka/log/stream/s3/metadata/StreamMetadataManager.java
@@ -20,15 +20,12 @@ import kafka.server.BrokerServer;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
-import org.apache.kafka.image.S3ObjectsImage;
 import org.apache.kafka.image.S3StreamMetadataImage;
-import org.apache.kafka.image.S3StreamsMetadataImage;
 import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.metadata.stream.InRangeObjects;
 import org.apache.kafka.metadata.stream.S3Object;
 import org.apache.kafka.metadata.stream.S3StreamObject;
-import org.apache.kafka.raft.OffsetAndEpoch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
After check most of kafka origin code. those will try to hold one version of MetadataImage to local variable to finish the request.
the MetadataImage is immutable so the process logic can be threadsafe.

change to volatile fields. when request needed hold as local variable and handle the request.
when the fetch retry the method call will read the current variable to handle the retry logic.