### PR TITLE
feat(s3stream): object storage writer

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -269,7 +269,7 @@ public class StreamObjectCompactor {
                         nextBlockPosition += dataBlock.size();
                         lastIndex = dataBlock;
                     }
-                    writer.copyWrite(ObjectUtils.genKey(0, object.objectId()), validDataBlockStartPosition, basicObjectInfo.dataBlockSize());
+                    writer.copyWrite(object, validDataBlockStartPosition, basicObjectInfo.dataBlockSize());
                     objectSize += basicObjectInfo.dataBlockSize() - validDataBlockStartPosition;
                     indexes.addComponent(true, subIndexes);
                     compactedObjectIds.add(object.objectId());

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryS3Operator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryS3Operator.java
@@ -10,6 +10,7 @@
  */
 package com.automq.stream.s3.operator;
 
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.network.ThrottleStrategy;
 import com.automq.stream.utils.FutureUtil;
 import io.netty.buffer.ByteBuf;
@@ -81,8 +82,8 @@ public class MemoryS3Operator implements S3Operator {
             }
 
             @Override
-            public void copyWrite(String sourcePath, long start, long end) {
-                ByteBuf source = storage.get(sourcePath);
+            public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+                ByteBuf source = storage.get(s3ObjectMetadata.key());
                 if (source == null) {
                     throw new IllegalArgumentException("object not exist");
                 }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
@@ -12,6 +12,7 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.metrics.MetricsLevel;
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.metrics.stats.S3ObjectStats;
@@ -98,11 +99,11 @@ public class MultiPartWriter implements Writer {
     }
 
     @Override
-    public void copyWrite(String sourcePath, long start, long end) {
+    public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
         long nextStart = start;
         for (; ; ) {
             long currentEnd = Math.min(nextStart + Writer.MAX_PART_SIZE, end);
-            copyWrite0(sourcePath, nextStart, currentEnd);
+            copyWrite0(s3ObjectMetadata.key(), nextStart, currentEnd);
             nextStart = currentEnd;
             if (currentEnd == end) {
                 break;

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriterV2.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriterV2.java
@@ -202,7 +202,7 @@ public class MultiPartWriterV2 implements Writer {
         public void copyOnWrite() {
             int size = partBuf.readableBytes();
             if (size > 0) {
-                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.context().allocType());
+                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.allocType());
                 buf.writeBytes(partBuf.duplicate());
                 CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
                 this.partBuf.release();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriterV2.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriterV2.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.TimerUtil;
+import com.automq.stream.s3.metrics.stats.S3ObjectStats;
+import com.automq.stream.s3.network.ThrottleStrategy;
+import com.automq.stream.utils.FutureUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class MultiPartWriterV2 implements Writer {
+    private static final long MAX_MERGE_WRITE_SIZE = 16L * 1024 * 1024;
+    final CompletableFuture<String> uploadIdCf = new CompletableFuture<>();
+    private final AbstractObjectStorage operator;
+    private final String path;
+    private final ObjectStorage.WriteOptions writeOptions;
+    private final List<CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart>> parts = new LinkedList<>();
+    private final AtomicInteger nextPartNumber = new AtomicInteger(1);
+    /**
+     * The minPartSize represents the minimum size of a part for a multipart object.
+     */
+    private final long minPartSize;
+    private final TimerUtil timerUtil = new TimerUtil();
+    private final AtomicLong totalWriteSize = new AtomicLong(0L);
+    private String uploadId;
+    private CompletableFuture<Void> closeCf;
+    private ObjectPart objectPart = null;
+
+
+    public MultiPartWriterV2(ObjectStorage.WriteOptions writeOptions, AbstractObjectStorage operator, String path, long minPartSize) {
+        this.writeOptions = writeOptions;
+        this.operator = operator;
+        this.path = path;
+        this.minPartSize = minPartSize;
+        init();
+    }
+
+    private void init() {
+        FutureUtil.propagate(
+            operator.createMultipartUpload(path).thenApply(uploadId -> {
+                this.uploadId = uploadId;
+                return uploadId;
+            }),
+            uploadIdCf
+        );
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ByteBuf data) {
+        totalWriteSize.addAndGet(data.readableBytes());
+
+        if (objectPart == null) {
+            objectPart = new ObjectPart(writeOptions.throttleStrategy());
+        }
+        ObjectPart objectPart = this.objectPart;
+
+        objectPart.write(data);
+        if (objectPart.size() > minPartSize) {
+            objectPart.upload();
+            // finish current part.
+            this.objectPart = null;
+        }
+        return objectPart.getFuture();
+    }
+
+    @Override
+    public void copyOnWrite() {
+        if (objectPart != null) {
+            objectPart.copyOnWrite();
+        }
+    }
+
+    @Override
+    public boolean hasBatchingPart() {
+        return objectPart != null;
+    }
+
+    @Override
+    public void copyWrite(S3ObjectMetadata sourceObjectMateData, long start, long end) {
+        long nextStart = start;
+        for (; ; ) {
+            long currentEnd = Math.min(nextStart + Writer.MAX_PART_SIZE, end);
+            copyWrite0(sourceObjectMateData, nextStart, currentEnd);
+            nextStart = currentEnd;
+            if (currentEnd == end) {
+                break;
+            }
+        }
+    }
+
+    public void copyWrite0(S3ObjectMetadata sourceObjectMateData, long start, long end) {
+        long targetSize = end - start;
+        if (objectPart == null) {
+            if (targetSize < minPartSize) {
+                this.objectPart = new ObjectPart(writeOptions.throttleStrategy());
+                objectPart.readAndWrite(sourceObjectMateData, start, end);
+            } else {
+                new CopyObjectPart(sourceObjectMateData.key(), start, end);
+            }
+        } else {
+            if (objectPart.size() + targetSize > MAX_MERGE_WRITE_SIZE) {
+                long readAndWriteCopyEnd = start + minPartSize - objectPart.size();
+                objectPart.readAndWrite(sourceObjectMateData, start, readAndWriteCopyEnd);
+                objectPart.upload();
+                this.objectPart = null;
+                new CopyObjectPart(sourceObjectMateData.key(), readAndWriteCopyEnd, end);
+            } else {
+                objectPart.readAndWrite(sourceObjectMateData, start, end);
+                if (objectPart.size() > minPartSize) {
+                    objectPart.upload();
+                    this.objectPart = null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        if (closeCf != null) {
+            return closeCf;
+        }
+
+        if (objectPart != null) {
+            // force upload the last part which can be smaller than minPartSize.
+            objectPart.upload();
+            objectPart = null;
+        }
+
+        S3ObjectStats.getInstance().objectStageReadyCloseStats.record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+        closeCf = new CompletableFuture<>();
+        CompletableFuture<Void> uploadDoneCf = uploadIdCf.thenCompose(uploadId -> CompletableFuture.allOf(parts.toArray(new CompletableFuture[0])));
+        FutureUtil.propagate(uploadDoneCf.thenCompose(nil -> operator.completeMultipartUpload(path, uploadId, genCompleteParts())), closeCf);
+        closeCf.whenComplete((nil, ex) -> {
+            S3ObjectStats.getInstance().objectStageTotalStats.record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+            S3ObjectStats.getInstance().objectNumInTotalStats.add(MetricsLevel.DEBUG, 1);
+            S3ObjectStats.getInstance().objectUploadSizeStats.record(totalWriteSize.get());
+        });
+        return closeCf;
+    }
+
+    @Override
+    public CompletableFuture<Void> release() {
+        // wait for all ongoing uploading parts to finish and release pending part
+        return CompletableFuture.allOf(parts.toArray(new CompletableFuture[0])).whenComplete((nil, ex) -> {
+            if (objectPart != null) {
+                objectPart.release();
+            }
+        });
+    }
+
+    private List<AbstractObjectStorage.ObjectStorageCompletedPart> genCompleteParts() {
+        return this.parts.stream().map(cf -> {
+            try {
+                return cf.get();
+            } catch (Throwable e) {
+                // won't happen.
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    class ObjectPart {
+        private final int partNumber = nextPartNumber.getAndIncrement();
+        private final CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
+        private final ThrottleStrategy throttleStrategy;
+        private CompositeByteBuf partBuf = ByteBufAlloc.compositeByteBuffer();
+        private CompletableFuture<Void> lastRangeReadCf = CompletableFuture.completedFuture(null);
+        private long size;
+
+        public ObjectPart(ThrottleStrategy throttleStrategy) {
+            this.throttleStrategy = throttleStrategy;
+            parts.add(partCf);
+        }
+
+        public void write(ByteBuf data) {
+            size += data.readableBytes();
+            // ensure addComponent happen before following write or copyWrite.
+            this.lastRangeReadCf = lastRangeReadCf.thenAccept(nil -> partBuf.addComponent(true, data));
+        }
+
+        public void copyOnWrite() {
+            int size = partBuf.readableBytes();
+            if (size > 0) {
+                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.context().allocType());
+                buf.writeBytes(partBuf.duplicate());
+                CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
+                this.partBuf.release();
+                this.partBuf = copy;
+            }
+        }
+
+        public void readAndWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+            size += end - start;
+            // TODO: parallel read and sequence add.
+            this.lastRangeReadCf = lastRangeReadCf
+                .thenCompose(nil -> operator.rangeRead(ObjectStorage.ReadOptions.DEFAULT.throttleStrategy(throttleStrategy), s3ObjectMetadata, start, end))
+                .thenAccept(buf -> partBuf.addComponent(true, buf));
+        }
+
+        public void upload() {
+            this.lastRangeReadCf.whenComplete((nil, ex) -> {
+                if (ex != null) {
+                    partCf.completeExceptionally(ex);
+                } else {
+                    upload0();
+                }
+            });
+        }
+
+        private void upload0() {
+            TimerUtil timerUtil = new TimerUtil();
+            FutureUtil.propagate(uploadIdCf.thenCompose(uploadId -> operator.uploadPart(path, uploadId, partNumber, partBuf, throttleStrategy)), partCf);
+            partCf.whenComplete((nil, ex) -> {
+                S3ObjectStats.getInstance().objectStageUploadPartStats.record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+            });
+        }
+
+        public long size() {
+            return size;
+        }
+
+        public CompletableFuture<Void> getFuture() {
+            return partCf.thenApply(nil -> null);
+        }
+
+        public void release() {
+            partBuf.release();
+        }
+    }
+
+    class CopyObjectPart {
+        private final CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
+
+        public CopyObjectPart(String sourcePath, long start, long end) {
+            int partNumber = nextPartNumber.getAndIncrement();
+            parts.add(partCf);
+            FutureUtil.propagate(uploadIdCf.thenCompose(uploadId -> operator.uploadPartCopy(sourcePath, path, start, end, uploadId, partNumber)), partCf);
+        }
+
+        public CompletableFuture<Void> getFuture() {
+            return partCf.thenApply(nil -> null);
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -40,14 +40,24 @@ public interface ObjectStorage {
         public static final WriteOptions DEFAULT = new WriteOptions();
 
         private ThrottleStrategy throttleStrategy = ThrottleStrategy.BYPASS;
+        private Writer.Context context = Writer.Context.DEFAULT;
 
         public WriteOptions throttleStrategy(ThrottleStrategy throttleStrategy) {
             this.throttleStrategy = throttleStrategy;
             return this;
         }
 
+        public WriteOptions context(Writer.Context context) {
+            this.context = context;
+            return this;
+        }
+
         public ThrottleStrategy throttleStrategy() {
             return throttleStrategy;
+        }
+
+        public Writer.Context context() {
+            return context;
         }
 
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -11,9 +11,11 @@
 
 package com.automq.stream.s3.operator;
 
+import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.network.ThrottleStrategy;
 import io.netty.buffer.ByteBuf;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -40,15 +42,15 @@ public interface ObjectStorage {
         public static final WriteOptions DEFAULT = new WriteOptions();
 
         private ThrottleStrategy throttleStrategy = ThrottleStrategy.BYPASS;
-        private Writer.Context context = Writer.Context.DEFAULT;
+        private int allocType = ByteBufAlloc.DEFAULT;
 
         public WriteOptions throttleStrategy(ThrottleStrategy throttleStrategy) {
             this.throttleStrategy = throttleStrategy;
             return this;
         }
 
-        public WriteOptions context(Writer.Context context) {
-            this.context = context;
+        public WriteOptions allocType(int allocType) {
+            this.allocType = allocType;
             return this;
         }
 
@@ -56,8 +58,8 @@ public interface ObjectStorage {
             return throttleStrategy;
         }
 
-        public Writer.Context context() {
-            return context;
+        public int allocType() {
+            return allocType;
         }
 
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
@@ -12,6 +12,7 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.metrics.MetricsLevel;
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.metrics.stats.S3ObjectStats;
@@ -71,11 +72,11 @@ class ProxyWriter implements Writer {
     }
 
     @Override
-    public void copyWrite(String sourcePath, long start, long end) {
+    public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
         if (multiPartWriter == null) {
             newMultiPartWriter();
         }
-        multiPartWriter.copyWrite(sourcePath, start, end);
+        multiPartWriter.copyWrite(s3ObjectMetadata, start, end);
     }
 
     @Override
@@ -141,7 +142,7 @@ class ProxyWriter implements Writer {
         }
 
         @Override
-        public void copyWrite(String sourcePath, long start, long end) {
+        public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
             throw new UnsupportedOperationException();
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriterV2.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriterV2.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024, AutoMQ CO.,LTD.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.TimerUtil;
+import com.automq.stream.s3.metrics.stats.S3ObjectStats;
+import com.automq.stream.utils.FutureUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * If object data size is less than ObjectWriter.MAX_UPLOAD_SIZE, we should use single upload to upload it.
+ * Else, we should use multi-part upload to upload it.
+ */
+class ProxyWriterV2 implements Writer {
+    final ObjectWriter objectWriter = new ObjectWriter();
+    private final ObjectStorage.WriteOptions writeOptions;
+    private final AbstractObjectStorage operator;
+    private final String path;
+    private final long minPartSize;
+    Writer multiPartWriter = null;
+
+    public ProxyWriterV2(ObjectStorage.WriteOptions writeOptions, AbstractObjectStorage operator, String path, long minPartSize) {
+        this.writeOptions = writeOptions;
+        this.operator = operator;
+        this.path = path;
+        this.minPartSize = minPartSize;
+    }
+
+    public ProxyWriterV2(ObjectStorage.WriteOptions writeOptions, AbstractObjectStorage operator, String path) {
+        this(writeOptions, operator, path, Writer.MIN_PART_SIZE);
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ByteBuf part) {
+        if (multiPartWriter != null) {
+            return multiPartWriter.write(part);
+        } else {
+            objectWriter.write(part);
+            if (objectWriter.isFull()) {
+                newMultiPartWriter();
+            }
+            return objectWriter.cf;
+        }
+    }
+
+    @Override
+    public void copyOnWrite() {
+        if (multiPartWriter != null) {
+            multiPartWriter.copyOnWrite();
+        } else {
+            objectWriter.copyOnWrite();
+        }
+    }
+
+    @Override
+    public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+        if (multiPartWriter == null) {
+            newMultiPartWriter();
+        }
+        multiPartWriter.copyWrite(s3ObjectMetadata, start, end);
+    }
+
+    @Override
+    public boolean hasBatchingPart() {
+        if (multiPartWriter != null) {
+            return multiPartWriter.hasBatchingPart();
+        } else {
+            return objectWriter.hasBatchingPart();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        if (multiPartWriter != null) {
+            return multiPartWriter.close();
+        } else {
+            return objectWriter.close();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> release() {
+        if (multiPartWriter != null) {
+            return multiPartWriter.release();
+        } else {
+            return objectWriter.release();
+        }
+    }
+
+    private void newMultiPartWriter() {
+        this.multiPartWriter = new MultiPartWriterV2(writeOptions, operator, path, minPartSize);
+        if (objectWriter.data.readableBytes() > 0) {
+            FutureUtil.propagate(multiPartWriter.write(objectWriter.data), objectWriter.cf);
+        } else {
+            objectWriter.data.release();
+            objectWriter.cf.complete(null);
+        }
+    }
+
+    class ObjectWriter implements Writer {
+        // max upload size, when object data size is larger MAX_UPLOAD_SIZE, we should use multi-part upload to upload it.
+        static final long MAX_UPLOAD_SIZE = 32L * 1024 * 1024;
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        CompositeByteBuf data = ByteBufAlloc.compositeByteBuffer();
+        TimerUtil timerUtil = new TimerUtil();
+
+        @Override
+        public CompletableFuture<Void> write(ByteBuf part) {
+            data.addComponent(true, part);
+            return cf;
+        }
+
+        @Override
+        public void copyOnWrite() {
+            int size = data.readableBytes();
+            if (size > 0) {
+                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.context().allocType());
+                buf.writeBytes(data.duplicate());
+                CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
+                this.data.release();
+                this.data = copy;
+            }
+        }
+
+        @Override
+        public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasBatchingPart() {
+            return true;
+        }
+
+        @Override
+        public CompletableFuture<Void> close() {
+            S3ObjectStats.getInstance().objectStageReadyCloseStats.record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+            int size = data.readableBytes();
+            FutureUtil.propagate(operator.write(path, data, writeOptions.throttleStrategy()), cf);
+            cf.whenComplete((nil, e) -> {
+                S3ObjectStats.getInstance().objectStageTotalStats.record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+                S3ObjectStats.getInstance().objectNumInTotalStats.add(MetricsLevel.DEBUG, 1);
+                S3ObjectStats.getInstance().objectUploadSizeStats.record(size);
+            });
+            return cf;
+        }
+
+        @Override
+        public CompletableFuture<Void> release() {
+            data.release();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        public boolean isFull() {
+            return data.readableBytes() > MAX_UPLOAD_SIZE;
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriterV2.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriterV2.java
@@ -130,7 +130,7 @@ class ProxyWriterV2 implements Writer {
         public void copyOnWrite() {
             int size = data.readableBytes();
             if (size > 0) {
-                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.context().allocType());
+                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.allocType());
                 buf.writeBytes(data.duplicate());
                 CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
                 this.data.release();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/Writer.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/Writer.java
@@ -12,6 +12,7 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import io.netty.buffer.ByteBuf;
 import java.util.concurrent.CompletableFuture;
 
@@ -56,11 +57,11 @@ public interface Writer {
     /**
      * Copy a part of the object.
      *
-     * @param sourcePath source object path.
+     * @param s3ObjectMetadata source object metadata.
      * @param start      start position of the source object.
      * @param end        end position of the source object.
      */
-    void copyWrite(String sourcePath, long start, long end);
+    void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end);
 
     boolean hasBatchingPart();
 

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
@@ -12,6 +12,8 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.TestUtils;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
+import com.automq.stream.s3.metadata.S3ObjectType;
 import io.netty.buffer.ByteBuf;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -166,20 +168,27 @@ class MultiPartWriterTest {
             return CompletableFuture.completedFuture(responsePublisher);
         });
 
+        S3ObjectMetadata s3ObjectMetadata1 = new S3ObjectMetadata(1, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata2 = new S3ObjectMetadata(2, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata3 = new S3ObjectMetadata(3, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata4 = new S3ObjectMetadata(4, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata5 = new S3ObjectMetadata(5, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata6 = new S3ObjectMetadata(6, 200, S3ObjectType.STREAM);
+        S3ObjectMetadata s3ObjectMetadata7 = new S3ObjectMetadata(7, 200, S3ObjectType.STREAM);
         // case 2
-        writer.copyWrite("path-1", 0, 120);
+        writer.copyWrite(s3ObjectMetadata1, 0, 120);
         // case 1
-        writer.copyWrite("path-2", 20, 40);
+        writer.copyWrite(s3ObjectMetadata2, 20, 40);
         // case 3
-        writer.copyWrite("path-3", 60, 100);
+        writer.copyWrite(s3ObjectMetadata3, 60, 100);
         // case 4
-        writer.copyWrite("path-4", 140, 200);
+        writer.copyWrite(s3ObjectMetadata4, 140, 200);
         // case 1
-        writer.copyWrite("path-5", 200, 280);
+        writer.copyWrite(s3ObjectMetadata5, 200, 280);
         // case 5
-        writer.copyWrite("path-6", 400, 600);
+        writer.copyWrite(s3ObjectMetadata6, 400, 600);
         // last part
-        writer.copyWrite("path-7", 10, 20);
+        writer.copyWrite(s3ObjectMetadata7, 10, 20);
 
         writer.close().get();
         assertEquals(3, uploadPartRequests.size());
@@ -205,7 +214,7 @@ class MultiPartWriterTest {
         assertEquals(1, uploadPartCopyRequests.size());
         assertEquals("unit-test-bucket", uploadPartCopyRequests.get(0).sourceBucket());
         assertEquals("unit-test-bucket", uploadPartCopyRequests.get(0).destinationBucket());
-        assertEquals(List.of("path-1"), uploadPartCopyRequests.stream()
+        assertEquals(List.of(s3ObjectMetadata1.key()), uploadPartCopyRequests.stream()
             .map(UploadPartCopyRequest::sourceKey)
             .collect(Collectors.toList()));
         assertEquals("test-path-2", uploadPartCopyRequests.get(0).destinationKey());

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
@@ -12,6 +12,8 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.TestUtils;
+import com.automq.stream.s3.metadata.S3ObjectMetadata;
+import com.automq.stream.s3.metadata.S3ObjectType;
 import com.automq.stream.s3.network.ThrottleStrategy;
 import io.netty.buffer.ByteBuf;
 import java.util.concurrent.CompletableFuture;
@@ -84,7 +86,8 @@ public class ProxyWriterTest {
             .thenReturn(CompletableFuture.completedFuture(CompletedPart.builder().partNumber(1).eTag("etag1").build()));
         when(operator.completeMultipartUpload(eq("testpath"), eq("test_upload_id"), any())).thenReturn(CompletableFuture.completedFuture(null));
 
-        writer.copyWrite("test_src_path", 0, 15 * 1024 * 1024);
+        S3ObjectMetadata s3ObjectMetadata = new S3ObjectMetadata(1, 15 * 1024 * 1024, S3ObjectType.STREAM);
+        writer.copyWrite(s3ObjectMetadata, 0, 15 * 1024 * 1024);
         Assertions.assertTrue(writer.close().isDone());
 
         verify(operator, times(1)).uploadPartCopy(any(), any(), anyLong(), anyLong(), any(), anyInt());


### PR DESCRIPTION
* update copyWrite parameter to accept S3ObjectMetadata
* The logic of `ProxyWriterV2` and `MultiPartWriterV2` is essentially the same as that of `ProxyWriter` and `MultiPartWriterV2`, with the primary changes being:
    * Utilization of the new object storage abstraction `AbstractObjectStorage`.
    * Replacement of `Context` and `ThrottleStrategy` with `WriteOptions`.