### PR TITLE
feat(issue1120): support reporting broker metrics in AutoBalancerMetricsReporter

### DIFF
--- a/core/src/main/java/kafka/autobalancer/LoadRetriever.java
+++ b/core/src/main/java/kafka/autobalancer/LoadRetriever.java
@@ -477,10 +477,6 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
         switch (metrics.metricType()) {
             case MetricTypes.TOPIC_PARTITION_METRIC:
                 TopicPartitionMetrics partitionMetrics = (TopicPartitionMetrics) metrics;
-
-                // TODO: remove this when reporting broker metrics is supported
-                clusterModel.updateBrokerMetrics(partitionMetrics.brokerId(), new HashMap<>(), partitionMetrics.time());
-
                 clusterModel.updateTopicPartitionMetrics(partitionMetrics.brokerId(),
                         new TopicPartition(partitionMetrics.topic(), partitionMetrics.partition()),
                         partitionMetrics.getMetricValueMap(), partitionMetrics.time());

--- a/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
@@ -13,7 +13,6 @@ package kafka.autobalancer.common.types;
 
 import kafka.autobalancer.common.types.metrics.AbnormalLatency;
 import kafka.autobalancer.common.types.metrics.AbnormalMetric;
-import kafka.autobalancer.common.types.metrics.AbnormalQueueSize;
 
 import java.util.Map;
 import java.util.Set;
@@ -23,14 +22,15 @@ public class RawMetricTypes {
     public static final byte PARTITION_BYTES_OUT = (byte) 1;
     public static final byte PARTITION_SIZE = (byte) 2;
     public static final byte BROKER_APPEND_LATENCY_AVG_MS = (byte) 3;
-    public static final byte BROKER_APPEND_QUEUE_SIZE = (byte) 4;
-    public static final byte BROKER_FETCH_QUEUE_SIZE = (byte) 5;
+    public static final byte BROKER_MAX_PENDING_APPEND_LATENCY_MS = (byte) 4;
+    public static final byte BROKER_MAX_PENDING_FETCH_LATENCY_MS = (byte) 5;
     public static final Set<Byte> PARTITION_METRICS = Set.of(PARTITION_BYTES_IN, PARTITION_BYTES_OUT, PARTITION_SIZE);
-    public static final Set<Byte> BROKER_METRICS = Set.of(BROKER_APPEND_LATENCY_AVG_MS, BROKER_APPEND_QUEUE_SIZE, BROKER_FETCH_QUEUE_SIZE);
+    public static final Set<Byte> BROKER_METRICS = Set.of(BROKER_APPEND_LATENCY_AVG_MS,
+            BROKER_MAX_PENDING_APPEND_LATENCY_MS, BROKER_MAX_PENDING_FETCH_LATENCY_MS);
     public static final Map<Byte, AbnormalMetric> ABNORMAL_METRICS = Map.of(
-            BROKER_APPEND_LATENCY_AVG_MS, new AbnormalLatency(50),
-            BROKER_APPEND_QUEUE_SIZE, new AbnormalQueueSize(100),
-            BROKER_FETCH_QUEUE_SIZE, new AbnormalQueueSize(100)
+            BROKER_APPEND_LATENCY_AVG_MS, new AbnormalLatency(100), // 100ms
+            BROKER_MAX_PENDING_APPEND_LATENCY_MS, new AbnormalLatency(10000), // 10s
+            BROKER_MAX_PENDING_FETCH_LATENCY_MS, new AbnormalLatency(10000)  // 10s
     );
 
     public static AbnormalMetric ofAbnormalType(byte metricType) {

--- a/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
+++ b/core/src/main/java/kafka/autobalancer/common/types/RawMetricTypes.java
@@ -24,16 +24,13 @@ public class RawMetricTypes {
     public static final byte PARTITION_SIZE = (byte) 2;
     public static final byte BROKER_APPEND_LATENCY_AVG_MS = (byte) 3;
     public static final byte BROKER_APPEND_QUEUE_SIZE = (byte) 4;
-    public static final byte BROKER_FAST_READ_LATENCY_AVG_MS = (byte) 5;
-    public static final byte BROKER_SLOW_READ_QUEUE_SIZE = (byte) 6;
+    public static final byte BROKER_FETCH_QUEUE_SIZE = (byte) 5;
     public static final Set<Byte> PARTITION_METRICS = Set.of(PARTITION_BYTES_IN, PARTITION_BYTES_OUT, PARTITION_SIZE);
-    public static final Set<Byte> BROKER_METRICS = Set.of(BROKER_APPEND_LATENCY_AVG_MS, BROKER_APPEND_QUEUE_SIZE,
-            BROKER_FAST_READ_LATENCY_AVG_MS, BROKER_SLOW_READ_QUEUE_SIZE);
+    public static final Set<Byte> BROKER_METRICS = Set.of(BROKER_APPEND_LATENCY_AVG_MS, BROKER_APPEND_QUEUE_SIZE, BROKER_FETCH_QUEUE_SIZE);
     public static final Map<Byte, AbnormalMetric> ABNORMAL_METRICS = Map.of(
             BROKER_APPEND_LATENCY_AVG_MS, new AbnormalLatency(50),
             BROKER_APPEND_QUEUE_SIZE, new AbnormalQueueSize(100),
-            BROKER_FAST_READ_LATENCY_AVG_MS, new AbnormalLatency(50),
-            BROKER_SLOW_READ_QUEUE_SIZE, new AbnormalQueueSize(100)
+            BROKER_FETCH_QUEUE_SIZE, new AbnormalQueueSize(100)
     );
 
     public static AbnormalMetric ofAbnormalType(byte metricType) {

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -11,6 +11,8 @@
 
 package kafka.autobalancer.metricsreporter;
 
+import com.automq.stream.s3.metrics.S3StreamMetricsManager;
+import com.automq.stream.s3.metrics.stats.StreamOperationStats;
 import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
@@ -19,6 +21,8 @@ import kafka.autobalancer.common.types.MetricTypes;
 import kafka.autobalancer.common.types.RawMetricTypes;
 import kafka.autobalancer.config.AutoBalancerMetricsReporterConfig;
 import kafka.autobalancer.metricsreporter.metric.AutoBalancerMetrics;
+import kafka.autobalancer.metricsreporter.metric.BrokerMetrics;
+import kafka.autobalancer.metricsreporter.metric.DeltaHistogram;
 import kafka.autobalancer.metricsreporter.metric.MetricSerde;
 import kafka.autobalancer.metricsreporter.metric.MetricsUtils;
 import kafka.autobalancer.metricsreporter.metric.YammerMetricProcessor;
@@ -49,6 +53,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class was modified based on Cruise Control: com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.
@@ -60,6 +65,7 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
     private static final Logger LOGGER = LoggerFactory.getLogger(AutoBalancerMetricsReporter.class);
     private final Map<MetricName, Metric> interestedMetrics = new ConcurrentHashMap<>();
     private final MetricsRegistry metricsRegistry = KafkaYammerMetrics.defaultRegistry();
+    protected final DeltaHistogram appendLatencyMetric = new DeltaHistogram();
     protected YammerMetricProcessor yammerMetricProcessor;
     private KafkaThread metricsReporterRunner;
     private KafkaProducer<String, AutoBalancerMetrics> producer;
@@ -344,7 +350,16 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
 
     protected void processMetrics(YammerMetricProcessor.Context context) throws Exception {
         processYammerMetrics(context);
+        addBrokerMetrics(context);
         addMandatoryMetrics(context);
+    }
+
+    protected void addBrokerMetrics(YammerMetricProcessor.Context context) {
+        context.merge(new BrokerMetrics(context.time(), brokerId, brokerRack)
+                .put(RawMetricTypes.BROKER_APPEND_LATENCY_AVG_MS,
+                        TimeUnit.NANOSECONDS.toMillis((long) appendLatencyMetric.deltaRate(StreamOperationStats.getInstance().appendStreamStats)))
+                .put(RawMetricTypes.BROKER_APPEND_QUEUE_SIZE, S3StreamMetricsManager.totalPendingStreamAppendNum())
+                .put(RawMetricTypes.BROKER_FETCH_QUEUE_SIZE, S3StreamMetricsManager.totalPendingStreamFetchNum()));
     }
 
     protected void processYammerMetrics(YammerMetricProcessor.Context context) throws Exception {

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -358,8 +358,10 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
         context.merge(new BrokerMetrics(context.time(), brokerId, brokerRack)
                 .put(RawMetricTypes.BROKER_APPEND_LATENCY_AVG_MS,
                         TimeUnit.NANOSECONDS.toMillis((long) appendLatencyMetric.deltaRate(StreamOperationStats.getInstance().appendStreamStats)))
-                .put(RawMetricTypes.BROKER_APPEND_QUEUE_SIZE, S3StreamMetricsManager.totalPendingStreamAppendNum())
-                .put(RawMetricTypes.BROKER_FETCH_QUEUE_SIZE, S3StreamMetricsManager.totalPendingStreamFetchNum()));
+                .put(RawMetricTypes.BROKER_MAX_PENDING_APPEND_LATENCY_MS,
+                        TimeUnit.NANOSECONDS.toMillis(S3StreamMetricsManager.maxPendingStreamAppendLatency()))
+                .put(RawMetricTypes.BROKER_MAX_PENDING_FETCH_LATENCY_MS,
+                        TimeUnit.NANOSECONDS.toMillis(S3StreamMetricsManager.maxPendingStreamFetchLatency())));
     }
 
     protected void processYammerMetrics(YammerMetricProcessor.Context context) throws Exception {

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/AutoBalancerMetrics.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/AutoBalancerMetrics.java
@@ -51,7 +51,12 @@ public abstract class AutoBalancerMetrics {
         return metricsMap;
     }
 
+    public abstract boolean isValidMetric(byte type);
+
     public AutoBalancerMetrics put(byte type, double value) {
+        if (!isValidMetric(type)) {
+            throw new IllegalArgumentException(String.format("Cannot put metric type %d into a %s metric.", type, this.getClass().getSimpleName()));
+        }
         this.metricValueMap.put(type, value);
         return this;
     }

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/AutoBalancerMetrics.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/AutoBalancerMetrics.java
@@ -115,12 +115,11 @@ public abstract class AutoBalancerMetrics {
 
     public String buildKVString() {
         StringBuilder builder = new StringBuilder();
-        for (Map.Entry<Byte, Double> entry : metricValueMap.entrySet()) {
-            builder.append(entry.getKey());
-            builder.append(":");
-            builder.append(String.format("%.4f", entry.getValue()));
+        metricValueMap.forEach((k, v) -> builder.append(k).append(":").append(v).append(","));
+        if (builder.length() == 0) {
+            return "";
         }
-        return builder.toString();
+        return builder.substring(0, builder.length() - 1);
     }
 
     @Override

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/BrokerMetrics.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/BrokerMetrics.java
@@ -48,11 +48,8 @@ public class BrokerMetrics extends AutoBalancerMetrics {
     }
 
     @Override
-    public AutoBalancerMetrics put(byte type, double value) {
-        if (!RawMetricTypes.BROKER_METRICS.contains(type)) {
-            throw new IllegalArgumentException("Cannot put non broker metric type " + type + " into a partition metric.");
-        }
-        return super.put(type, value);
+    public boolean isValidMetric(byte type) {
+        return RawMetricTypes.BROKER_METRICS.contains(type);
     }
 
     @Override

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/DeltaHistogram.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/DeltaHistogram.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.autobalancer.metricsreporter.metric;
+
+import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
+
+public class DeltaHistogram {
+    private long count = 0;
+    private long sum = 0;
+
+    public double deltaRate(YammerHistogramMetric metric) {
+        long deltaCount = metric.count() - count;
+        if (deltaCount == 0) {
+            return 0;
+        }
+        double deltaRate = (double) (metric.sum() - sum) / deltaCount;
+        count = metric.count();
+        sum = metric.sum();
+        return deltaRate;
+    }
+}

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/MetricSerde.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/MetricSerde.java
@@ -52,6 +52,8 @@ public class MetricSerde implements Serializer<AutoBalancerMetrics>, Deserialize
         switch (buffer.get()) {
             case MetricTypes.TOPIC_PARTITION_METRIC:
                 return TopicPartitionMetrics.fromBuffer(buffer);
+            case MetricTypes.BROKER_METRIC:
+                return BrokerMetrics.fromBuffer(buffer);
             default:
                 // This could happen when a new type of metric is added, but we are still running the old code.
                 // simply ignore the metric by returning a null.

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/TopicPartitionMetrics.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/TopicPartitionMetrics.java
@@ -62,13 +62,9 @@ public class TopicPartitionMetrics extends AutoBalancerMetrics {
     }
 
     @Override
-    public AutoBalancerMetrics put(byte type, double value) {
-        if (!RawMetricTypes.PARTITION_METRICS.contains(type)) {
-            throw new IllegalArgumentException("Cannot put non partition metric type " + type + " into a partition metric.");
-        }
-        return super.put(type, value);
+    public boolean isValidMetric(byte type) {
+        return RawMetricTypes.PARTITION_METRICS.contains(type);
     }
-
 
     @Override
     public String key() {

--- a/core/src/main/java/kafka/autobalancer/model/BrokerUpdater.java
+++ b/core/src/main/java/kafka/autobalancer/model/BrokerUpdater.java
@@ -40,8 +40,7 @@ public class BrokerUpdater extends AbstractInstanceUpdater {
 
     @Override
     protected boolean validateMetrics(Map<Byte, Double> metricsMap) {
-        // TODO: add broker metrics validation when reporting broker metrics is supported
-        return true;
+        return metricsMap.keySet().containsAll(RawMetricTypes.BROKER_METRICS);
     }
 
     @Override

--- a/core/src/main/java/kafka/autobalancer/model/MetricValueSequence.java
+++ b/core/src/main/java/kafka/autobalancer/model/MetricValueSequence.java
@@ -16,7 +16,6 @@ import java.util.LinkedList;
 
 public class MetricValueSequence {
     private static final int DEFAULT_MAX_SIZE = 1024;
-    private static final int MIN_VALID_LENGTH = 30;
     private final Deque<Double> values;
     private final int maxSize;
     private Snapshot prev;
@@ -44,9 +43,6 @@ public class MetricValueSequence {
     }
 
     public Snapshot snapshot() {
-        if (values.size() < MIN_VALID_LENGTH) {
-            return null;
-        }
         Snapshot snapshot = new Snapshot(prev, values);
         this.prev = snapshot;
         return snapshot;

--- a/core/src/main/java/kafka/autobalancer/model/Snapshot.java
+++ b/core/src/main/java/kafka/autobalancer/model/Snapshot.java
@@ -17,12 +17,13 @@ import java.util.Collection;
 public class Snapshot {
     private final Snapshot prev;
     private final double[] values;
-    private Double latest;
+    private final double latest;
     private Double percentile90th;
 
     public Snapshot(Snapshot prev, Collection<Double> values) {
         this.prev = prev;
         this.values = values.stream().mapToDouble(Double::doubleValue).toArray();
+        this.latest = this.values.length > 0 ? this.values[this.values.length - 1] : 0.0;
         Arrays.sort(this.values);
     }
 
@@ -55,9 +56,6 @@ public class Snapshot {
     }
 
     public double getLatest() {
-        if (this.latest == null) {
-            this.latest = this.values[this.values.length - 1];
-        }
         return latest;
     }
 

--- a/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
+++ b/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
@@ -147,7 +147,10 @@ public class AnomalyDetectorTest {
         int brokerNum = 20;
         for (int i = 0; i < brokerNum; i++) {
             clusterModel.registerBroker(i, "");
-            clusterModel.updateBrokerMetrics(i, new HashMap<>(), System.currentTimeMillis());
+            clusterModel.updateBrokerMetrics(i, Map.of(
+                    RawMetricTypes.BROKER_APPEND_LATENCY_AVG_MS, 0.0,
+                    RawMetricTypes.BROKER_APPEND_QUEUE_SIZE, 0.0,
+                    RawMetricTypes.BROKER_FETCH_QUEUE_SIZE, 0.0), System.currentTimeMillis());
         }
         int topicNum = 5000;
         int totalPartitionNum = 100000;

--- a/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
+++ b/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
@@ -149,8 +149,8 @@ public class AnomalyDetectorTest {
             clusterModel.registerBroker(i, "");
             clusterModel.updateBrokerMetrics(i, Map.of(
                     RawMetricTypes.BROKER_APPEND_LATENCY_AVG_MS, 0.0,
-                    RawMetricTypes.BROKER_APPEND_QUEUE_SIZE, 0.0,
-                    RawMetricTypes.BROKER_FETCH_QUEUE_SIZE, 0.0), System.currentTimeMillis());
+                    RawMetricTypes.BROKER_MAX_PENDING_APPEND_LATENCY_MS, 0.0,
+                    RawMetricTypes.BROKER_MAX_PENDING_FETCH_LATENCY_MS, 0.0), System.currentTimeMillis());
         }
         int topicNum = 5000;
         int totalPartitionNum = 100000;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -79,6 +79,8 @@ public class S3StreamMetricsConstant {
     public static final String NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRIC_NAME = "network_outbound_limiter_queue_time";
     public static final String READ_AHEAD_SIZE_METRIC_NAME = "read_ahead_size";
     public static final String READ_AHEAD_STAGE_TIME_METRIC_NAME = "read_ahead_stage_time";
+    public static final String PENDING_STREAM_APPEND_NUM_METRIC_NAME = "pending_stream_append_num";
+    public static final String PENDING_STREAM_FETCH_NUM_METRIC_NAME = "pending_stream_fetch_num";
     public static final String SUM_METRIC_NAME_SUFFIX = "_sum";
     public static final String COUNT_METRIC_NAME_SUFFIX = "_count";
     public static final String P50_METRIC_NAME_SUFFIX = "_50p";

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -79,8 +79,8 @@ public class S3StreamMetricsConstant {
     public static final String NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRIC_NAME = "network_outbound_limiter_queue_time";
     public static final String READ_AHEAD_SIZE_METRIC_NAME = "read_ahead_size";
     public static final String READ_AHEAD_STAGE_TIME_METRIC_NAME = "read_ahead_stage_time";
-    public static final String PENDING_STREAM_APPEND_NUM_METRIC_NAME = "pending_stream_append_num";
-    public static final String PENDING_STREAM_FETCH_NUM_METRIC_NAME = "pending_stream_fetch_num";
+    public static final String PENDING_STREAM_APPEND_LATENCY_METRIC_NAME = "pending_stream_append_latency";
+    public static final String PENDING_STREAM_FETCH_LATENCY_METRIC_NAME = "pending_stream_fetch_latency";
     public static final String SUM_METRIC_NAME_SUFFIX = "_sum";
     public static final String COUNT_METRIC_NAME_SUFFIX = "_count";
     public static final String P50_METRIC_NAME_SUFFIX = "_50p";

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -76,6 +76,8 @@ public class S3StreamMetricsManager {
     private static ObservableLongGauge inflightWALUploadTasksCount = new NoopObservableLongGauge();
     private static ObservableLongGauge allocatedMemorySize = new NoopObservableLongGauge();
     private static ObservableLongGauge usedMemorySize = new NoopObservableLongGauge();
+    private static ObservableLongGauge pendingStreamAppendNumMetrics = new NoopObservableLongGauge();
+    private static ObservableLongGauge pendingStreamFetchNumMetrics = new NoopObservableLongGauge();
     private static LongCounter compactionReadSizeInTotal = new NoopLongCounter();
     private static LongCounter compactionWriteSizeInTotal = new NoopLongCounter();
     private static Supplier<Long> networkInboundAvailableBandwidthSupplier = () -> 0L;
@@ -90,6 +92,8 @@ public class S3StreamMetricsManager {
     private static Map<Integer, Supplier<Integer>> availableInflightS3ReadQuotaSupplier = new ConcurrentHashMap<>();
     private static Map<Integer, Supplier<Integer>> availableInflightS3WriteQuotaSupplier = new ConcurrentHashMap<>();
     private static Supplier<Integer> inflightWALUploadTasksCountSupplier = () -> 0;
+    private static Map<Long, Supplier<Integer>> pendingStreamAppendNumSupplier = new ConcurrentHashMap<>();
+    private static Map<Long, Supplier<Integer>> pendingStreamFetchNumSupplier = new ConcurrentHashMap<>();
     private static MetricsConfig metricsConfig = new MetricsConfig(MetricsLevel.INFO, Attributes.empty());
     private static final MultiAttributes<String> ALLOC_TYPE_ATTRIBUTES = new MultiAttributes<>(Attributes.empty(),
         S3StreamMetricsConstant.LABEL_TYPE);
@@ -289,6 +293,22 @@ public class S3StreamMetricsManager {
                     result.record(ByteBufAlloc.byteBufAllocMetric.getUsedMemory(), metricsConfig.getBaseAttributes());
                 }
             });
+        pendingStreamAppendNumMetrics = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.PENDING_STREAM_APPEND_NUM_METRIC_NAME)
+                .setDescription("The number of pending stream append requests")
+                .ofLongs()
+                .buildWithCallback(result -> {
+                    if (MetricsLevel.INFO.isWithin(metricsConfig.getMetricsLevel())) {
+                        result.record(totalPendingStreamAppendNum(), metricsConfig.getBaseAttributes());
+                    }
+                });
+        pendingStreamFetchNumMetrics = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.PENDING_STREAM_FETCH_NUM_METRIC_NAME)
+                .setDescription("The number of pending stream fetch requests")
+                .ofLongs()
+                .buildWithCallback(result -> {
+                    if (MetricsLevel.INFO.isWithin(metricsConfig.getMetricsLevel())) {
+                        result.record(totalPendingStreamFetchNum(), metricsConfig.getBaseAttributes());
+                    }
+                });
     }
 
     public static void registerNetworkLimiterSupplier(AsyncNetworkBandwidthLimiter.Type type,
@@ -535,5 +555,29 @@ public class S3StreamMetricsManager {
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             return metric;
         }
+    }
+
+    public static int totalPendingStreamAppendNum() {
+        return pendingStreamAppendNumSupplier.values().stream().mapToInt(Supplier::get).sum();
+    }
+
+    public static int totalPendingStreamFetchNum() {
+        return pendingStreamFetchNumSupplier.values().stream().mapToInt(Supplier::get).sum();
+    }
+
+    public static void registerPendingStreamAppendNumSupplier(long streamId, Supplier<Integer> pendingStreamAppendNumSupplier) {
+        S3StreamMetricsManager.pendingStreamAppendNumSupplier.put(streamId, pendingStreamAppendNumSupplier);
+    }
+
+    public static void registerPendingStreamFetchNumSupplier(long streamId, Supplier<Integer> pendingStreamFetchNumSupplier) {
+        S3StreamMetricsManager.pendingStreamFetchNumSupplier.put(streamId, pendingStreamFetchNumSupplier);
+    }
+
+    public static void removePendingStreamAppendNumSupplier(long streamId) {
+        S3StreamMetricsManager.pendingStreamAppendNumSupplier.remove(streamId);
+    }
+
+    public static void removePendingStreamFetchNumSupplier(long streamId) {
+        S3StreamMetricsManager.pendingStreamFetchNumSupplier.remove(streamId);
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/TimerUtil.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/TimerUtil.java
@@ -25,6 +25,10 @@ public class TimerUtil {
         last.set(System.nanoTime());
     }
 
+    public long lastAs(TimeUnit timeUnit) {
+        return timeUnit.convert(last.get(), TimeUnit.NANOSECONDS);
+    }
+
     public long elapsedAs(TimeUnit timeUnit) {
         return timeUnit.convert(System.nanoTime() - last.get(), TimeUnit.NANOSECONDS);
     }

--- a/server-common/src/main/java/org/apache/kafka/server/metrics/s3stream/S3StreamKafkaMetricsConstants.java
+++ b/server-common/src/main/java/org/apache/kafka/server/metrics/s3stream/S3StreamKafkaMetricsConstants.java
@@ -21,6 +21,7 @@ public class S3StreamKafkaMetricsConstants {
     public static final String STREAM_OBJECT_NUM = "stream_object_num";
     public static final String FETCH_LIMITER_PERMIT_NUM = "fetch_limiter_permit_num";
     public static final String FETCH_PENDING_TASK_NUM = "fetch_pending_task_num";
+    public static final String SLOW_BROKER_METRIC_NAME = "slow_broker_count";
 
     public static final AttributeKey<String> LABEL_NODE_ID = AttributeKey.stringKey("node_id");
 


### PR DESCRIPTION
This PR is part of #1120 which implements client-side broker-level metrics reporting.

Currently a broker will marked as "slow" if any of the following conditions is met:
1. latest append stream latency exceeds 100ms
2. maximum pending append stream request latency exceeds 10s
3. maximum pending fetch stream request latency exceeds 10s 

If a slow broker is detected, no additional partitions will be assigned to it and value of metric kafka_stream_slow_broker_count with corresponding label "node_id=x" will be set to 1