### PR TITLE
fix(s3stream): ensure wal header shutdown type UNGRACEFULLY when startup

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -292,6 +292,8 @@ public class BlockWALService implements WriteAheadLog {
         } else {
             LOGGER.info("read WALHeader from WAL: {}", header);
         }
+
+        header.setShutdownType(ShutdownType.UNGRACEFULLY);
         walHeaderReady(header);
 
         started.set(true);


### PR DESCRIPTION
current code if wal sliding window not expand 
the wal header won't flush to UNGRACEFULLY



