### PR TITLE
fix(s3stream): avoid starting wal twice during failover

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -263,6 +263,10 @@ public class BlockWALService implements WriteAheadLog {
 
     @Override
     public WriteAheadLog start() throws IOException {
+        if (started.get()) {
+            LOGGER.warn("block WAL service already started");
+            return this;
+        }
         StopWatch stopWatch = StopWatch.createStarted();
 
         walChannel.open(channel -> Optional.ofNullable(tryReadWALHeader(walChannel))

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -381,6 +381,7 @@ public class BlockWALService implements WriteAheadLog {
 
     @Override
     public WALMetadata metadata() {
+        checkStarted();
         return new WALMetadata(walHeader.getNodeId(), walHeader.getEpoch());
     }
 


### PR DESCRIPTION
`WriteAheadLog#start()` is called twice during failover in:
- `Failover#FailoverTask#failover()`
- `S3Storage#recover(WALMetadata, StreamManager, ObjectManager, Logger)`