### PR TITLE
fix(core): fix leader fast ABA reassign cause epoch outdated

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2657,6 +2657,7 @@ class ReplicaManager(val config: KafkaConfig,
           throw new IllegalStateException(s"Topic $tp exists, but its ID is " +
             s"${partition.topicId.get}, not $topicId as expected")
         }
+        createHook.accept(partition)
         Some(partition, false)
 
       case HostedPartition.None =>


### PR DESCRIPTION
main branch already fix this in https://github.com/AutoMQ/automq/pull/1180