### PR TITLE
chore(s3stream): add `toString` methods to fix logs

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/streams/ControllerStreamManager.java
+++ b/core/src/main/scala/kafka/log/stream/s3/streams/ControllerStreamManager.java
@@ -94,6 +94,11 @@ public class ControllerStreamManager implements StreamManager {
             public Builder toRequestBuilder() {
                 return new GetOpeningStreamsRequest.Builder(request);
             }
+
+            @Override
+            public String toString() {
+                return request.toString();
+            }
         };
 
         CompletableFuture<List<StreamMetadata>> future = new CompletableFuture<>();

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
@@ -530,6 +530,17 @@ import static com.automq.stream.utils.FutureUtil.exec;
                 data.markRead();
             }
         }
+
+        @Override
+        public String toString() {
+            return "Block{" +
+                "metadata=" + metadata +
+                ", index=" + index +
+                ", data=" + data +
+                ", exception=" + exception +
+                ", released=" + released +
+                '}';
+        }
     }
 
     class Readahead {


### PR DESCRIPTION
The same as #1380 