### PR TITLE
feat(metrics): use delta value on reporting percentile metrics

### DIFF
--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -22,7 +22,7 @@ import kafka.autobalancer.common.types.RawMetricTypes;
 import kafka.autobalancer.config.AutoBalancerMetricsReporterConfig;
 import kafka.autobalancer.metricsreporter.metric.AutoBalancerMetrics;
 import kafka.autobalancer.metricsreporter.metric.BrokerMetrics;
-import kafka.autobalancer.metricsreporter.metric.DeltaHistogram;
+import kafka.autobalancer.metricsreporter.metric.Delta;
 import kafka.autobalancer.metricsreporter.metric.MetricSerde;
 import kafka.autobalancer.metricsreporter.metric.MetricsUtils;
 import kafka.autobalancer.metricsreporter.metric.YammerMetricProcessor;
@@ -65,7 +65,7 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
     private static final Logger LOGGER = LoggerFactory.getLogger(AutoBalancerMetricsReporter.class);
     private final Map<MetricName, Metric> interestedMetrics = new ConcurrentHashMap<>();
     private final MetricsRegistry metricsRegistry = KafkaYammerMetrics.defaultRegistry();
-    protected final DeltaHistogram appendLatencyMetric = new DeltaHistogram();
+    protected final Delta appendLatencyMetric = new Delta();
     protected YammerMetricProcessor yammerMetricProcessor;
     private KafkaThread metricsReporterRunner;
     private KafkaProducer<String, AutoBalancerMetrics> producer;

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/metric/Delta.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/metric/Delta.java
@@ -13,7 +13,7 @@ package kafka.autobalancer.metricsreporter.metric;
 
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
 
