### PR TITLE
feat(issue668): disable swap action temporarily

### DIFF
--- a/core/src/main/java/kafka/autobalancer/goals/AbstractResourceDistributionGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractResourceDistributionGoal.java
@@ -46,9 +46,9 @@ public abstract class AbstractResourceDistributionGoal extends AbstractResourceG
                     eligibleBrokers.stream().filter(b -> b.getBrokerId() != broker.getBrokerId()).collect(Collectors.toList());
             if (requireLessLoad(broker)) {
                 List<Action> brokerActions = tryReduceLoadByAction(ActionType.MOVE, cluster, broker, candidateBrokers, goalsByPriority);
-                if (!isBrokerAcceptable(broker)) {
-                    brokerActions.addAll(tryReduceLoadByAction(ActionType.SWAP, cluster, broker, candidateBrokers, goalsByPriority));
-                }
+//                if (!isBrokerAcceptable(broker)) {
+//                    brokerActions.addAll(tryReduceLoadByAction(ActionType.SWAP, cluster, broker, candidateBrokers, goalsByPriority));
+//                }
                 actions.addAll(brokerActions);
             } else if (requireMoreLoad(broker)) {
                 if (broker.isSlowBroker()) {
@@ -56,9 +56,9 @@ public abstract class AbstractResourceDistributionGoal extends AbstractResourceG
                     continue;
                 }
                 List<Action> brokerActions = tryIncreaseLoadByAction(ActionType.MOVE, cluster, broker, candidateBrokers, goalsByPriority);
-                if (!isBrokerAcceptable(broker)) {
-                    brokerActions.addAll(tryIncreaseLoadByAction(ActionType.SWAP, cluster, broker, candidateBrokers, goalsByPriority));
-                }
+//                if (!isBrokerAcceptable(broker)) {
+//                    brokerActions.addAll(tryIncreaseLoadByAction(ActionType.SWAP, cluster, broker, candidateBrokers, goalsByPriority));
+//                }
                 actions.addAll(brokerActions);
             }
 

--- a/core/src/main/java/kafka/autobalancer/goals/AbstractResourceGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractResourceGoal.java
@@ -84,7 +84,7 @@ public abstract class AbstractResourceGoal extends AbstractGoal {
                 optionalAction = tryMovePartitionOut(cluster, tp, srcBroker, candidateBrokers, goalsByPriority);
             } else {
                 optionalAction = trySwapPartitionOut(cluster, tp, srcBroker, candidateBrokers, goalsByPriority,
-                        (src, candidate) -> src.load(resource()) > candidate.load(resource()));
+                        Comparator.comparingDouble(p -> p.load(resource())), (src, candidate) -> src.load(resource()) > candidate.load(resource()));
             }
 
             if (optionalAction.isPresent()) {
@@ -129,7 +129,7 @@ public abstract class AbstractResourceGoal extends AbstractGoal {
                     optionalAction = tryMovePartitionOut(cluster, tp, candidateBroker, List.of(srcBroker), goalsByPriority);
                 } else {
                     optionalAction = trySwapPartitionOut(cluster, tp, candidateBroker, List.of(srcBroker), goalsByPriority,
-                            (src, candidate) -> src.load(resource()) > candidate.load(resource()));
+                            Comparator.comparingDouble(p -> p.load(resource())), (src, candidate) -> src.load(resource()) > candidate.load(resource()));
                 }
 
                 if (optionalAction.isPresent()) {

--- a/core/src/test/java/kafka/autobalancer/goals/AbstractResourceUsageDistributionGoalTest.java
+++ b/core/src/test/java/kafka/autobalancer/goals/AbstractResourceUsageDistributionGoalTest.java
@@ -28,6 +28,7 @@ import kafka.server.KafkaConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -364,6 +365,7 @@ public class AbstractResourceUsageDistributionGoalTest extends GoalTestBase {
     }
 
     @Test
+    @Disabled
     public void testMultiGoalOptimizeWithOneToOneReplicaSwap() {
         testMultiGoalOptimizeWithOneToOneReplicaSwap(Resource.NW_IN);
         testMultiGoalOptimizeWithOneToOneReplicaSwap(Resource.NW_OUT);


### PR DESCRIPTION
This is part of #668
Swap action is rarely effective for load balancing in most cases, and the time cost to derive a valid swap action grows exponentially with the number of overall partitions, so it's better to disable it until we find a better way to solve this issue.