### PR TITLE
feat(s3stream): add aws s3 rangeRead implementation for object storage

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator;
+
+import com.automq.stream.s3.metadata.ObjectUtils;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
+import com.automq.stream.s3.metrics.S3StreamMetricsManager;
+import com.automq.stream.s3.metrics.TimerUtil;
+import com.automq.stream.s3.metrics.stats.NetworkStats;
+import com.automq.stream.s3.metrics.stats.S3OperationStats;
+import com.automq.stream.s3.metrics.stats.StorageOperationStats;
+import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
+import com.automq.stream.utils.FutureUtil;
+import com.automq.stream.utils.ThreadUtils;
+import com.automq.stream.utils.Threads;
+import com.automq.stream.utils.Utils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.model.Tagging;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static com.automq.stream.s3.metadata.ObjectUtils.tagging;
+
+public abstract class AbstractObjectStorage implements ObjectStorage {
+    static final Logger LOGGER = LoggerFactory.getLogger(AbstractObjectStorage.class);
+    private static final AtomicInteger INDEX = new AtomicInteger(-1);
+    private static final int DEFAULT_CONCURRENCY_PER_CORE = 25;
+    private static final int MIN_CONCURRENCY = 50;
+    private static final int MAX_CONCURRENCY = 1000;
+    private final float maxMergeReadSparsityRate;
+    private final int currentIndex;
+    final String bucket;
+    final Tagging tagging;
+    private final Semaphore inflightReadLimiter;
+    private final Semaphore inflightWriteLimiter;
+    private final List<AbstractObjectStorage.ReadTask> waitingReadTasks = new LinkedList<>();
+    private final AsyncNetworkBandwidthLimiter networkInboundBandwidthLimiter;
+    private final AsyncNetworkBandwidthLimiter networkOutboundBandwidthLimiter;
+    private final ExecutorService readLimiterCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(1,
+        "s3-read-limiter-cb-executor", true, LOGGER);
+    private final ExecutorService readCallbackExecutor = Threads.newFixedThreadPoolWithMonitor(8,
+        "s3-read-cb-executor", true, LOGGER);
+    private final HashedWheelTimer timeoutDetect = new HashedWheelTimer(
+        ThreadUtils.createThreadFactory("s3-timeout-detect", true), 1, TimeUnit.SECONDS, 100);
+    final ScheduledExecutorService scheduler = Threads.newSingleThreadScheduledExecutor(
+        ThreadUtils.createThreadFactory("objectStorage", true), LOGGER);
+    boolean checkS3ApiMode = false;
+
+    public AbstractObjectStorage(String bucket, Map<String, String> tagging,
+        AsyncNetworkBandwidthLimiter networkInboundBandwidthLimiter,
+        AsyncNetworkBandwidthLimiter networkOutboundBandwidthLimiter,
+        boolean readWriteIsolate,
+        boolean checkS3ApiMode) {
+        this.bucket = bucket;
+        this.tagging = tagging(tagging);
+        this.currentIndex = INDEX.incrementAndGet();
+        this.maxMergeReadSparsityRate = Utils.getMaxMergeReadSparsityRate();
+        int maxObjectStorageConcurrency = getMaxObjectStorageConcurrency();
+        this.inflightWriteLimiter = new Semaphore(maxObjectStorageConcurrency);
+        this.inflightReadLimiter = readWriteIsolate ? new Semaphore(maxObjectStorageConcurrency) : inflightWriteLimiter;
+        this.networkInboundBandwidthLimiter = networkInboundBandwidthLimiter;
+        this.networkOutboundBandwidthLimiter = networkOutboundBandwidthLimiter;
+        this.checkS3ApiMode = checkS3ApiMode;
+        scheduler.scheduleWithFixedDelay(this::tryMergeRead, 1, 1, TimeUnit.MILLISECONDS);
+        checkConfig();
+        S3StreamMetricsManager.registerInflightS3ReadQuotaSupplier(inflightReadLimiter::availablePermits, currentIndex);
+        S3StreamMetricsManager.registerInflightS3WriteQuotaSupplier(inflightWriteLimiter::availablePermits, currentIndex);
+    }
+
+    @Override
+    public Writer writer(WriteOptions options, String objectPath) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<ByteBuf> rangeRead(ReadOptions options, S3ObjectMetadata objectMetadata, long start, long end) {
+        CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
+        if (start > end) {
+            IllegalArgumentException ex = new IllegalArgumentException();
+            LOGGER.error("[UNEXPECTED] rangeRead [{}, {})", start, end, ex);
+            cf.completeExceptionally(ex);
+            return cf;
+        } else if (start == end) {
+            cf.complete(Unpooled.EMPTY_BUFFER);
+            return cf;
+        }
+
+        if (networkInboundBandwidthLimiter != null) {
+            TimerUtil timerUtil = new TimerUtil();
+            networkInboundBandwidthLimiter.consume(options.throttleStrategy(), end - start).whenCompleteAsync((v, ex) -> {
+                NetworkStats.getInstance().networkLimiterQueueTimeStats(AsyncNetworkBandwidthLimiter.Type.INBOUND, options.throttleStrategy())
+                    .record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+                if (ex != null) {
+                    cf.completeExceptionally(ex);
+                } else {
+                    rangeRead0(objectMetadata, start, end, cf);
+                }
+            }, readLimiterCallbackExecutor);
+        } else {
+            rangeRead0(objectMetadata, start, end, cf);
+
+        }
+        Timeout timeout = timeoutDetect.newTimeout(t -> LOGGER.warn("rangeRead {} {}-{} timeout", objectMetadata, start, end), 3, TimeUnit.MINUTES);
+        return cf.whenComplete((rst, ex) -> timeout.cancel());
+    }
+
+    @Override
+    public CompletableFuture<ByteBuf> rangeRead(S3ObjectMetadata objectMetadata, long start, long end) {
+        return rangeRead(ReadOptions.DEFAULT, objectMetadata, start, end);
+    }
+
+    abstract void doRangeRead(String path, long start, long end, CompletableFuture<ByteBuf> cf, Consumer<Throwable> failHandler);
+
+    abstract boolean isUnrecoverable(Throwable ex);
+
+    private void rangeRead0(S3ObjectMetadata s3ObjectMetadata, long start, long end, CompletableFuture<ByteBuf> cf) {
+        synchronized (waitingReadTasks) {
+            waitingReadTasks.add(new AbstractObjectStorage.ReadTask(s3ObjectMetadata, start, end, cf));
+        }
+    }
+
+    private void tryMergeRead() {
+        try {
+            tryMergeRead0();
+        } catch (Throwable e) {
+            LOGGER.error("[UNEXPECTED] tryMergeRead fail", e);
+        }
+    }
+
+    /**
+     * Get adjacent read tasks and merge them into one read task which read range is not exceed 16MB.
+     */
+    private void tryMergeRead0() {
+        List<AbstractObjectStorage.MergedReadTask> mergedReadTasks = new ArrayList<>();
+        synchronized (waitingReadTasks) {
+            if (waitingReadTasks.isEmpty()) {
+                return;
+            }
+            int readPermit = availableReadPermit();
+            while (readPermit > 0 && !waitingReadTasks.isEmpty()) {
+                Iterator<AbstractObjectStorage.ReadTask> it = waitingReadTasks.iterator();
+                Map<String, AbstractObjectStorage.MergedReadTask> mergingReadTasks = new HashMap<>();
+                while (it.hasNext()) {
+                    AbstractObjectStorage.ReadTask readTask = it.next();
+                    String path = ObjectUtils.genKey(0, readTask.s3ObjectMetadata.objectId());
+                    AbstractObjectStorage.MergedReadTask mergedReadTask = mergingReadTasks.get(path);
+                    if (mergedReadTask == null) {
+                        if (readPermit > 0) {
+                            readPermit -= 1;
+                            mergedReadTask = new AbstractObjectStorage.MergedReadTask(readTask, maxMergeReadSparsityRate);
+                            mergingReadTasks.put(path, mergedReadTask);
+                            mergedReadTasks.add(mergedReadTask);
+                            it.remove();
+                        }
+                    } else {
+                        if (mergedReadTask.tryMerge(readTask)) {
+                            it.remove();
+                        }
+                    }
+                }
+            }
+        }
+        mergedReadTasks.forEach(
+            mergedReadTask -> {
+                String path = mergedReadTask.s3ObjectMetadata.key();
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("[S3BlockCache] merge read: {}, {}-{}, size: {}, sparsityRate: {}",
+                        path, mergedReadTask.start, mergedReadTask.end,
+                        mergedReadTask.end - mergedReadTask.start, mergedReadTask.dataSparsityRate);
+                }
+                mergedRangeRead(path, mergedReadTask.start, mergedReadTask.end)
+                    .whenComplete((rst, ex) -> FutureUtil.suppress(() -> mergedReadTask.handleReadCompleted(rst, ex), LOGGER));
+            }
+        );
+    }
+
+    private int availableReadPermit() {
+        return inflightReadLimiter.availablePermits();
+    }
+
+    private CompletableFuture<ByteBuf> mergedRangeRead(String path, long start, long end) {
+        end = end - 1;
+        CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
+        CompletableFuture<ByteBuf> retCf = acquireReadPermit(cf);
+        if (retCf.isDone()) {
+            return retCf;
+        }
+        mergedRangeRead0(path, start, end, cf);
+        return retCf;
+    }
+
+    private void mergedRangeRead0(String path, long start, long end, CompletableFuture<ByteBuf> cf) {
+        TimerUtil timerUtil = new TimerUtil();
+        long size = end - start + 1;
+        Consumer<Throwable> failHandler = ex -> {
+            if (isUnrecoverable(ex) || checkS3ApiMode) {
+                LOGGER.error("GetObject for object {} [{}, {}) fail", path, start, end, ex);
+                cf.completeExceptionally(ex);
+            } else {
+                LOGGER.warn("GetObject for object {} [{}, {}) fail, retry later", path, start, end, ex);
+                scheduler.schedule(() -> mergedRangeRead0(path, start, end, cf), 100, TimeUnit.MILLISECONDS);
+            }
+            S3OperationStats.getInstance().getObjectStats(size, false).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+        };
+        doRangeRead(path, start, end, cf, failHandler);
+    }
+
+    int getMaxObjectStorageConcurrency() {
+        int cpuCores = Runtime.getRuntime().availableProcessors();
+        return Math.max(MIN_CONCURRENCY, Math.min(cpuCores * DEFAULT_CONCURRENCY_PER_CORE, MAX_CONCURRENCY));
+    }
+
+    private void checkConfig() {
+        if (this.networkInboundBandwidthLimiter != null) {
+            if (this.networkInboundBandwidthLimiter.getMaxTokens() < Writer.MIN_PART_SIZE) {
+                throw new IllegalArgumentException(String.format("Network inbound burst bandwidth limit %d must be no less than min part size %d",
+                    this.networkInboundBandwidthLimiter.getMaxTokens(), Writer.MIN_PART_SIZE));
+            }
+        }
+        if (this.networkOutboundBandwidthLimiter != null) {
+            if (this.networkOutboundBandwidthLimiter.getMaxTokens() < Writer.MIN_PART_SIZE) {
+                throw new IllegalArgumentException(String.format("Network outbound burst bandwidth limit %d must be no less than min part size %d",
+                    this.networkOutboundBandwidthLimiter.getMaxTokens(), Writer.MIN_PART_SIZE));
+            }
+        }
+    }
+
+    /**
+     * Acquire read permit, permit will auto release when cf complete.
+     *
+     * @return retCf the retCf should be used as method return value to ensure release before following operations.
+     */
+    <T> CompletableFuture<T> acquireReadPermit(CompletableFuture<T> cf) {
+        // TODO: async acquire?
+        try {
+            TimerUtil timerUtil = new TimerUtil();
+            inflightReadLimiter.acquire();
+            StorageOperationStats.getInstance().readS3LimiterStats(currentIndex).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+            CompletableFuture<T> newCf = new CompletableFuture<>();
+            cf.whenComplete((rst, ex) -> {
+                inflightReadLimiter.release();
+                readCallbackExecutor.execute(() -> {
+                    if (ex != null) {
+                        newCf.completeExceptionally(ex);
+                    } else {
+                        newCf.complete(rst);
+                    }
+                });
+            });
+            return newCf;
+        } catch (InterruptedException e) {
+            cf.completeExceptionally(e);
+            return cf;
+        }
+    }
+
+    static class MergedReadTask {
+        static final int MAX_MERGE_READ_SIZE = 4 * 1024 * 1024;
+        final S3ObjectMetadata s3ObjectMetadata;
+        final List<AbstractObjectStorage.ReadTask> readTasks = new ArrayList<>();
+        long start;
+        long end;
+        long uniqueDataSize;
+        float dataSparsityRate = 0f;
+        float maxMergeReadSparsityRate;
+
+        MergedReadTask(AbstractObjectStorage.ReadTask readTask, float maxMergeReadSparsityRate) {
+            this.s3ObjectMetadata = readTask.s3ObjectMetadata;
+            this.start = readTask.start;
+            this.end = readTask.end;
+            this.readTasks.add(readTask);
+            this.uniqueDataSize = readTask.end - readTask.start;
+            this.maxMergeReadSparsityRate = maxMergeReadSparsityRate;
+        }
+
+        boolean tryMerge(AbstractObjectStorage.ReadTask readTask) {
+            if (!canMerge(readTask)) {
+                return false;
+            }
+
+            long newStart = Math.min(start, readTask.start);
+            long newEnd = Math.max(end, readTask.end);
+            boolean merge = newEnd - newStart <= MAX_MERGE_READ_SIZE;
+            if (merge) {
+                // insert read task in order
+                int i = 0;
+                long overlap = 0L;
+                for (; i < readTasks.size(); i++) {
+                    AbstractObjectStorage.ReadTask task = readTasks.get(i);
+                    if (task.start >= readTask.start) {
+                        readTasks.add(i, readTask);
+                        // calculate data overlap
+                        AbstractObjectStorage.ReadTask prev = i > 0 ? readTasks.get(i - 1) : null;
+                        AbstractObjectStorage.ReadTask next = readTasks.get(i + 1);
+
+                        if (prev != null && readTask.start < prev.end) {
+                            overlap += prev.end - readTask.start;
+                        }
+                        if (readTask.end > next.start) {
+                            overlap += readTask.end - next.start;
+                        }
+                        break;
+                    }
+                }
+                if (i == readTasks.size()) {
+                    readTasks.add(readTask);
+                    AbstractObjectStorage.ReadTask prev = i >= 1 ? readTasks.get(i - 1) : null;
+                    if (prev != null && readTask.start < prev.end) {
+                        overlap += prev.end - readTask.start;
+                    }
+                }
+                long uniqueSize = readTask.end - readTask.start - overlap;
+                long tmpUniqueSize = uniqueDataSize + uniqueSize;
+                float tmpSparsityRate = 1 - (float) tmpUniqueSize / (newEnd - newStart);
+                if (tmpSparsityRate > maxMergeReadSparsityRate) {
+                    // remove read task
+                    readTasks.remove(i);
+                    return false;
+                }
+                uniqueDataSize = tmpUniqueSize;
+                dataSparsityRate = tmpSparsityRate;
+                start = newStart;
+                end = newEnd;
+            }
+            return merge;
+        }
+
+        private boolean canMerge(AbstractObjectStorage.ReadTask readTask) {
+            return s3ObjectMetadata != null &&
+                s3ObjectMetadata.equals(readTask.s3ObjectMetadata) &&
+                dataSparsityRate <= this.maxMergeReadSparsityRate;
+        }
+
+        void handleReadCompleted(ByteBuf rst, Throwable ex) {
+            if (ex != null) {
+                readTasks.forEach(readTask -> readTask.cf.completeExceptionally(ex));
+            } else {
+                for (AbstractObjectStorage.ReadTask readTask : readTasks) {
+                    readTask.cf.complete(rst.retainedSlice((int) (readTask.start - start), (int) (readTask.end - readTask.start)));
+                }
+                rst.release();
+            }
+        }
+    }
+
+    static final class ReadTask {
+        private final S3ObjectMetadata s3ObjectMetadata;
+        private final long start;
+        private final long end;
+        private final CompletableFuture<ByteBuf> cf;
+
+        ReadTask(S3ObjectMetadata s3ObjectMetadata, long start, long end, CompletableFuture<ByteBuf> cf) {
+            this.s3ObjectMetadata = s3ObjectMetadata;
+            this.start = start;
+            this.end = end;
+            this.cf = cf;
+        }
+
+        public S3ObjectMetadata s3ObjectMetadata() {
+            return s3ObjectMetadata;
+        }
+
+        public long start() {
+            return start;
+        }
+
+        public long end() {
+            return end;
+        }
+
+        public CompletableFuture<ByteBuf> cf() {
+            return cf;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this)
+                return true;
+            if (obj == null || obj.getClass() != this.getClass())
+                return false;
+            var that = (AbstractObjectStorage.ReadTask) obj;
+            return Objects.equals(this.s3ObjectMetadata, that.s3ObjectMetadata) &&
+                this.start == that.start &&
+                this.end == that.end &&
+                Objects.equals(this.cf, that.cf);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(s3ObjectMetadata, start, end, cf);
+        }
+
+        @Override
+        public String toString() {
+            return "ReadTask[" +
+                "s3ObjectMetadata=" + s3ObjectMetadata + ", " +
+                "start=" + start + ", " +
+                "end=" + end + ", " +
+                "cf=" + cf + ']';
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -31,7 +31,6 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.model.Tagging;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,8 +47,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static com.automq.stream.s3.metadata.ObjectUtils.tagging;
-
 public abstract class AbstractObjectStorage implements ObjectStorage {
     static final Logger LOGGER = LoggerFactory.getLogger(AbstractObjectStorage.class);
     private static final AtomicInteger INDEX = new AtomicInteger(-1);
@@ -58,8 +55,6 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
     private static final int MAX_CONCURRENCY = 1000;
     private final float maxMergeReadSparsityRate;
     private final int currentIndex;
-    final String bucket;
-    final Tagging tagging;
     private final Semaphore inflightReadLimiter;
     private final Semaphore inflightWriteLimiter;
     private final List<AbstractObjectStorage.ReadTask> waitingReadTasks = new LinkedList<>();
@@ -75,13 +70,11 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         ThreadUtils.createThreadFactory("objectStorage", true), LOGGER);
     boolean checkS3ApiMode = false;
 
-    public AbstractObjectStorage(String bucket, Map<String, String> tagging,
+    public AbstractObjectStorage(
         AsyncNetworkBandwidthLimiter networkInboundBandwidthLimiter,
         AsyncNetworkBandwidthLimiter networkOutboundBandwidthLimiter,
         boolean readWriteIsolate,
         boolean checkS3ApiMode) {
-        this.bucket = bucket;
-        this.tagging = tagging(tagging);
         this.currentIndex = INDEX.incrementAndGet();
         this.maxMergeReadSparsityRate = Utils.getMaxMergeReadSparsityRate();
         int maxObjectStorageConcurrency = getMaxObjectStorageConcurrency();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.Tagging;
 
 import java.net.URI;
 import java.time.Duration;
@@ -40,10 +41,13 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import static com.automq.stream.s3.metadata.ObjectUtils.tagging;
 import static com.automq.stream.utils.FutureUtil.cause;
 
 public class AwsObjectStorage extends AbstractObjectStorage {
 
+    private final String bucket;
+    private final Tagging tagging;
     private final S3AsyncClient readS3Client;
     private final S3AsyncClient writeS3Client;
 
@@ -53,7 +57,9 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         AsyncNetworkBandwidthLimiter networkOutboundBandwidthLimiter,
         boolean readWriteIsolate,
         boolean checkMode) {
-        super(bucket, tagging, networkInboundBandwidthLimiter, networkOutboundBandwidthLimiter, readWriteIsolate, checkMode);
+        super(networkInboundBandwidthLimiter, networkOutboundBandwidthLimiter, readWriteIsolate, checkMode);
+        this.bucket = bucket;
+        this.tagging = tagging(tagging);
         this.writeS3Client = newS3Client(endpoint, region, forcePathStyle, credentialsProviders, getMaxObjectStorageConcurrency());
         this.readS3Client = readWriteIsolate ? newS3Client(endpoint, region, forcePathStyle, credentialsProviders, getMaxObjectStorageConcurrency()) : writeS3Client;
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.TimerUtil;
+import com.automq.stream.s3.metrics.stats.S3OperationStats;
+import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.ssl.OpenSsl;
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.automq.stream.utils.FutureUtil.cause;
+
+public class AwsObjectStorage extends AbstractObjectStorage {
+
+    private final S3AsyncClient readS3Client;
+    private final S3AsyncClient writeS3Client;
+
+    public AwsObjectStorage(String endpoint, Map<String, String> tagging, String region, String bucket, boolean forcePathStyle,
+        List<AwsCredentialsProvider> credentialsProviders,
+        AsyncNetworkBandwidthLimiter networkInboundBandwidthLimiter,
+        AsyncNetworkBandwidthLimiter networkOutboundBandwidthLimiter,
+        boolean readWriteIsolate,
+        boolean checkMode) {
+        super(bucket, tagging, networkInboundBandwidthLimiter, networkOutboundBandwidthLimiter, readWriteIsolate, checkMode);
+        this.writeS3Client = newS3Client(endpoint, region, forcePathStyle, credentialsProviders, getMaxObjectStorageConcurrency());
+        this.readS3Client = readWriteIsolate ? newS3Client(endpoint, region, forcePathStyle, credentialsProviders, getMaxObjectStorageConcurrency()) : writeS3Client;
+    }
+
+    @Override
+    void doRangeRead(String path, long start, long end, CompletableFuture<ByteBuf> cf, Consumer<Throwable> failHandler) {
+        TimerUtil timerUtil = new TimerUtil();
+        long size = end - start + 1;
+        GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(path).range(range(start, end)).build();
+        readS3Client.getObject(request, AsyncResponseTransformer.toPublisher())
+            .thenAccept(responsePublisher -> {
+                CompositeByteBuf buf = ByteBufAlloc.compositeByteBuffer();
+                responsePublisher.subscribe(bytes -> {
+                    // the aws client will copy DefaultHttpContent to heap ByteBuffer
+                    buf.addComponent(true, Unpooled.wrappedBuffer(bytes));
+                }).thenAccept(v -> {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("[S3BlockCache] getObject from path: {}, {}-{}, size: {}, cost: {} ms",
+                            path, start, end, size, timerUtil.elapsedAs(TimeUnit.MILLISECONDS));
+                    }
+                    S3OperationStats.getInstance().downloadSizeTotalStats.add(MetricsLevel.INFO, size);
+                    S3OperationStats.getInstance().getObjectStats(size, true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+                    cf.complete(buf);
+                }).exceptionally(ex -> {
+                    buf.release();
+                    failHandler.accept(ex);
+                    return null;
+                });
+            })
+            .exceptionally(ex -> {
+                failHandler.accept(ex);
+                return null;
+            });
+    }
+
+
+    @Override
+    boolean isUnrecoverable(Throwable ex) {
+        ex = cause(ex);
+        if (ex instanceof S3Exception) {
+            S3Exception s3Ex = (S3Exception) ex;
+            return s3Ex.statusCode() == HttpStatusCode.FORBIDDEN || s3Ex.statusCode() == HttpStatusCode.NOT_FOUND;
+        }
+        return false;
+    }
+
+    private String range(long start, long end) {
+        if (end == -1L) {
+            return "bytes=" + start + "-";
+        }
+        return "bytes=" + start + "-" + end;
+    }
+
+    private S3AsyncClient newS3Client(String endpoint, String region, boolean forcePathStyle,
+        List<AwsCredentialsProvider> credentialsProviders, int maxConcurrency) {
+        S3AsyncClientBuilder builder = S3AsyncClient.builder().region(Region.of(region));
+        if (StringUtils.isNotBlank(endpoint)) {
+            builder.endpointOverride(URI.create(endpoint));
+        }
+        if (!OpenSsl.isAvailable()) {
+            LOGGER.warn("OpenSSL is not available, using JDK SSL provider, which may have performance issue.", OpenSsl.unavailabilityCause());
+        }
+        SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder()
+            .maxConcurrency(maxConcurrency)
+            .build();
+        builder.httpClient(httpClient);
+        builder.serviceConfiguration(c -> c.pathStyleAccessEnabled(forcePathStyle));
+        builder.credentialsProvider(newCredentialsProviderChain(credentialsProviders));
+        builder.overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMinutes(2))
+            .apiCallAttemptTimeout(Duration.ofSeconds(60)));
+        return builder.build();
+    }
+
+    private AwsCredentialsProvider newCredentialsProviderChain(List<AwsCredentialsProvider> credentialsProviders) {
+        List<AwsCredentialsProvider> providers = new ArrayList<>(credentialsProviders);
+        // Add default providers to the end of the chain
+        providers.add(InstanceProfileCredentialsProvider.create());
+        providers.add(AnonymousCredentialsProvider.create());
+        return AwsCredentialsProviderChain.builder()
+            .reuseLastProviderEnabled(true)
+            .credentialsProviders(providers)
+            .build();
+    }
+
+}


### PR DESCRIPTION
* The logic of MergeRead and acquireReadPermit has been extracted to `AbstractObjectStorage.java`
* Most of the logic remains consistent with before, except that the `String path` in ReadTask has been replaced with `S3ObjectMetadata s3ObjectMetadata`.
* `AwsObjectStorage.java` is responsible for performing the rangeRead operations from S3, `doRangeRead`.