-public class DeltaHistogram {
+public class Delta {
     private long count = 0;
     private long sum = 0;
 

--- a/core/src/main/scala/kafka/log/stream/s3/telemetry/TelemetryManager.java
+++ b/core/src/main/scala/kafka/log/stream/s3/telemetry/TelemetryManager.java
@@ -151,10 +151,10 @@ public class TelemetryManager {
 
             // initialize S3Stream metrics
             Meter meter = openTelemetrySdk.getMeter(TelemetryConstants.TELEMETRY_SCOPE_NAME);
-            S3StreamMetricsManager.configure(new MetricsConfig(metricsLevel(), Attributes.empty()));
+            S3StreamMetricsManager.configure(new MetricsConfig(metricsLevel(), Attributes.empty(), kafkaConfig.s3ExporterReportIntervalMs()));
             S3StreamMetricsManager.initMetrics(meter, TelemetryConstants.KAFKA_METRICS_PREFIX);
 
-            S3StreamKafkaMetricsManager.configure(new MetricsConfig(metricsLevel(), Attributes.empty()));
+            S3StreamKafkaMetricsManager.configure(new MetricsConfig(metricsLevel(), Attributes.empty(), kafkaConfig.s3ExporterReportIntervalMs()));
             S3StreamKafkaMetricsManager.initMetrics(meter, TelemetryConstants.KAFKA_METRICS_PREFIX);
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/MetricsConfig.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/MetricsConfig.java
@@ -14,17 +14,23 @@ package com.automq.stream.s3.metrics;
 import io.opentelemetry.api.common.Attributes;
 
 public class MetricsConfig {
+    private static final long DEFAULT_METRICS_REPORT_INTERVAL_MS = 5000;
     private MetricsLevel metricsLevel;
     private Attributes baseAttributes;
+    private long metricsReportIntervalMs;
 
     public MetricsConfig() {
-        this.metricsLevel = MetricsLevel.INFO;
-        this.baseAttributes = Attributes.empty();
+        this(MetricsLevel.INFO, Attributes.empty());
     }
 
     public MetricsConfig(MetricsLevel metricsLevel, Attributes baseAttributes) {
+        this(metricsLevel, baseAttributes, DEFAULT_METRICS_REPORT_INTERVAL_MS);
+    }
+
+    public MetricsConfig(MetricsLevel metricsLevel, Attributes baseAttributes, long interval) {
         this.metricsLevel = metricsLevel;
         this.baseAttributes = baseAttributes;
+        this.metricsReportIntervalMs = interval;
     }
 
     public MetricsLevel getMetricsLevel() {
@@ -35,11 +41,19 @@ public class MetricsConfig {
         return baseAttributes;
     }
 
+    public long getMetricsReportIntervalMs() {
+        return metricsReportIntervalMs;
+    }
+
     public void setMetricsLevel(MetricsLevel metricsLevel) {
         this.metricsLevel = metricsLevel;
     }
 
     public void setBaseAttributes(Attributes baseAttributes) {
         this.baseAttributes = baseAttributes;
+    }
+
+    public void setMetricsReportIntervalMs(long interval) {
+        this.metricsReportIntervalMs = interval;
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -85,7 +85,6 @@ public class S3StreamMetricsConstant {
     public static final String COUNT_METRIC_NAME_SUFFIX = "_count";
     public static final String P50_METRIC_NAME_SUFFIX = "_50p";
     public static final String P99_METRIC_NAME_SUFFIX = "_99p";
-    public static final String MEAN_METRIC_NAME_SUFFIX = "_mean";
     public static final String MAX_METRIC_NAME_SUFFIX = "_max";
     public static final String WAL_START_OFFSET = "wal_start_offset";
     public static final String WAL_TRIMMED_OFFSET = "wal_trimmed_offset";

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -21,7 +21,6 @@ import com.automq.stream.s3.metrics.wrapper.HistogramInstrument;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
 import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.ThrottleStrategy;
-import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -385,40 +384,40 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildStageOperationMetric(MetricName metricName, MetricsLevel metricsLevel, S3Stage stage) {
+    public static YammerHistogramMetric buildStageOperationMetric(MetricsLevel metricsLevel, S3Stage stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel,
-                metricsConfig, AttributesUtils.buildAttributes(stage));
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
+                    AttributesUtils.buildAttributes(stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OPERATION_LATENCY_METRICS.add(metric);
             return metric;
         }
     }
 
-    public static YammerHistogramMetric buildOperationMetric(MetricName metricName, MetricsLevel metricsLevel, S3Operation operation) {
+    public static YammerHistogramMetric buildOperationMetric(MetricsLevel metricsLevel, S3Operation operation) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel,
-                metricsConfig, AttributesUtils.buildAttributes(operation));
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
+                    AttributesUtils.buildAttributes(operation));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OPERATION_LATENCY_METRICS.add(metric);
             return metric;
         }
     }
 
-    public static YammerHistogramMetric buildOperationMetric(MetricName metricName, MetricsLevel metricsLevel,
+    public static YammerHistogramMetric buildOperationMetric(MetricsLevel metricsLevel,
         S3Operation operation, String status, String sizeLabelName) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
-                AttributesUtils.buildAttributes(operation, status, sizeLabelName));
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
+                    AttributesUtils.buildAttributes(operation, status, sizeLabelName));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OPERATION_LATENCY_METRICS.add(metric);
             return metric;
         }
     }
 
-    public static YammerHistogramMetric buildOperationMetric(MetricName metricName, MetricsLevel metricsLevel, S3Operation operation, String status) {
+    public static YammerHistogramMetric buildOperationMetric(MetricsLevel metricsLevel, S3Operation operation, String status) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     AttributesUtils.buildAttributes(operation, status));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OPERATION_LATENCY_METRICS.add(metric);
@@ -426,9 +425,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildReadAheadStageTimeMetric(MetricName metricName, MetricsLevel metricsLevel, String stage) {
+    public static YammerHistogramMetric buildReadAheadStageTimeMetric(MetricsLevel metricsLevel, String stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     AttributesUtils.buildAttributesStage(stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_AHEAD_STAGE_TIME_METRICS.add(metric);
@@ -444,9 +443,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildObjectStageCostMetric(MetricName metricName, MetricsLevel metricsLevel, S3ObjectStage stage) {
+    public static YammerHistogramMetric buildObjectStageCostMetric(MetricsLevel metricsLevel, S3ObjectStage stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                 AttributesUtils.buildAttributes(stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OBJECT_STAGE_METRICS.add(metric);
@@ -454,9 +453,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildObjectUploadSizeMetric(MetricName metricName, MetricsLevel metricsLevel) {
+    public static YammerHistogramMetric buildObjectUploadSizeMetric(MetricsLevel metricsLevel) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig);
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig);
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             OBJECT_STAGE_METRICS.add(metric);
             return metric;
@@ -479,11 +478,10 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildNetworkInboundLimiterQueueTimeMetric(MetricName metricName,
-                                                                                  MetricsLevel metricsLevel,
+    public static YammerHistogramMetric buildNetworkInboundLimiterQueueTimeMetric(MetricsLevel metricsLevel,
                                                                                   ThrottleStrategy strategy) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     AttributesUtils.buildAttributes(strategy));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             NETWORK_INBOUND_LIMITER_QUEUE_TIME_METRICS.add(metric);
@@ -491,11 +489,10 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildNetworkOutboundLimiterQueueTimeMetric(MetricName metricName,
-                                                                                   MetricsLevel metricsLevel,
+    public static YammerHistogramMetric buildNetworkOutboundLimiterQueueTimeMetric(MetricsLevel metricsLevel,
                                                                                    ThrottleStrategy strategy) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     AttributesUtils.buildAttributes(strategy));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             NETWORK_OUTBOUND_LIMITER_QUEUE_TIME_METRICS.add(metric);
@@ -503,9 +500,10 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildReadAheadSizeMetric(MetricName metricName, MetricsLevel metricsLevel, String status) {
+    public static YammerHistogramMetric buildReadAheadSizeMetric(MetricsLevel metricsLevel, String status) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig, AttributesUtils.buildAttributes(status));
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
+                    AttributesUtils.buildAttributes(status));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_AHEAD_SIZE_METRICS.add(metric);
             return metric;
@@ -513,9 +511,9 @@ public class S3StreamMetricsManager {
 
     }
 
-    public static YammerHistogramMetric buildReadBlockCacheStageTime(MetricName metricName, MetricsLevel metricsLevel, String status, String stage) {
+    public static YammerHistogramMetric buildReadBlockCacheStageTime(MetricsLevel metricsLevel, String status, String stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     AttributesUtils.buildStatusStageAttributes(status, stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_BLOCK_CACHE_TIME_METRICS.add(metric);
@@ -533,9 +531,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildReadS3LimiterTimeMetric(MetricName metricName, MetricsLevel metricsLevel, int index) {
+    public static YammerHistogramMetric buildReadS3LimiterTimeMetric(MetricsLevel metricsLevel, int index) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     Attributes.of(S3StreamMetricsConstant.LABEL_INDEX, String.valueOf(index)));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             READ_S3_METRICS.add(metric);
@@ -543,9 +541,9 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildWriteS3LimiterTimeMetric(MetricName metricName, MetricsLevel metricsLevel, int index) {
+    public static YammerHistogramMetric buildWriteS3LimiterTimeMetric(MetricsLevel metricsLevel, int index) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig,
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
                     Attributes.of(S3StreamMetricsConstant.LABEL_INDEX, String.valueOf(index)));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             WRITE_S3_METRICS.add(metric);
@@ -553,9 +551,10 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static YammerHistogramMetric buildGetIndexTimeMetric(MetricName metricName, MetricsLevel metricsLevel, String stage) {
+    public static YammerHistogramMetric buildGetIndexTimeMetric(MetricsLevel metricsLevel, String stage) {
         synchronized (BASE_ATTRIBUTES_LISTENERS) {
-            YammerHistogramMetric metric = new YammerHistogramMetric(metricName, metricsLevel, metricsConfig, Attributes.of(S3StreamMetricsConstant.LABEL_STAGE, stage));
+            YammerHistogramMetric metric = new YammerHistogramMetric(metricsLevel, metricsConfig,
+                    Attributes.of(S3StreamMetricsConstant.LABEL_STAGE, stage));
             BASE_ATTRIBUTES_LISTENERS.add(metric);
             GET_INDEX_METRICS.add(metric);
             return metric;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
@@ -17,7 +17,6 @@ import com.automq.stream.s3.metrics.wrapper.CounterMetric;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
 import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.ThrottleStrategy;
-import com.yammer.metrics.core.MetricName;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,11 +51,7 @@ public class NetworkStats {
 
     public YammerHistogramMetric networkLimiterQueueTimeStats(AsyncNetworkBandwidthLimiter.Type type, ThrottleStrategy strategy) {
         return type == AsyncNetworkBandwidthLimiter.Type.INBOUND
-                ? networkInboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy, k -> S3StreamMetricsManager.buildNetworkInboundLimiterQueueTimeMetric(
-                        new MetricName(NetworkStats.class, "NetworkInboundLimiterQueueTime-" + strategy.getName()),
-                        MetricsLevel.INFO, strategy))
-                : networkOutboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy, k -> S3StreamMetricsManager.buildNetworkOutboundLimiterQueueTimeMetric(
-                        new MetricName(NetworkStats.class, "NetworkOutboundLimiterQueueTime-" + strategy.getName()),
-                        MetricsLevel.INFO, strategy));
+                ? networkInboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy, k -> S3StreamMetricsManager.buildNetworkInboundLimiterQueueTimeMetric(MetricsLevel.INFO, strategy))
+                : networkOutboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy, k -> S3StreamMetricsManager.buildNetworkOutboundLimiterQueueTimeMetric(MetricsLevel.INFO, strategy));
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/S3ObjectStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/S3ObjectStats.java
@@ -16,20 +16,18 @@ import com.automq.stream.s3.metrics.S3StreamMetricsManager;
 import com.automq.stream.s3.metrics.operations.S3ObjectStage;
 import com.automq.stream.s3.metrics.wrapper.CounterMetric;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
-import com.yammer.metrics.core.MetricName;
 
 public class S3ObjectStats {
     private volatile static S3ObjectStats instance = null;
 
     public final CounterMetric objectNumInTotalStats = S3StreamMetricsManager.buildObjectNumMetric();
-    public final YammerHistogramMetric objectStageUploadPartStats = S3StreamMetricsManager.buildObjectStageCostMetric(
-        new MetricName(S3ObjectStats.class, S3ObjectStage.UPLOAD_PART.getUniqueKey()), MetricsLevel.DEBUG, S3ObjectStage.UPLOAD_PART);
-    public final YammerHistogramMetric objectStageReadyCloseStats = S3StreamMetricsManager.buildObjectStageCostMetric(
-        new MetricName(S3ObjectStats.class, S3ObjectStage.READY_CLOSE.getUniqueKey()), MetricsLevel.DEBUG, S3ObjectStage.READY_CLOSE);
-    public final YammerHistogramMetric objectStageTotalStats = S3StreamMetricsManager.buildObjectStageCostMetric(
-        new MetricName(S3ObjectStats.class, S3ObjectStage.TOTAL.getUniqueKey()), MetricsLevel.DEBUG, S3ObjectStage.TOTAL);
-    public final YammerHistogramMetric objectUploadSizeStats = S3StreamMetricsManager.buildObjectUploadSizeMetric(
-        new MetricName(S3ObjectStats.class, "ObjectUploadSize"), MetricsLevel.DEBUG);
+    public final YammerHistogramMetric objectStageUploadPartStats = S3StreamMetricsManager
+            .buildObjectStageCostMetric(MetricsLevel.DEBUG, S3ObjectStage.UPLOAD_PART);
+    public final YammerHistogramMetric objectStageReadyCloseStats = S3StreamMetricsManager
+            .buildObjectStageCostMetric(MetricsLevel.DEBUG, S3ObjectStage.READY_CLOSE);
+    public final YammerHistogramMetric objectStageTotalStats = S3StreamMetricsManager
+            .buildObjectStageCostMetric(MetricsLevel.DEBUG, S3ObjectStage.TOTAL);
+    public final YammerHistogramMetric objectUploadSizeStats = S3StreamMetricsManager.buildObjectUploadSizeMetric(MetricsLevel.DEBUG);
 
     private S3ObjectStats() {
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/S3OperationStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/S3OperationStats.java
@@ -18,7 +18,6 @@ import com.automq.stream.s3.metrics.S3StreamMetricsManager;
 import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.metrics.wrapper.CounterMetric;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
-import com.yammer.metrics.core.MetricName;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -31,36 +30,26 @@ public class S3OperationStats {
     private final Map<String, YammerHistogramMetric> putObjectSuccessStats = new ConcurrentHashMap<>();
     private final Map<String, YammerHistogramMetric> putObjectFailedStats = new ConcurrentHashMap<>();
     private final YammerHistogramMetric deleteObjectSuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.DELETE_OBJECT.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
         MetricsLevel.INFO, S3Operation.DELETE_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
     private final YammerHistogramMetric deleteObjectFailedStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.DELETE_OBJECT.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
         MetricsLevel.INFO, S3Operation.DELETE_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
     private final YammerHistogramMetric deleteObjectsSuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.DELETE_OBJECTS.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
         MetricsLevel.INFO, S3Operation.DELETE_OBJECTS, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
     private final YammerHistogramMetric deleteObjectsFailedStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.DELETE_OBJECTS.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
         MetricsLevel.INFO, S3Operation.DELETE_OBJECTS, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
     private final YammerHistogramMetric createMultiPartUploadSuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.CREATE_MULTI_PART_UPLOAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
         MetricsLevel.INFO, S3Operation.CREATE_MULTI_PART_UPLOAD, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
     private final YammerHistogramMetric createMultiPartUploadFailedStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.CREATE_MULTI_PART_UPLOAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
         MetricsLevel.INFO, S3Operation.CREATE_MULTI_PART_UPLOAD, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
     private final Map<String, YammerHistogramMetric> uploadPartSuccessStats = new ConcurrentHashMap<>();
     private final Map<String, YammerHistogramMetric> uploadPartFailedStats = new ConcurrentHashMap<>();
     private final YammerHistogramMetric uploadPartCopySuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.UPLOAD_PART_COPY.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
         MetricsLevel.INFO, S3Operation.UPLOAD_PART_COPY, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
     private final YammerHistogramMetric uploadPartCopyFailedStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.UPLOAD_PART_COPY.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
         MetricsLevel.INFO, S3Operation.UPLOAD_PART_COPY, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
     private final YammerHistogramMetric completeMultiPartUploadSuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.COMPLETE_MULTI_PART_UPLOAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
         MetricsLevel.INFO, S3Operation.COMPLETE_MULTI_PART_UPLOAD, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
     private final YammerHistogramMetric completeMultiPartUploadFailedStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(S3OperationStats.class, S3Operation.COMPLETE_MULTI_PART_UPLOAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
         MetricsLevel.INFO, S3Operation.COMPLETE_MULTI_PART_UPLOAD, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
 
     private S3OperationStats() {
@@ -81,13 +70,9 @@ public class S3OperationStats {
         String label = AttributesUtils.getObjectBucketLabel(size);
         if (isSuccess) {
             return getObjectSuccessStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.GET_OBJECT.getUniqueKey()
-                    + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS + label),
                 MetricsLevel.INFO, S3Operation.GET_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS, label));
         } else {
             return getObjectFailedStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.GET_OBJECT.getUniqueKey()
-                    + S3StreamMetricsConstant.LABEL_STATUS_FAILED + label),
                 MetricsLevel.INFO, S3Operation.GET_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_FAILED, label));
         }
     }
@@ -96,13 +81,9 @@ public class S3OperationStats {
         String label = AttributesUtils.getObjectBucketLabel(size);
         if (isSuccess) {
             return putObjectSuccessStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.PUT_OBJECT.getUniqueKey()
-                    + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS + label),
                 MetricsLevel.INFO, S3Operation.PUT_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS, label));
         } else {
             return putObjectFailedStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.PUT_OBJECT.getUniqueKey() +
-                    S3StreamMetricsConstant.LABEL_STATUS_FAILED + label),
                 MetricsLevel.INFO, S3Operation.PUT_OBJECT, S3StreamMetricsConstant.LABEL_STATUS_FAILED, label));
         }
     }
@@ -111,13 +92,9 @@ public class S3OperationStats {
         String label = AttributesUtils.getObjectBucketLabel(size);
         if (isSuccess) {
             return uploadPartSuccessStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.UPLOAD_PART.getUniqueKey() +
-                    S3StreamMetricsConstant.LABEL_STATUS_SUCCESS + label),
                 MetricsLevel.INFO, S3Operation.UPLOAD_PART, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS, label));
         } else {
             return uploadPartFailedStats.computeIfAbsent(label, name -> S3StreamMetricsManager.buildOperationMetric(
-                new MetricName(S3OperationStats.class, S3Operation.UPLOAD_PART.getUniqueKey() +
-                    S3StreamMetricsConstant.LABEL_STATUS_FAILED + label),
                 MetricsLevel.INFO, S3Operation.UPLOAD_PART, S3StreamMetricsConstant.LABEL_STATUS_FAILED, label));
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
@@ -18,135 +18,100 @@ import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.metrics.operations.S3Stage;
 import com.automq.stream.s3.metrics.wrapper.CounterMetric;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
-import com.yammer.metrics.core.MetricName;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.automq.stream.s3.metrics.S3StreamMetricsConstant.GET_INDEX_TIME_METRIC_NAME;
-import static com.automq.stream.s3.metrics.S3StreamMetricsConstant.READ_BLOCK_CACHE_METRIC_NAME;
-
 public class StorageOperationStats {
     private volatile static StorageOperationStats instance = null;
 
-    public final YammerHistogramMetric appendStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.APPEND_STORAGE.getUniqueKey()), MetricsLevel.INFO, S3Operation.APPEND_STORAGE);
-    public final YammerHistogramMetric appendWALBeforeStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_BEFORE.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.APPEND_WAL_BEFORE);
-    public final YammerHistogramMetric appendWALBlockPolledStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_BLOCK_POLLED.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.APPEND_WAL_BLOCK_POLLED);
-    public final YammerHistogramMetric appendWALAwaitStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_AWAIT.getUniqueKey()), MetricsLevel.INFO, S3Stage.APPEND_WAL_AWAIT);
-    public final YammerHistogramMetric appendWALWriteStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_WRITE.getUniqueKey()), MetricsLevel.INFO, S3Stage.APPEND_WAL_WRITE);
-    public final YammerHistogramMetric appendWALAfterStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_AFTER.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.APPEND_WAL_AFTER);
-    public final YammerHistogramMetric appendWALCompleteStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.APPEND_WAL_COMPLETE.getUniqueKey()), MetricsLevel.INFO, S3Stage.APPEND_WAL_COMPLETE);
-    public final YammerHistogramMetric appendCallbackStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.APPEND_STORAGE_APPEND_CALLBACK.getUniqueKey()), MetricsLevel.DEBUG, S3Operation.APPEND_STORAGE_APPEND_CALLBACK);
-    public final YammerHistogramMetric appendWALFullStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.APPEND_STORAGE_WAL_FULL.getUniqueKey()), MetricsLevel.INFO, S3Operation.APPEND_STORAGE_WAL_FULL);
-    public final YammerHistogramMetric appendLogCacheStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.APPEND_STORAGE_LOG_CACHE.getUniqueKey()), MetricsLevel.INFO, S3Operation.APPEND_STORAGE_LOG_CACHE);
-    public final YammerHistogramMetric appendLogCacheFullStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.APPEND_STORAGE_LOG_CACHE_FULL.getUniqueKey()), MetricsLevel.INFO, S3Operation.APPEND_STORAGE_LOG_CACHE_FULL);
-    public final YammerHistogramMetric uploadWALPrepareStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.UPLOAD_WAL_PREPARE.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_PREPARE);
-    public final YammerHistogramMetric uploadWALUploadStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.UPLOAD_WAL_UPLOAD.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_UPLOAD);
-    public final YammerHistogramMetric uploadWALCommitStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.UPLOAD_WAL_COMMIT.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_COMMIT);
-    public final YammerHistogramMetric uploadWALCompleteStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.UPLOAD_WAL_COMPLETE.getUniqueKey()), MetricsLevel.INFO, S3Stage.UPLOAD_WAL_COMPLETE);
-    public final YammerHistogramMetric forceUploadWALAwaitStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.FORCE_UPLOAD_WAL_AWAIT.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_AWAIT);
-    public final YammerHistogramMetric forceUploadWALCompleteStats = S3StreamMetricsManager.buildStageOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Stage.FORCE_UPLOAD_WAL_COMPLETE.getUniqueKey()), MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_COMPLETE);
-    public final YammerHistogramMetric readStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.READ_STORAGE.getUniqueKey()), MetricsLevel.INFO, S3Operation.READ_STORAGE);
-    private final YammerHistogramMetric readLogCacheHitStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.READ_STORAGE_LOG_CACHE.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_HIT),
-        MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_HIT);
-    private final YammerHistogramMetric readLogCacheMissStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.READ_STORAGE_LOG_CACHE.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_MISS),
-        MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_MISS);
-    private final YammerHistogramMetric readBlockCacheHitStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.READ_STORAGE_BLOCK_CACHE.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_HIT),
-        MetricsLevel.INFO, S3Operation.READ_STORAGE_BLOCK_CACHE, S3StreamMetricsConstant.LABEL_STATUS_HIT);
-    private final YammerHistogramMetric readBlockCacheMissStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.READ_STORAGE_BLOCK_CACHE.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_MISS),
-        MetricsLevel.INFO, S3Operation.READ_STORAGE_BLOCK_CACHE, S3StreamMetricsConstant.LABEL_STATUS_MISS);
-    private final YammerHistogramMetric readAheadSyncTimeStats = S3StreamMetricsManager.buildOperationMetric(
-            new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SYNC),
-            MetricsLevel.INFO, S3Operation.BLOCK_CACHE_READ_AHEAD, S3StreamMetricsConstant.LABEL_STATUS_SYNC);
-    private final YammerHistogramMetric readAheadAsyncTimeStats = S3StreamMetricsManager.buildOperationMetric(
-            new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_ASYNC),
-            MetricsLevel.INFO, S3Operation.BLOCK_CACHE_READ_AHEAD, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
-    public final YammerHistogramMetric readAheadGetIndicesTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
-        new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES),
-        MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES);
-    public final YammerHistogramMetric readAheadThrottleTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
-            new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_THROTTLE),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_THROTTLE);
-    public final YammerHistogramMetric readAheadReadS3TimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
-            new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_READ_S3),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
-    public final YammerHistogramMetric readAheadPutBlockCacheTimeStats = S3StreamMetricsManager.buildReadAheadStageTimeMetric(
-            new MetricName(StorageOperationStats.class, S3Operation.BLOCK_CACHE_READ_AHEAD.getUniqueKey() + S3StreamMetricsConstant.LABEL_STAGE_PUT_BLOCK_CACHE),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_PUT_BLOCK_CACHE);
+    public final YammerHistogramMetric appendStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STORAGE);
+    public final YammerHistogramMetric appendWALBeforeStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.APPEND_WAL_BEFORE);
+    public final YammerHistogramMetric appendWALBlockPolledStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.APPEND_WAL_BLOCK_POLLED);
+    public final YammerHistogramMetric appendWALAwaitStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.APPEND_WAL_AWAIT);
+    public final YammerHistogramMetric appendWALWriteStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.APPEND_WAL_WRITE);
+    public final YammerHistogramMetric appendWALAfterStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.APPEND_WAL_AFTER);
+    public final YammerHistogramMetric appendWALCompleteStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.APPEND_WAL_COMPLETE);
+    public final YammerHistogramMetric appendCallbackStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.DEBUG, S3Operation.APPEND_STORAGE_APPEND_CALLBACK);
+    public final YammerHistogramMetric appendWALFullStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STORAGE_WAL_FULL);
+    public final YammerHistogramMetric appendLogCacheStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STORAGE_LOG_CACHE);
+    public final YammerHistogramMetric appendLogCacheFullStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STORAGE_LOG_CACHE_FULL);
+    public final YammerHistogramMetric uploadWALPrepareStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_PREPARE);
+    public final YammerHistogramMetric uploadWALUploadStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_UPLOAD);
+    public final YammerHistogramMetric uploadWALCommitStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_COMMIT);
+    public final YammerHistogramMetric uploadWALCompleteStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.UPLOAD_WAL_COMPLETE);
+    public final YammerHistogramMetric forceUploadWALAwaitStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_AWAIT);
+    public final YammerHistogramMetric forceUploadWALCompleteStats = S3StreamMetricsManager
+            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_COMPLETE);
+    public final YammerHistogramMetric readStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE);
+    private final YammerHistogramMetric readLogCacheHitStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_HIT);
+    private final YammerHistogramMetric readLogCacheMissStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_MISS);
+    private final YammerHistogramMetric readBlockCacheHitStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE_BLOCK_CACHE, S3StreamMetricsConstant.LABEL_STATUS_HIT);
+    private final YammerHistogramMetric readBlockCacheMissStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE_BLOCK_CACHE, S3StreamMetricsConstant.LABEL_STATUS_MISS);
+    private final YammerHistogramMetric readAheadSyncTimeStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.BLOCK_CACHE_READ_AHEAD, S3StreamMetricsConstant.LABEL_STATUS_SYNC);
+    private final YammerHistogramMetric readAheadAsyncTimeStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.BLOCK_CACHE_READ_AHEAD, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
+    public final YammerHistogramMetric readAheadGetIndicesTimeStats = S3StreamMetricsManager
+            .buildReadAheadStageTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_INDICES);
+    public final YammerHistogramMetric readAheadThrottleTimeStats = S3StreamMetricsManager
+            .buildReadAheadStageTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_THROTTLE);
+    public final YammerHistogramMetric readAheadReadS3TimeStats = S3StreamMetricsManager
+            .buildReadAheadStageTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
+    public final YammerHistogramMetric readAheadPutBlockCacheTimeStats = S3StreamMetricsManager
+            .buildReadAheadStageTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_PUT_BLOCK_CACHE);
 
