### PR TITLE
feat(issue1134): prevent trivial scheduling

### DIFF
--- a/core/src/main/java/kafka/autobalancer/common/Action.java
+++ b/core/src/main/java/kafka/autobalancer/common/Action.java
@@ -58,6 +58,13 @@ public class Action {
         return srcBrokerId;
     }
 
+    public Action undo() {
+        if (type == ActionType.MOVE) {
+            return new Action(type, srcTp, destBrokerId, srcBrokerId);
+        }
+        return new Action(type, destTp, destBrokerId, srcBrokerId, srcTp);
+    }
+
     @Override
     public String toString() {
         return "Action{" +

--- a/core/src/main/java/kafka/autobalancer/config/AutoBalancerControllerConfig.java
+++ b/core/src/main/java/kafka/autobalancer/config/AutoBalancerControllerConfig.java
@@ -45,6 +45,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
     public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS = PREFIX + "execution.interval.ms";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS = PREFIX + "exclude.broker.ids";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS = PREFIX + "exclude.topics";
+    public static final String AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO = PREFIX + "network.in.trivial.change.ratio";
+    public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO = PREFIX + "network.out.trivial.change.ratio";
     /* Default values */
     public static final boolean DEFAULT_AUTO_BALANCER_CONTROLLER_ENABLE = false;
     public static final Integer DEFAULT_AUTO_BALANCER_CONTROLLER_METRICS_TOPIC_NUM_PARTITIONS_CONFIG = 1;
@@ -58,13 +60,15 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
             .add(NetworkOutUsageDistributionGoal.class.getName()).toString();
     public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_ANOMALY_DETECT_INTERVAL_MS = 60000;
     public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_USAGE_DISTRIBUTION_DETECT_THRESHOLD = 1024 * 1024;
-    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.2;
+    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.15;
     public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD = 1024 * 1024;
-    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.2;
+    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION = 0.15;
     public static final int DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY = 50;
     public static final long DEFAULT_AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS = 5000;
     public static final String DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS = "";
     public static final String DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS = "";
+    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO = 0.05;
+    public static final double DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO = 0.05;
     /* Documents */
     private static final String AUTO_BALANCER_CONTROLLER_METRICS_TOPIC_NUM_PARTITIONS_CONFIG_DOC = "The number of partitions of Auto Balancer metrics topic";
     private static final String AUTO_BALANCER_CONTROLLER_METRICS_TOPIC_RETENTION_MS_CONFIG_DOC = TopicConfig.RETENTION_MS_DOC;
@@ -86,6 +90,8 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
     public static final String AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS_DOC = "Time interval between each action batch in milliseconds";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS_DOC = "Broker ids that auto balancer will ignore during balancing";
     public static final String AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS_DOC = "Topics that auto balancer will ignore during balancing";
+    public static final String AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO_DOC = "The ratio of network inbound traffic change that is considered trivial. Trivial change will not be applied to the cluster";
+    public static final String AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO_DOC = "The ratio of network outbound traffic change that is considered trivial. Trivial change will not be applied to the cluster";
 
     public static final Set<String> RECONFIGURABLE_CONFIGS = Set.of(
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_ENABLE,
@@ -99,7 +105,9 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXECUTION_CONCURRENCY,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXECUTION_INTERVAL_MS,
             AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS,
-            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS
+            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS,
+            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO,
+            AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO
     );
 
     static {
@@ -157,7 +165,13 @@ public class AutoBalancerControllerConfig extends AbstractConfig {
                         AUTO_BALANCER_CONTROLLER_EXCLUDE_BROKER_IDS_DOC)
                 .define(AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS, ConfigDef.Type.LIST,
                         DEFAULT_AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS, ConfigDef.Importance.HIGH,
-                        AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS_DOC);
+                        AUTO_BALANCER_CONTROLLER_EXCLUDE_TOPICS_DOC)
+                .define(AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO, ConfigDef.Type.DOUBLE,
+                        DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO, ConfigDef.Importance.HIGH,
+                        AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO_DOC)
+                .define(AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO, ConfigDef.Type.DOUBLE,
+                    DEFAULT_AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO, ConfigDef.Importance.HIGH,
+                        AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO_DOC);
     }
 
     public AutoBalancerControllerConfig(Map<?, ?> originals, boolean doLog) {

--- a/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
+++ b/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
@@ -272,6 +272,7 @@ public class AnomalyDetector extends AbstractResumableService {
         List<Action> totalActions = new ArrayList<>();
         Map<String, Set<String>> goalsByGroup = GoalUtils.groupGoals(goals);
         List<Goal> optimizedGoals = new ArrayList<>();
+        goals.forEach(goal -> goal.initialize(goal.getEligibleBrokers(snapshot)));
         for (Goal goal : goals) {
             if (!isRunnable()) {
                 break;

--- a/core/src/main/java/kafka/autobalancer/goals/AbstractGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractGoal.java
@@ -32,6 +32,17 @@ import java.util.stream.Collectors;
 public abstract class AbstractGoal implements Goal {
     public static final Double NOT_ACCEPTABLE = -1.0;
     public static final double POSITIVE_ACTION_SCORE_THRESHOLD = 0.5;
+    protected boolean initialized = false;
+
+    @Override
+    public void initialize(Collection<BrokerUpdater.Broker> brokers) {
+        initialized = true;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     protected Optional<Action> tryMovePartitionOut(ClusterModelSnapshot cluster,
                                                    TopicPartitionReplicaUpdater.TopicPartitionReplica replica,
@@ -216,8 +227,7 @@ public abstract class AbstractGoal implements Goal {
         BrokerUpdater.Broker srcBrokerBefore = cluster.broker(action.getSrcBrokerId());
         BrokerUpdater.Broker destBrokerBefore = cluster.broker(action.getDestBrokerId());
 
-        if (!srcBrokerBefore.getMetricVersion().isGoalSupported(this)
-                || !destBrokerBefore.getMetricVersion().isGoalSupported(this)) {
+        if (!(isEligibleBroker(srcBrokerBefore) && isEligibleBroker(destBrokerBefore))) {
             return POSITIVE_ACTION_SCORE_THRESHOLD;
         }
 

--- a/core/src/main/java/kafka/autobalancer/goals/AbstractResourceUsageDistributionGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/AbstractResourceUsageDistributionGoal.java
@@ -23,8 +23,9 @@ public abstract class AbstractResourceUsageDistributionGoal extends AbstractReso
     private final Comparator<BrokerUpdater.Broker> highLoadComparator = Comparator.comparingDouble(b -> -b.loadValue(resource()));
     private final Comparator<BrokerUpdater.Broker> lowLoadComparator = Comparator.comparingDouble(b -> b.loadValue(resource()));
     protected Normalizer normalizer;
-    protected volatile long usageDetectThreshold;
-    protected volatile double usageAvgDeviationRatio;
+    protected long usageDetectThreshold;
+    protected double usageAvgDeviationRatio;
+    protected double usageTrivialRatio;
     protected double usageAvg;
     protected double usageAvgDeviation;
     protected double usageDistLowerBound;
@@ -32,6 +33,7 @@ public abstract class AbstractResourceUsageDistributionGoal extends AbstractReso
 
     @Override
     public void initialize(Collection<BrokerUpdater.Broker> brokers) {
+        super.initialize(brokers);
         byte resource = resource();
         usageAvg = brokers.stream().mapToDouble(e -> e.loadValue(resource)).sum() / brokers.size();
         usageAvgDeviation = usageAvg * usageAvgDeviationRatio;
@@ -89,4 +91,9 @@ public abstract class AbstractResourceUsageDistributionGoal extends AbstractReso
     }
 
     public abstract double linearNormalizerThreshold();
+
+    @Override
+    public boolean isTrivialLoadChange(BrokerUpdater.Broker broker, double loadChange) {
+        return Math.abs(loadChange) < usageTrivialRatio * usageAvg;
+    }
 }

--- a/core/src/main/java/kafka/autobalancer/goals/NetworkInUsageDistributionGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/NetworkInUsageDistributionGoal.java
@@ -39,6 +39,7 @@ public class NetworkInUsageDistributionGoal extends AbstractNetworkUsageDistribu
         this.usageDetectThreshold = controllerConfig.getLong(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_IN_USAGE_DISTRIBUTION_DETECT_THRESHOLD);
         this.usageAvgDeviationRatio = Math.max(0.0, Math.min(1.0,
                 controllerConfig.getDouble(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_IN_DISTRIBUTION_DETECT_AVG_DEVIATION)));
+        this.usageTrivialRatio = controllerConfig.getDouble(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_IN_TRIVIAL_CHANGE_RATIO);
     }
 
     @Override

--- a/core/src/main/java/kafka/autobalancer/goals/NetworkOutUsageDistributionGoal.java
+++ b/core/src/main/java/kafka/autobalancer/goals/NetworkOutUsageDistributionGoal.java
@@ -39,6 +39,7 @@ public class NetworkOutUsageDistributionGoal extends AbstractNetworkUsageDistrib
         this.usageDetectThreshold = controllerConfig.getLong(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_USAGE_DISTRIBUTION_DETECT_THRESHOLD);
         this.usageAvgDeviationRatio = Math.max(0.0, Math.min(1.0,
                 controllerConfig.getDouble(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_DISTRIBUTION_DETECT_AVG_DEVIATION)));
+        this.usageTrivialRatio = controllerConfig.getDouble(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_NETWORK_OUT_TRIVIAL_CHANGE_RATIO);
     }
 
     @Override

--- a/core/src/main/java/kafka/autobalancer/model/ClusterModelSnapshot.java
+++ b/core/src/main/java/kafka/autobalancer/model/ClusterModelSnapshot.java
@@ -89,6 +89,11 @@ public class ClusterModelSnapshot {
         }
     }
 
+    public void undoAction(Action action) {
+        Action undoAction = action.undo();
+        applyAction(undoAction);
+    }
+
     public void markSlowBrokers() {
         Map<BrokerUpdater.Broker, Map<Byte, Snapshot>> brokerMetricsValues = new HashMap<>();
         Map<Byte, Map<BrokerUpdater.Broker, Snapshot>> metricsValues = new HashMap<>();

--- a/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
+++ b/core/src/test/java/kafka/autobalancer/detector/AnomalyDetectorTest.java
@@ -328,10 +328,10 @@ public class AnomalyDetectorTest {
         Assertions.assertEquals(2, detector.goals().size());
         Assertions.assertEquals(NetworkInUsageDistributionGoal.class, detector.goals().get(0).getClass());
         Assertions.assertEquals(1024 * 1024, ((AbstractResourceUsageDistributionGoal) detector.goals().get(0)).getUsageDetectThreshold());
-        Assertions.assertEquals(0.2, ((AbstractResourceUsageDistributionGoal) detector.goals().get(0)).getUsageAvgDeviationRatio());
+        Assertions.assertEquals(0.15, ((AbstractResourceUsageDistributionGoal) detector.goals().get(0)).getUsageAvgDeviationRatio());
         Assertions.assertEquals(NetworkOutUsageDistributionGoal.class, detector.goals().get(1).getClass());
         Assertions.assertEquals(1024 * 1024, ((AbstractResourceUsageDistributionGoal) detector.goals().get(1)).getUsageDetectThreshold());
-        Assertions.assertEquals(0.2, ((AbstractResourceUsageDistributionGoal) detector.goals().get(1)).getUsageAvgDeviationRatio());
+        Assertions.assertEquals(0.15, ((AbstractResourceUsageDistributionGoal) detector.goals().get(1)).getUsageAvgDeviationRatio());
 
         detector.reconfigure(Map.of(
                 AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_GOALS, new StringJoiner(",")


### PR DESCRIPTION
## What is trivial scheduling?
A trivial scheduling involves of a series of partition reassignments that minimally impacts the broker load, which can be easily affect by load fluctuation.

## How to identify a trivial scheduling
After optimizing each broker for a specified goal, collect the overall load impact for that broker from all actions derived from the previous optimization and check if the ratio of the load change and load avg is above the trivial ratio threshold (0.05 by default), and undo those actions which have been considered as trivial 

#1134 