### PR TITLE
feat(issue1179): accelerate partition reassignments on load balancing

### DIFF
--- a/core/src/main/java/kafka/autobalancer/config/AutoBalancerControllerConfig.java
+++ b/core/src/main/java/kafka/autobalancer/config/AutoBalancerControllerConfig.java
@@ -41,8 +41,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION = PREFIX + "network.in.distribution.detect.avg.deviation";
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD = PREFIX + "network.out.usage.distribution.detect.threshold";
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION = PREFIX + "network.out.distribution.detect.avg.deviation";
+    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY = PREFIX + "execution.concurrency";
     public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS = PREFIX + "execution.interval.ms";
-    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS = PREFIX + "execution.steps";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS = PREFIX + "exclude.broker.ids";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS = PREFIX + "exclude.topics";
     /* Default values */
@@ -61,8 +61,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
     public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.2;
     public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD = 1024 * 1024;
     public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.2;
-    public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS = 1000;
-    public static final int DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS = 60;
+    public static final int DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY = 50;
+    public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS = 5000;
     public static final String DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS = "";
     public static final String DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS = "";
     /* Documents */
@@ -82,8 +82,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION_DOC = "The acceptable range of deviation for average network input bandwidth usage. Default is 0.2, which means the expected network traffic range will be [0.8 * loadAvg, 1.2 * loadAvg]";
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD_DOC = "The detection threshold of NetworkOutUsageDistributionGoal. If a broker's outbound network bandwidth usage is below this configured value, the broker will not be proactively scheduled for rebalancing.";
     public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION_DOC = "The acceptable range of deviation for average network out bandwidth usage. Default is 0.2, which means the expected network traffic range will be [0.8 * loadAvg, 1.2 * loadAvg]";
-    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS_DOC = "Time interval between reassignments per broker in milliseconds";
-    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS_DOC = "The max number of reassignments per broker in one execution";
+    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY_DOC = "The maximum number of actions that can be executed in a single batch per broker, including partition closing and openning";
+    public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS_DOC = "Time interval between each action batch in milliseconds";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS_DOC = "Broker ids that auto balancer will ignore during balancing";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS_DOC = "Topics that auto balancer will ignore during balancing";
 
@@ -96,8 +96,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION,
+            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS,
-            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS
     );
@@ -149,9 +149,9 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
                 .define(AUTO_BALANCER_CONTROLLER_ANOMALY_DETECT_INTERVAL_MS, ConfigDef.Type.LONG,
                         DEFAULT_AUTO_BALANCER_CONTROLLER_ANOMALY_DETECT_INTERVAL_MS, ConfigDef.Importance.HIGH,
                         AUTO_BALANCER_CONTROLLER_ANOMALY_DETECT_INTERVAL_MS_DOC)
-                .define(AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS, ConfigDef.Type.INT,
-                        DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS, ConfigDef.Importance.HIGH,
-                        AUTO_BALANCER_CONTROLLER_EXECUTION_STEPS_DOC)
+                .define(AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY, ConfigDef.Type.INT,
+                        DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY, ConfigDef.Importance.HIGH,
+                        AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY_DOC)
                 .define(AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS, ConfigDef.Type.LIST,
                         DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS, ConfigDef.Importance.HIGH,
                         AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS_DOC)

--- a/core/src/main/java/kafka/autobalancer/detector/AnomalyDetectorBuilder.java
+++ b/core/src/main/java/kafka/autobalancer/detector/AnomalyDetectorBuilder.java
@@ -29,10 +29,10 @@ public class AnomalyDetectorBuilder {
     private LogContext logContext = null;
     private ClusterModel clusterModel = null;
     private ActionExecutorService executor = null;
-    private int maxActionsNumPerDetect = Integer.MAX_VALUE;
     private long detectIntervalMs = 60000;
     private long maxTolerateMetricsDelayMs = 30000;
-    private long coolDownIntervalPerActionMs = 100;
+    private int executionConcurrency = 50;
+    private long executionIntervalMs = 5000;
 
     public AnomalyDetectorBuilder() {
 
@@ -83,11 +83,6 @@ public class AnomalyDetectorBuilder {
         return this;
     }
 
-    public AnomalyDetectorBuilder maxActionsNumPerExecution(int maxActionsNumPerExecution) {
-        this.maxActionsNumPerDetect = maxActionsNumPerExecution;
-        return this;
-    }
-
     public AnomalyDetectorBuilder detectIntervalMs(long detectIntervalMs) {
         this.detectIntervalMs = detectIntervalMs;
         return this;
@@ -98,8 +93,13 @@ public class AnomalyDetectorBuilder {
         return this;
     }
 
-    public AnomalyDetectorBuilder coolDownIntervalPerActionMs(long coolDownIntervalPerActionMs) {
-        this.coolDownIntervalPerActionMs = coolDownIntervalPerActionMs;
+    public AnomalyDetectorBuilder executionConcurrency(int executionConcurrency) {
+        this.executionConcurrency = executionConcurrency;
+        return this;
+    }
+
+    public AnomalyDetectorBuilder executionIntervalMs(long executionIntervalMs) {
+        this.executionIntervalMs = executionIntervalMs;
         return this;
     }
 
@@ -116,7 +116,7 @@ public class AnomalyDetectorBuilder {
         if (goalsByPriority.isEmpty()) {
             throw new IllegalArgumentException("At least one goal must be set");
         }
-        return new AnomalyDetector(logContext, maxActionsNumPerDetect, detectIntervalMs, maxTolerateMetricsDelayMs,
-                coolDownIntervalPerActionMs, clusterModel, executor, goalsByPriority, excludedBrokers, excludedTopics);
+        return new AnomalyDetector(logContext, detectIntervalMs, maxTolerateMetricsDelayMs, executionConcurrency,
+                executionIntervalMs, clusterModel, executor, goalsByPriority, excludedBrokers, excludedTopics);
     }
 }

--- a/core/src/main/java/kafka/autobalancer/executor/ActionExecutorService.java
+++ b/core/src/main/java/kafka/autobalancer/executor/ActionExecutorService.java
@@ -12,10 +12,9 @@
 package kafka.autobalancer.executor;
 
 import kafka.autobalancer.common.Action;
-import org.apache.kafka.common.config.ConfigException;
 
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public interface ActionExecutorService {
 
@@ -23,11 +22,5 @@ public interface ActionExecutorService {
 
     void shutdown();
 
-    void execute(Action action);
-
-    void execute(List<Action> actions);
-
-    void validateReconfiguration(Map<String, Object> configs) throws ConfigException;
-
-    void reconfigure(Map<String, Object> configs);
+    CompletableFuture<Void> execute(List<Action> actions);
 }


### PR DESCRIPTION
## Current implementation
a fixed interval between each execution of actions

## Optimized procedure
1. actions will be grouped into batches, actions within the same batch will be submitted to controller at once.
2. batching rules:
  1. number of partitions from same topic in a batch exceeds half of the total partition number of that topic
  2. number of partition closing/openning operation of a broker in a batch exceeds the max execution concurrency (50 by default)
3. wait for a fixed interval before executing the next action batch 