-    public final YammerHistogramMetric getIndicesTimeGetObjectStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
-                new MetricName(StorageOperationStats.class, GET_INDEX_TIME_METRIC_NAME + S3StreamMetricsConstant.LABEL_STAGE_GET_OBJECTS),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_OBJECTS);
-    public final YammerHistogramMetric getIndicesTimeFindIndexStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
-            new MetricName(StorageOperationStats.class, GET_INDEX_TIME_METRIC_NAME + S3StreamMetricsConstant.LABEL_STAGE_FIND_INDEX),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_FIND_INDEX);
-    public final YammerHistogramMetric getIndicesTimeComputeStats = S3StreamMetricsManager.buildGetIndexTimeMetric(
-            new MetricName(StorageOperationStats.class, GET_INDEX_TIME_METRIC_NAME + S3StreamMetricsConstant.LABEL_STAGE_COMPUTE),
-            MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_COMPUTE);
+    public final YammerHistogramMetric getIndicesTimeGetObjectStats = S3StreamMetricsManager
+            .buildGetIndexTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_GET_OBJECTS);
+    public final YammerHistogramMetric getIndicesTimeFindIndexStats = S3StreamMetricsManager
+            .buildGetIndexTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_FIND_INDEX);
+    public final YammerHistogramMetric getIndicesTimeComputeStats = S3StreamMetricsManager
+            .buildGetIndexTimeMetric(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STAGE_COMPUTE);
 
     private final Map<Integer, YammerHistogramMetric> readS3LimiterStatsMap = new ConcurrentHashMap<>();
     private final Map<Integer, YammerHistogramMetric> writeS3LimiterStatsMap = new ConcurrentHashMap<>();
