### PR TITLE
build(issues1033): switch log appender from DailyRollingFileAppender to RollingFileAppender #1092

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -24,8 +24,9 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
 # and copied in the same directory but with a filename that ends in the `DatePattern` option.
 #
-log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.connectAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.connectAppender.MaxFileSize=10MB
+log4j.appender.kafkaAppender.MaxBackupIndex=11
 log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
 log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
 

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -21,62 +21,72 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.kafkaAppender.MaxFileSize=100MB
+log4j.appender.kafkaAppender.MaxBackupIndex=14
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.stateChangeAppender.MaxFileSize=10MB
+log4j.appender.stateChangeAppender.MaxBackupIndex=11
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.requestAppender.MaxFileSize=10MB
+log4j.appender.requestAppender.MaxBackupIndex=11
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.cleanerAppender.MaxFileSize=10MB
+log4j.appender.cleanerAppender.MaxBackupIndex=11
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.controllerAppender.MaxFileSize=100MB
+log4j.appender.controllerAppender.MaxBackupIndex=14
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.authorizerAppender.MaxFileSize=10MB
+log4j.appender.authorizerAppender.MaxBackupIndex=11
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.s3ObjectAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.s3ObjectAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.s3ObjectAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.s3ObjectAppender.MaxFileSize=100MB
+log4j.appender.s3ObjectAppender.MaxBackupIndex=14
 log4j.appender.s3ObjectAppender.File=${kafka.logs.dir}/s3-object.log
 log4j.appender.s3ObjectAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.s3ObjectAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.s3StreamMetricsAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.s3StreamMetricsAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.s3StreamMetricsAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.s3StreamMetricsAppender.MaxFileSize=10MB
+log4j.appender.s3StreamMetricsAppender.MaxBackupIndex=11
 log4j.appender.s3StreamMetricsAppender.File=${kafka.logs.dir}/s3stream-metrics.log
 log4j.appender.s3StreamMetricsAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.s3StreamMetricsAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.s3StreamThreadPoolAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.s3StreamThreadPoolAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.s3StreamThreadPoolAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.s3StreamThreadPoolAppender.MaxFileSize=10MB
+log4j.appender.s3StreamThreadPoolAppender.MaxBackupIndex=11
 log4j.appender.s3StreamThreadPoolAppender.File=${kafka.logs.dir}/s3stream-threads.log
 log4j.appender.s3StreamThreadPoolAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.s3StreamThreadPoolAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.autoBalancerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.autoBalancerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.autoBalancerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.autoBalancerAppender.MaxFileSize=10MB
+log4j.appender.autoBalancerAppender.MaxBackupIndex=11
 log4j.appender.autoBalancerAppender.File=${kafka.logs.dir}/auto-balancer.log
 log4j.appender.autoBalancerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.autoBalancerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n


### PR DESCRIPTION
This PR cherry-picks a fix from the main branch to the 1.0 branch, addressing the logging issue outlined in #1033 by switching from DailyRollingFileAppender to RollingFileAppender. 