### PR TITLE
perf(s3stream): reduce lock granularity in `StreamMetadataManager`

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/image/S3StreamsMetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/S3StreamsMetadataImageTest.java
@@ -362,7 +362,7 @@ public class S3StreamsMetadataImageTest {
                         long start = r.nextLong(startOffset, endOffset);
                         long end = r.nextLong(start, endOffset);
 
-                        streamsImage.getObjects(STREAM0, start, end, r.nextInt(3,17));
+                        streamsImage.getObjects(STREAM0, start, end, r.nextInt(3, 17));
                     } catch (Exception e) {
                         hasException.set(true);
                     }

--- a/metadata/src/test/java/org/apache/kafka/image/S3StreamsMetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/S3StreamsMetadataImageTest.java
@@ -398,7 +398,7 @@ public class S3StreamsMetadataImageTest {
 
         assertFalse(hasException.get());
 
-        result.entrySet().forEach((entry) -> {
+        result.entrySet().forEach(entry -> {
             Item item = entry.getKey();
             InRangeObjects objects = entry.getValue();
             assertEquals(streamsImage.getObjects(STREAM0, item.start, item.end, item.limit), objects);


### PR DESCRIPTION
1. use volatile field to store MetadataImage avoid acquire lock when kraft metadata update
2. when access metadata store MetadataImage to local field without hold locks.
3. for the index structure in MetadataImage use lock to trigger index build and after build success the access is volatile access.
4. avoid get list.size() in for iter.

##### test
1. add concurrent access metadata test to check the access is right.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