-    public final YammerHistogramMetric readAheadSyncSizeStats = S3StreamMetricsManager.buildReadAheadSizeMetric(
-        new MetricName(StorageOperationStats.class, "ReadAheadSize-" + S3StreamMetricsConstant.LABEL_STATUS_SYNC),
-            MetricsLevel.INFO, S3StreamMetricsConstant.LABEL_STATUS_SYNC);
-    public final YammerHistogramMetric readAheadAsyncSizeStats = S3StreamMetricsManager.buildReadAheadSizeMetric(
-            new MetricName(StorageOperationStats.class, "ReadAheadSize-" + S3StreamMetricsConstant.LABEL_STATUS_ASYNC),
-            MetricsLevel.INFO, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
+    public final YammerHistogramMetric readAheadSyncSizeStats = S3StreamMetricsManager
+            .buildReadAheadSizeMetric(MetricsLevel.INFO, S3StreamMetricsConstant.LABEL_STATUS_SYNC);
+    public final YammerHistogramMetric readAheadAsyncSizeStats = S3StreamMetricsManager
+            .buildReadAheadSizeMetric(MetricsLevel.INFO, S3StreamMetricsConstant.LABEL_STATUS_ASYNC);
 
-    public final YammerHistogramMetric readBlockCacheStageMissWaitInflightTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_MISS
-            + S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
-            S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
-    public final YammerHistogramMetric readBlockCacheStageMissReadCacheTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_MISS
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
-    public final YammerHistogramMetric readBlockCacheStageMissReadAheadTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_MISS
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
-    public final YammerHistogramMetric readBlockCacheStageMissReadS3TimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_MISS
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_S3), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
-    public final YammerHistogramMetric readBlockCacheStageHitWaitInflightTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_HIT
-                    + S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
-            S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
-    public final YammerHistogramMetric readBlockCacheStageHitReadCacheTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_HIT
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
-    public final YammerHistogramMetric readBlockCacheStageHitReadAheadTimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_HIT
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
-    public final YammerHistogramMetric readBlockCacheStageHitReadS3TimeStats = S3StreamMetricsManager.buildReadBlockCacheStageTime(
-            new MetricName(StorageOperationStats.class, READ_BLOCK_CACHE_METRIC_NAME + S3StreamMetricsConstant.LABEL_STATUS_HIT
-                    + S3StreamMetricsConstant.LABEL_STAGE_READ_S3), MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT,
-            S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
+    public final YammerHistogramMetric readBlockCacheStageMissWaitInflightTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS, S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
+    public final YammerHistogramMetric readBlockCacheStageMissReadCacheTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS, S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
+    public final YammerHistogramMetric readBlockCacheStageMissReadAheadTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS, S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
+    public final YammerHistogramMetric readBlockCacheStageMissReadS3TimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_MISS, S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
+    public final YammerHistogramMetric readBlockCacheStageHitWaitInflightTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT, S3StreamMetricsConstant.LABEL_STAGE_WAIT_INFLIGHT);
+    public final YammerHistogramMetric readBlockCacheStageHitReadCacheTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT, S3StreamMetricsConstant.LABEL_STAGE_READ_CACHE);
+    public final YammerHistogramMetric readBlockCacheStageHitReadAheadTimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT, S3StreamMetricsConstant.LABEL_STAGE_READ_AHEAD);
+    public final YammerHistogramMetric readBlockCacheStageHitReadS3TimeStats = S3StreamMetricsManager
+            .buildReadBlockCacheStageTime(MetricsLevel.DEBUG, S3StreamMetricsConstant.LABEL_STATUS_HIT, S3StreamMetricsConstant.LABEL_STAGE_READ_S3);
 
     public final CounterMetric blockCacheReadS3Throughput = S3StreamMetricsManager.buildBlockCacheOpsThroughputMetric("read_s3");
     public final CounterMetric blockCacheBlockHitThroughput = S3StreamMetricsManager.buildBlockCacheOpsThroughputMetric("block_hit");
