### PR TITLE
feat(s3stream): support config MAJOR_V1 skip compact small object

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -133,7 +133,7 @@ public class StreamObjectCompactor {
         return object -> {
             ObjectAttributes.Type objectType = ObjectAttributes.from(object.attributes()).type();
             if (!includeCompositeObject && objectType == Composite) {
-                return true;
+                return false;
             }
 
             // MAJOR_V1 compaction won't compact small object into composite object.

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/DeleteObjectsAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/DeleteObjectsAccumulatorTest.java
@@ -262,7 +262,7 @@ public class DeleteObjectsAccumulatorTest {
                     CompletableFuture<Void> completableFuture = new CompletableFuture<>();
 
                     // add timeout for check request can be done.
-                    completableFuture.orTimeout(100, TimeUnit.MILLISECONDS);
+                    completableFuture.orTimeout(2, TimeUnit.MINUTES);
                     allIoCf.add(completableFuture);
 
                     List<ObjectStorage.ObjectPath> objectPaths =


### PR DESCRIPTION
1. support MAJOR_V1 compaction skip object which size is below the MINOR_V1_COMPACTION_SIZE.
2. default skip logic is disabled.