### PR TITLE
chore(examples): remove hardcoded value in TransactionProducer 

### DIFF
--- a/examples/src/main/java/kafka/examples/TransactionProducer.java
+++ b/examples/src/main/java/kafka/examples/TransactionProducer.java
@@ -24,7 +24,7 @@ public class TransactionProducer {
     public static void main(String... args) {
         // Set the required properties for running the Kafka producer.
         Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaProperties.BOOTSTRAP_SERVERS);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "my-transactional-id");

--- a/examples/src/main/java/kafka/examples/TransactionProducer.java
+++ b/examples/src/main/java/kafka/examples/TransactionProducer.java
@@ -28,7 +28,6 @@ public class TransactionProducer {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "my-transactional-id");
-        props.put(ProducerConfig.BATCH_SIZE_CONFIG, "1");
 
         // Create a Kafka producer with the provided properties.
         Producer<String, String> producer = new KafkaProducer<>(props);


### PR DESCRIPTION
refactor TransactionProducer class.

1. replace server configuration to use static properties instead of hardcoded value.
2. remove batch size initialization code

it is unnecessary, refer to the following [link ](https://github.com/AutoMQ/automq/blob/2821f2462e88e35506c8d0a57bf6b09c548c12a2/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L432)