### PR TITLE
feat(issue1120): support slow broker detect in controller

### DIFF
--- a/core/src/main/java/kafka/autobalancer/LoadRetriever.java
+++ b/core/src/main/java/kafka/autobalancer/LoadRetriever.java
@@ -17,6 +17,7 @@ import kafka.autobalancer.common.types.MetricTypes;
 import kafka.autobalancer.config.AutoBalancerControllerConfig;
 import kafka.autobalancer.listeners.BrokerStatusListener;
 import kafka.autobalancer.metricsreporter.metric.AutoBalancerMetrics;
+import kafka.autobalancer.metricsreporter.metric.BrokerMetrics;
 import kafka.autobalancer.metricsreporter.metric.MetricSerde;
 import kafka.autobalancer.metricsreporter.metric.TopicPartitionMetrics;
 import kafka.autobalancer.model.ClusterModel;
@@ -476,10 +477,17 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
         switch (metrics.metricType()) {
             case MetricTypes.TOPIC_PARTITION_METRIC:
                 TopicPartitionMetrics partitionMetrics = (TopicPartitionMetrics) metrics;
+
+                // TODO: remove this when reporting broker metrics is supported
                 clusterModel.updateBrokerMetrics(partitionMetrics.brokerId(), new HashMap<>(), partitionMetrics.time());
+
                 clusterModel.updateTopicPartitionMetrics(partitionMetrics.brokerId(),
                         new TopicPartition(partitionMetrics.topic(), partitionMetrics.partition()),
                         partitionMetrics.getMetricValueMap(), partitionMetrics.time());
+                break;
+            case MetricTypes.BROKER_METRIC:
+                BrokerMetrics brokerMetrics = (BrokerMetrics) metrics;
+                clusterModel.updateBrokerMetrics(brokerMetrics.brokerId(), brokerMetrics.getMetricValueMap(), brokerMetrics.time());
                 break;
             default:
                 logger.error("Not supported metrics version {}", metrics.metricType());

--- a/core/src/main/java/kafka/autobalancer/common/types/MetricTypes.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/MetricTypes.java
@@ -13,4 +13,5 @@ package kafka.autobalancer.common.types;
 
 public class MetricTypes {
     public static final byte TOPIC_PARTITION_METRIC = (byte) 0;
+    public static final byte BROKER_METRIC = (byte) 1;
 }

--- a/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
@@ -11,14 +11,32 @@
 
 package kafka.autobalancer.common.types;
 
+import kafka.autobalancer.common.types.metrics.AbnormalLatency;
+import kafka.autobalancer.common.types.metrics.AbnormalMetric;
+import kafka.autobalancer.common.types.metrics.AbnormalQueueSize;
+
+import java.util.Map;
 import java.util.Set;
 
 public class RawMetricTypes {
-    public static final byte TOPIC_PARTITION_BYTES_IN = (byte) 0;
-    public static final byte TOPIC_PARTITION_BYTES_OUT = (byte) 1;
+    public static final byte PARTITION_BYTES_IN = (byte) 0;
+    public static final byte PARTITION_BYTES_OUT = (byte) 1;
     public static final byte PARTITION_SIZE = (byte) 2;
+    public static final byte BROKER_APPEND_LATENCY_AVG_MS = (byte) 3;
+    public static final byte BROKER_APPEND_QUEUE_SIZE = (byte) 4;
+    public static final byte BROKER_FAST_READ_LATENCY_AVG_MS = (byte) 5;
+    public static final byte BROKER_SLOW_READ_QUEUE_SIZE = (byte) 6;
+    public static final Set<Byte> PARTITION_METRICS = Set.of(PARTITION_BYTES_IN, PARTITION_BYTES_OUT, PARTITION_SIZE);
+    public static final Set<Byte> BROKER_METRICS = Set.of(BROKER_APPEND_LATENCY_AVG_MS, BROKER_APPEND_QUEUE_SIZE,
+            BROKER_FAST_READ_LATENCY_AVG_MS, BROKER_SLOW_READ_QUEUE_SIZE);
+    public static final Map<Byte, AbnormalMetric> ABNORMAL_METRICS = Map.of(
+            BROKER_APPEND_LATENCY_AVG_MS, new AbnormalLatency(50),
+            BROKER_APPEND_QUEUE_SIZE, new AbnormalQueueSize(100),
+            BROKER_FAST_READ_LATENCY_AVG_MS, new AbnormalLatency(50),
+            BROKER_SLOW_READ_QUEUE_SIZE, new AbnormalQueueSize(100)
+    );
 
-    public static Set<Byte> partitionMetrics() {
-        return Set.of(TOPIC_PARTITION_BYTES_IN, TOPIC_PARTITION_BYTES_OUT, PARTITION_SIZE);
+    public static AbnormalMetric ofAbnormalType(byte metricType) {
+        return ABNORMAL_METRICS.get(metricType);
     }
 }

--- a/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalLatency.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalLatency.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.common.types.metrics;
+
+import kafka.autobalancer.model.BrokerUpdater;
+import kafka.autobalancer.model.Snapshot;
+
+import java.util.Map;
+
+public class AbnormalLatency extends AbstractSimpleAbnormalMetric {
+
+    public AbnormalLatency(float abnormalLatency) {
+        super(abnormalLatency);
+    }
+
+    @Override
+    public boolean isAbnormalToPeer(Snapshot self, Map<BrokerUpdater.Broker, Snapshot> peers) {
+        // TODO: compare with peer
+        return false;
+    }
+}

--- a/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalMetric.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalMetric.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.common.types.metrics;
+
+import kafka.autobalancer.model.BrokerUpdater;
+import kafka.autobalancer.model.Snapshot;
+
+import java.util.Map;
+
+public interface AbnormalMetric {
+    default boolean isAbnormal(Snapshot self, Map<BrokerUpdater.Broker, Snapshot> peers) {
+        if (self == null) {
+            return false;
+        }
+        if (isSelfAbnormal(self)) {
+            return true;
+        }
+        return isAbnormalToPeer(self, peers);
+    }
+
+    boolean isSelfAbnormal(Snapshot self);
+
+    boolean isAbnormalToPeer(Snapshot self, Map<BrokerUpdater.Broker, Snapshot> peers);
+}

--- a/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalQueueSize.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/metrics/AbnormalQueueSize.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.common.types.metrics;
+
+import kafka.autobalancer.model.BrokerUpdater;
+import kafka.autobalancer.model.Snapshot;
+
+import java.util.Map;
+
+public class AbnormalQueueSize extends AbstractSimpleAbnormalMetric {
+
+    public AbnormalQueueSize(int abnormalQueueSizeThreshold) {
+        super(abnormalQueueSizeThreshold);
+    }
+
+    @Override
+    public boolean isAbnormalToPeer(Snapshot self, Map<BrokerUpdater.Broker, Snapshot> peers) {
+        return false;
+    }
+
+}

--- a/core/src/main/java/kafka/autobalancer/common/types/metrics/AbstractSimpleAbnormalMetric.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/metrics/AbstractSimpleAbnormalMetric.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.common.types.metrics;
+
+import kafka.autobalancer.model.Snapshot;
+
+public abstract class AbstractSimpleAbnormalMetric implements AbnormalMetric {
+    protected final double abnormalThreshold;
+
+    public AbstractSimpleAbnormalMetric(double abnormalThreshold) {
+        this.abnormalThreshold = abnormalThreshold;
+    }
+
+    @Override
+    public boolean isSelfAbnormal(Snapshot self) {
+        // TODO: compare with historical data
+        return self.getLatest() > abnormalThreshold;
+    }
+}

--- a/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
+++ b/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
@@ -243,6 +243,7 @@ public class AnomalyDetector extends AbstractResumableService {
         logger.info("Start detect");
         // The delay in processing kraft log could result in outdated cluster snapshot
         ClusterModelSnapshot snapshot = this.clusterModel.snapshot(excludedBrokers, excludedTopics, maxTolerateMetricsDelayMs);
+        snapshot.markSlowBrokers();
 
         for (BrokerUpdater.Broker broker : snapshot.brokers()) {
             logger.info("Broker status: {}", broker.shortString());

--- a/core/src/main/java/kafka/autobalancer/goals/AbstractResourceDistributionGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractResourceDistributionGoal.java
@@ -51,6 +51,10 @@ public abstract class AbstractResourceDistributionGoal extends AbstractResourceG
                 }
                 actions.addAll(brokerActions);
             } else if (requireMoreLoad(broker)) {
+                if (broker.isSlowBroker()) {
+                    // prevent scheduling more partitions to slow broker
+                    continue;
+                }
                 List<Action> brokerActions = tryIncreaseLoadByAction(ActionType.MOVE, cluster, broker, candidateBrokers, goalsByPriority);
                 if (!isBrokerAcceptable(broker)) {
                     brokerActions.addAll(tryIncreaseLoadByAction(ActionType.SWAP, cluster, broker, candidateBrokers, goalsByPriority));

--- a/core/src/main/java/kafka/autobalancer/goals/AbstractResourceGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractResourceGoal.java
@@ -68,6 +68,10 @@ public abstract class AbstractResourceGoal extends AbstractGoal {
                                                  List<BrokerUpdater.Broker> candidateBrokers,
                                                  Collection<Goal> goalsByPriority) {
         List<Action> actionList = new ArrayList<>();
+        candidateBrokers = candidateBrokers.stream().filter(b -> !b.isSlowBroker()).collect(Collectors.toList());
+        if (candidateBrokers.isEmpty()) {
+            return actionList;
+        }
         List<TopicPartitionReplicaUpdater.TopicPartitionReplica> srcReplicas = cluster
                 .replicasFor(srcBroker.getBrokerId())
                 .stream()

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -358,8 +358,8 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
         for (AutoBalancerMetrics metrics : context.getMetricMap().values()) {
             if (metrics.metricType() == MetricTypes.TOPIC_PARTITION_METRIC
                     && !MetricsUtils.sanityCheckTopicPartitionMetricsCompleteness(metrics)) {
-                metrics.getMetricValueMap().putIfAbsent(RawMetricTypes.TOPIC_PARTITION_BYTES_IN, 0.0);
-                metrics.getMetricValueMap().putIfAbsent(RawMetricTypes.TOPIC_PARTITION_BYTES_OUT, 0.0);
+                metrics.getMetricValueMap().putIfAbsent(RawMetricTypes.PARTITION_BYTES_IN, 0.0);
+                metrics.getMetricValueMap().putIfAbsent(RawMetricTypes.PARTITION_BYTES_OUT, 0.0);
                 metrics.getMetricValueMap().putIfAbsent(RawMetricTypes.PARTITION_SIZE, 0.0);
             }
         }

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/MetricsUtils.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/MetricsUtils.java
@@ -243,7 +243,7 @@ public final class MetricsUtils {
                                                        int brokerId, String brokerRack, double value) {
 
         if (topic != null && partition != -1) {
-            return new TopicPartitionMetrics(nowMs, brokerId, brokerRack, topic, partition).put(RawMetricTypes.TOPIC_PARTITION_BYTES_IN, value);
+            return new TopicPartitionMetrics(nowMs, brokerId, brokerRack, topic, partition).put(RawMetricTypes.PARTITION_BYTES_IN, value);
         }
         return null;
     }
@@ -252,12 +252,12 @@ public final class MetricsUtils {
                                                         int brokerId, String brokerRack, double value) {
 
         if (topic != null && partition != -1) {
-            return new TopicPartitionMetrics(nowMs, brokerId, brokerRack, topic, partition).put(RawMetricTypes.TOPIC_PARTITION_BYTES_OUT, value);
+            return new TopicPartitionMetrics(nowMs, brokerId, brokerRack, topic, partition).put(RawMetricTypes.PARTITION_BYTES_OUT, value);
         }
         return null;
     }
 
     public static boolean sanityCheckTopicPartitionMetricsCompleteness(AutoBalancerMetrics metrics) {
-        return metrics.getMetricValueMap().keySet().containsAll(RawMetricTypes.partitionMetrics());
+        return metrics.getMetricValueMap().keySet().containsAll(RawMetricTypes.PARTITION_METRICS);
     }
 }

--- a/core/src/main/java/kafka/autobalancer/model/MetricValueSequence.java
+++ b/core/src/main/java/kafka/autobalancer/model/MetricValueSequence.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.model;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class MetricValueSequence {
+    private static final int DEFAULT_MAX_SIZE = 1024;
+    private static final int MIN_VALID_LENGTH = 30;
+    private final Deque<Double> values;
+    private final int maxSize;
+    private Snapshot prev;
+
+    public MetricValueSequence() {
+        this(DEFAULT_MAX_SIZE);
+    }
+
+    public MetricValueSequence(int maxSize) {
+        this.maxSize = maxSize;
+        this.values = new LinkedList<>();
+    }
+
+    public MetricValueSequence copy() {
+        MetricValueSequence copy = new MetricValueSequence(maxSize);
+        copy.values.addAll(values);
+        return copy;
+    }
+
+    public void append(double value) {
+        while (values.size() == maxSize) {
+            values.pop();
+        }
+        values.offer(value);
+    }
+
+    public Snapshot snapshot() {
+        if (values.size() < MIN_VALID_LENGTH) {
+            return null;
+        }
+        Snapshot snapshot = new Snapshot(prev, values);
+        this.prev = snapshot;
+        return snapshot;
+    }
+
+    public int size() {
+        return values.size();
+    }
+}

--- a/core/src/main/java/kafka/autobalancer/model/Snapshot.java
+++ b/core/src/main/java/kafka/autobalancer/model/Snapshot.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class Snapshot {
+    private final Snapshot prev;
+    private final double[] values;
+    private Double latest;
+    private Double percentile90th;
+
+    public Snapshot(Snapshot prev, Collection<Double> values) {
+        this.prev = prev;
+        this.values = values.stream().mapToDouble(Double::doubleValue).toArray();
+        Arrays.sort(this.values);
+    }
+
+    public double getValue(double quantile) {
+        if (!(quantile < 0.0) && !(quantile > 1.0)) {
+            if (this.values.length == 0) {
+                return 0.0;
+            } else {
+                double pos = quantile * (double) (this.values.length + 1);
+                if (pos < 1.0) {
+                    return this.values[0];
+                } else if (pos >= (double) this.values.length) {
+                    return this.values[this.values.length - 1];
+                } else {
+                    double lower = this.values[(int) pos - 1];
+                    double upper = this.values[(int) pos];
+                    return lower + (pos - Math.floor(pos)) * (upper - lower);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException(quantile + " is not in [0..1]");
+        }
+    }
+
+    public double get90thPercentile() {
+        if (this.percentile90th == null) {
+            this.percentile90th = this.getValue(0.9);
+        }
+        return this.percentile90th;
+    }
+
+    public double getLatest() {
+        if (this.latest == null) {
+            this.latest = this.values[this.values.length - 1];
+        }
+        return latest;
+    }
+
+    public Snapshot getPrev() {
+        return this.prev;
+    }
+
+    public int size() {
+        return this.values.length;
+    }
+
+    public double[] getValues() {
+        return Arrays.copyOf(this.values, this.values.length);
+    }
+}

--- a/core/src/main/java/kafka/autobalancer/model/TopicPartitionReplicaUpdater.java
+++ b/core/src/main/java/kafka/autobalancer/model/TopicPartitionReplicaUpdater.java
@@ -31,7 +31,7 @@ public class TopicPartitionReplicaUpdater extends AbstractInstanceUpdater {
 
     @Override
     protected boolean validateMetrics(Map<Byte, Double> metricsMap) {
-        return metricsMap.keySet().containsAll(RawMetricTypes.partitionMetrics());
+        return metricsMap.keySet().containsAll(RawMetricTypes.PARTITION_METRICS);
     }
 
     @Override
@@ -59,14 +59,14 @@ public class TopicPartitionReplicaUpdater extends AbstractInstanceUpdater {
         @Override
         public void processMetrics() {
             for (Map.Entry<Byte, Double> entry : metricsMap.entrySet()) {
-                if (!RawMetricTypes.partitionMetrics().contains(entry.getKey())) {
+                if (!RawMetricTypes.PARTITION_METRICS.contains(entry.getKey())) {
                     continue;
                 }
                 switch (entry.getKey()) {
-                    case RawMetricTypes.TOPIC_PARTITION_BYTES_IN:
+                    case RawMetricTypes.PARTITION_BYTES_IN:
                         this.setLoad(Resource.NW_IN, entry.getValue());
                         break;
-                    case RawMetricTypes.TOPIC_PARTITION_BYTES_OUT:
+                    case RawMetricTypes.PARTITION_BYTES_OUT:
                         this.setLoad(Resource.NW_OUT, entry.getValue());
                         break;
                     default:

--- a/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
+++ b/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
@@ -262,8 +262,8 @@ public class AnomalyDetectorTest {
 
     private Map<Byte, Double> generateRandomMetrics(Random r) {
         Map<Byte, Double> metrics = new HashMap<>();
-        metrics.put(RawMetricTypes.TOPIC_PARTITION_BYTES_OUT, r.nextDouble(0, 1024 * 1024));
-        metrics.put(RawMetricTypes.TOPIC_PARTITION_BYTES_IN, r.nextDouble(0, 1024 * 1024));
+        metrics.put(RawMetricTypes.PARTITION_BYTES_OUT, r.nextDouble(0, 1024 * 1024));
+        metrics.put(RawMetricTypes.PARTITION_BYTES_IN, r.nextDouble(0, 1024 * 1024));
         metrics.put(RawMetricTypes.PARTITION_SIZE, 0.0);
         return metrics;
     }

--- a/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
+++ b/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
@@ -46,8 +46,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import static kafka.autobalancer.common.types.RawMetricTypes.PARTITION_SIZE;
-import static kafka.autobalancer.common.types.RawMetricTypes.TOPIC_PARTITION_BYTES_IN;
-import static kafka.autobalancer.common.types.RawMetricTypes.TOPIC_PARTITION_BYTES_OUT;
+import static kafka.autobalancer.common.types.RawMetricTypes.PARTITION_BYTES_IN;
+import static kafka.autobalancer.common.types.RawMetricTypes.PARTITION_BYTES_OUT;
 
 @Tag("S3Unit")
 public class AutoBalancerMetricsReporterTest extends AutoBalancerClientsIntegrationTestHarness {
@@ -94,8 +94,8 @@ public class AutoBalancerMetricsReporterTest extends AutoBalancerClientsIntegrat
             consumer.subscribe(Collections.singleton(Topic.AUTO_BALANCER_METRICS_TOPIC_NAME));
             long startMs = System.currentTimeMillis();
             Set<Byte> expectedTopicPartitionMetricTypes = new HashSet<>(Arrays.asList(
-                    TOPIC_PARTITION_BYTES_IN,
-                    TOPIC_PARTITION_BYTES_OUT,
+                    PARTITION_BYTES_IN,
+                    PARTITION_BYTES_OUT,
                     PARTITION_SIZE));
             Set<Byte> expectedMetricTypes = new HashSet<>(expectedTopicPartitionMetricTypes);
 

--- a/core/src/test/java/kafka/autobalancer/metricsreporter/metric/MetricSerdeTest.java
+++ b/core/src/test/java/kafka/autobalancer/metricsreporter/metric/MetricSerdeTest.java
@@ -42,16 +42,16 @@ public class MetricSerdeTest {
     public void testPartitionMetricSerde() throws UnknownVersionException {
         AutoBalancerMetrics topicPartitionMetrics = new TopicPartitionMetrics(123L, 0, "", TOPIC, PARTITION)
                 .put(RawMetricTypes.PARTITION_SIZE, VALUE)
-                .put(RawMetricTypes.TOPIC_PARTITION_BYTES_IN, VALUE1);
+                .put(RawMetricTypes.PARTITION_BYTES_IN, VALUE1);
         AutoBalancerMetrics deserialized = MetricSerde.fromBytes(MetricSerde.toBytes(topicPartitionMetrics));
         assertNotNull(deserialized);
         assertEquals(MetricTypes.TOPIC_PARTITION_METRIC, deserialized.metricType());
         Map<Byte, Double> metricMap = deserialized.getMetricValueMap();
         assertEquals(2, metricMap.size());
         assertTrue(metricMap.containsKey(RawMetricTypes.PARTITION_SIZE));
-        assertTrue(metricMap.containsKey(RawMetricTypes.TOPIC_PARTITION_BYTES_IN));
+        assertTrue(metricMap.containsKey(RawMetricTypes.PARTITION_BYTES_IN));
         assertEquals(VALUE, metricMap.get(RawMetricTypes.PARTITION_SIZE), 0.000001);
-        assertEquals(VALUE1, metricMap.get(RawMetricTypes.TOPIC_PARTITION_BYTES_IN), 0.000001);
+        assertEquals(VALUE1, metricMap.get(RawMetricTypes.PARTITION_BYTES_IN), 0.000001);
         assertEquals(TIME, deserialized.time());
         assertEquals(BROKER_ID, deserialized.brokerId());
         assertEquals(TOPIC, ((TopicPartitionMetrics) deserialized).topic());

--- a/core/src/test/java/kafka/autobalancer/metricsreporter/metric/MetricsUtilsTest.java
+++ b/core/src/test/java/kafka/autobalancer/metricsreporter/metric/MetricsUtilsTest.java
@@ -28,9 +28,9 @@ public class MetricsUtilsTest {
     @Test
     public void testSanityCheckTopicPartitionMetricsCompleteness() {
         TopicPartitionMetrics metrics = new TopicPartitionMetrics(System.currentTimeMillis(), 1, "", "testTopic", 0);
-        metrics.put(RawMetricTypes.TOPIC_PARTITION_BYTES_IN, 10);
+        metrics.put(RawMetricTypes.PARTITION_BYTES_IN, 10);
         Assertions.assertFalse(MetricsUtils.sanityCheckTopicPartitionMetricsCompleteness(metrics));
-        metrics.put(RawMetricTypes.TOPIC_PARTITION_BYTES_OUT, 10);
+        metrics.put(RawMetricTypes.PARTITION_BYTES_OUT, 10);
         Assertions.assertFalse(MetricsUtils.sanityCheckTopicPartitionMetricsCompleteness(metrics));
         metrics.put(RawMetricTypes.PARTITION_SIZE, 10);
         Assertions.assertTrue(MetricsUtils.sanityCheckTopicPartitionMetricsCompleteness(metrics));

--- a/core/src/test/java/kafka/autobalancer/model/MetricValueSequenceTest.java
+++ b/core/src/test/java/kafka/autobalancer/model/MetricValueSequenceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MetricValueSequenceTest {
+    @Test
+    public void testAppendAndSnapshot() {
+        MetricValueSequence sequence = new MetricValueSequence(512);
+        for (int i = 0; i < 1000; i++) {
+            sequence.append(i);
+        }
+        Assertions.assertEquals(512, sequence.size());
+        Snapshot snapshot = sequence.snapshot();
+        Assertions.assertNotNull(snapshot);
+        Assertions.assertNull(snapshot.getPrev());
+        Assertions.assertEquals(512, snapshot.size());
+        Assertions.assertEquals(948, snapshot.get90thPercentile(), 1);
+        Assertions.assertEquals(744, snapshot.getValue(0.5), 1);
+
+        for (int i = 1000; i < 2000; i++) {
+            sequence.append(i);
+        }
+        snapshot = sequence.snapshot();
+        Assertions.assertNotNull(snapshot);
+        Assertions.assertNotNull(snapshot.getPrev());
+        Assertions.assertEquals(512, snapshot.size());
+        Assertions.assertEquals(948, snapshot.getPrev().get90thPercentile(), 1);
+        Assertions.assertEquals(744, snapshot.getPrev().getValue(0.5), 1);
+        Assertions.assertEquals(1948, snapshot.get90thPercentile(), 1);
+        Assertions.assertEquals(1744, snapshot.getValue(0.5), 1);
+    }
+}


### PR DESCRIPTION
This PR is part of #1120 which implements slow broker detection in controller side. Client-side metrics reporting is yet to be implemented.

- BrokerMetrics is introduced to represent broker-wide metrics, such as append latency, append queue size, fetch latency and fetch queue size
- The metrics used to detect slow broker implementes interface of AbnormalMetric, which currently use a simple threshold to mark a abnormal status and will be optimized to using historical data and peer measurement later.