@@ -181,13 +146,11 @@ public class StorageOperationStats {
     }
 
     public YammerHistogramMetric readS3LimiterStats(int index) {
-        return this.readS3LimiterStatsMap.computeIfAbsent(index, k -> S3StreamMetricsManager.buildReadS3LimiterTimeMetric(
-                new MetricName(StorageOperationStats.class, "ReadS3Limiter-" + index), MetricsLevel.DEBUG, index));
+        return this.readS3LimiterStatsMap.computeIfAbsent(index, k -> S3StreamMetricsManager.buildReadS3LimiterTimeMetric(MetricsLevel.DEBUG, index));
     }
 
     public YammerHistogramMetric writeS3LimiterStats(int index) {
-        return this.writeS3LimiterStatsMap.computeIfAbsent(index, k -> S3StreamMetricsManager.buildWriteS3LimiterTimeMetric(
-                new MetricName(StorageOperationStats.class, "WriteS3Limiter-" + index), MetricsLevel.DEBUG, index));
+        return this.writeS3LimiterStatsMap.computeIfAbsent(index, k -> S3StreamMetricsManager.buildWriteS3LimiterTimeMetric(MetricsLevel.DEBUG, index));
     }
 
     public YammerHistogramMetric readAheadSizeStats(boolean isSync) {

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StreamOperationStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StreamOperationStats.java
@@ -16,26 +16,23 @@ import com.automq.stream.s3.metrics.S3StreamMetricsConstant;
 import com.automq.stream.s3.metrics.S3StreamMetricsManager;
 import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.metrics.wrapper.YammerHistogramMetric;
-import com.yammer.metrics.core.MetricName;
 
 public class StreamOperationStats {
     private volatile static StreamOperationStats instance = null;
-    public final YammerHistogramMetric createStreamStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.CREATE_STREAM.getUniqueKey()), MetricsLevel.INFO, S3Operation.CREATE_STREAM);
-    public final YammerHistogramMetric openStreamStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.OPEN_STREAM.getUniqueKey()), MetricsLevel.INFO, S3Operation.OPEN_STREAM);
-    public final YammerHistogramMetric appendStreamStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.APPEND_STREAM.getUniqueKey()), MetricsLevel.INFO, S3Operation.APPEND_STREAM);
-    public final YammerHistogramMetric fetchStreamStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.FETCH_STREAM.getUniqueKey()), MetricsLevel.INFO, S3Operation.FETCH_STREAM);
-    public final YammerHistogramMetric trimStreamStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.TRIM_STREAM.getUniqueKey()), MetricsLevel.INFO, S3Operation.TRIM_STREAM);
-    private final YammerHistogramMetric closeStreamSuccessStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.CLOSE_STREAM.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_SUCCESS),
-        MetricsLevel.INFO, S3Operation.CLOSE_STREAM, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
-    private final YammerHistogramMetric closeStreamFailStats = S3StreamMetricsManager.buildOperationMetric(
-        new MetricName(StreamOperationStats.class, S3Operation.CLOSE_STREAM.getUniqueKey() + S3StreamMetricsConstant.LABEL_STATUS_FAILED),
-        MetricsLevel.INFO, S3Operation.CLOSE_STREAM, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
+    public final YammerHistogramMetric createStreamStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.CREATE_STREAM);
+    public final YammerHistogramMetric openStreamStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.OPEN_STREAM);
+    public final YammerHistogramMetric appendStreamStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STREAM);
+    public final YammerHistogramMetric fetchStreamStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.FETCH_STREAM);
+    public final YammerHistogramMetric trimStreamStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.TRIM_STREAM);
+    private final YammerHistogramMetric closeStreamSuccessStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.CLOSE_STREAM, S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
+    private final YammerHistogramMetric closeStreamFailStats = S3StreamMetricsManager
+            .buildOperationMetric(MetricsLevel.INFO, S3Operation.CLOSE_STREAM, S3StreamMetricsConstant.LABEL_STATUS_FAILED);
 
     private StreamOperationStats() {
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/DeltaHistogram.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/DeltaHistogram.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.metrics.wrapper;
+
+import com.yammer.metrics.stats.ExponentiallyDecayingSample;
+import com.yammer.metrics.stats.Sample;
+import com.yammer.metrics.stats.Snapshot;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiPredicate;
+
+public class DeltaHistogram {
+    private static final Long DEFAULT_SNAPSHOT_INTERVAL_MS = 5000L;
+    private final AtomicLong cumulativeCount = new AtomicLong(0L);
+    private final AtomicLong cumulativeSum = new AtomicLong(0L);
+    private final AtomicLong min = new AtomicLong(Long.MAX_VALUE);
+    private final AtomicLong max = new AtomicLong(Long.MIN_VALUE);
+    private final Sample sample = new ExponentiallyDecayingSample(1028, 0.015D);
+    private volatile long snapshotInterval;
+    private Snapshot lastSnapshot;
+    private long lastSnapshotTime;
+
+    public DeltaHistogram() {
+        this(DEFAULT_SNAPSHOT_INTERVAL_MS);
+    }
+
+    public DeltaHistogram(long snapshotInterval) {
+        this.snapshotInterval = snapshotInterval;
+    }
+
+    public void setSnapshotInterval(long snapshotInterval) {
+        this.snapshotInterval = snapshotInterval;
+    }
+
+    long getSnapshotInterval() {
+        return snapshotInterval;
+    }
+
+    public long min() {
+        return min.get();
+    }
+
+    public long max() {
+        return max.get();
+    }
+
+    private void updateMax(long value) {
+        update(value, max, (curr, candidate) -> candidate > curr);
+    }
+
+    private void updateMin(long value) {
+        update(value, min, (curr, candidate) -> candidate < curr);
+    }
+
+    private void update(long candidate, AtomicLong target, BiPredicate<Long, Long> predicate) {
+        long curr;
+        do {
+            curr = target.get();
+        } while (predicate.test(curr, candidate) && !target.compareAndSet(curr, candidate));
+    }
+
+    public void record(long value) {
+        cumulativeCount.incrementAndGet();
+        cumulativeSum.addAndGet(value);
+        sample.update(value);
+        updateMax(value);
+        updateMin(value);
+    }
+
+    public long count() {
+        return cumulativeCount.get();
+    }
+
+    public long sum() {
+        return cumulativeSum.get();
+    }
+
+    public double p99() {
+        snapshotAndReset();
+        return lastSnapshot.get99thPercentile();
+    }
+
+    public double p50() {
+        snapshotAndReset();
+        return lastSnapshot.getMedian();
+    }
+
+    private void snapshotAndReset() {
+        synchronized (this) {
+            if (lastSnapshot == null || System.currentTimeMillis() - lastSnapshotTime > snapshotInterval) {
+                lastSnapshot = sample.getSnapshot();
+                lastSnapshotTime = System.currentTimeMillis();
+                sample.clear();
+            }
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramInstrument.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramInstrument.java
@@ -29,7 +29,6 @@ public class HistogramInstrument {
     private final ObservableLongGauge sum;
     private final ObservableDoubleGauge histP50Value;
     private final ObservableDoubleGauge histP99Value;
-    private final ObservableDoubleGauge histMeanValue;
     private final ObservableDoubleGauge histMaxValue;
 
     public HistogramInstrument(Meter meter, String name, String desc, String unit, Supplier<List<YammerHistogramMetric>> histogramsSupplier) {
@@ -75,17 +74,6 @@ public class HistogramInstrument {
                 histograms.forEach(histogram -> {
                     if (histogram.shouldRecord()) {
                         result.record(histogram.p99(), histogram.attributes);
-                    }
-                });
-            });
-        this.histMeanValue = meter.gaugeBuilder(name + S3StreamMetricsConstant.MEAN_METRIC_NAME_SUFFIX)
-            .setDescription(desc + " (mean)")
-            .setUnit(unit)
-            .buildWithCallback(result -> {
-                List<YammerHistogramMetric> histograms = histogramsSupplier.get();
-                histograms.forEach(histogram -> {
-                    if (histogram.shouldRecord()) {
-                        result.record(histogram.mean(), histogram.attributes);
                     }
                 });
             });


### PR DESCRIPTION
1. introduced DeltaHistogram to record distribution of values, sample sequence will be reset based on reporting interval
2. removed mean metrics for histogram type metrics, from now on mean metrics should be derived from sum and count
