### PR TITLE
feat(core): optimize LoadAwarePartitionLeaderSelector

### DIFF
--- a/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
+++ b/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
@@ -158,6 +158,7 @@ public class ClusterModel {
             long now = System.currentTimeMillis();
             for (Map.Entry<Integer, Map<TopicPartition, TopicPartitionReplicaUpdater>> entry : brokerReplicaMap.entrySet()) {
                 int brokerId = entry.getKey();
+                brokerLoads.put(brokerId, 0.0);
                 for (Map.Entry<TopicPartition, TopicPartitionReplicaUpdater> tpEntry : entry.getValue().entrySet()) {
                     TopicPartition tp = tpEntry.getKey();
                     TopicPartitionReplicaUpdater replicaUpdater = tpEntry.getValue();

--- a/metadata/src/main/java/org/apache/kafka/controller/es/ClusterStats.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/es/ClusterStats.java
@@ -11,6 +11,7 @@
 
 package org.apache.kafka.controller.es;
 
+import java.util.HashMap;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Map;
@@ -21,8 +22,8 @@ public class ClusterStats {
     private static final long EXPIRE_TIME_MS = 60000; // 1 minute
     private volatile static ClusterStats instance = null;
     private volatile Set<Integer> excludedBrokers;
-    private volatile Map<Integer, Double> brokerLoads;
-    private volatile Map<TopicPartition, Double> partitionLoads;
+    private volatile Map<Integer, Double> brokerLoads = new HashMap<>();
+    private volatile Map<TopicPartition, Double> partitionLoads = new HashMap<>();
     private volatile long lastUpdateTime = 0;
 
     private ClusterStats() {

--- a/metadata/src/test/java/org/apache/kafka/controller/es/LoadAwarePartitionLeaderSelectorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/es/LoadAwarePartitionLeaderSelectorTest.java
@@ -12,6 +12,7 @@
 package org.apache.kafka.controller.es;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.server.util.MockRandom;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,102 +29,80 @@ public class LoadAwarePartitionLeaderSelectorTest {
         List<Integer> aliveBrokers = List.of(0, 1, 2, 3, 4, 5);
         Set<Integer> brokerSet = new HashSet<>(aliveBrokers);
         int brokerToRemove = 5;
-        LoadAwarePartitionLeaderSelector loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(aliveBrokers, broker -> broker != brokerToRemove);
+        MockRandom random = new MockRandom();
+        LoadAwarePartitionLeaderSelector loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(random,
+            aliveBrokers, broker -> broker != brokerToRemove);
 
         // fallback to random selector
-        int brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 0)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertTrue(brokerId != brokerToRemove);
+        setUpCluster();
+        Map<Integer, Double> brokerLoads = new HashMap<>();
+        randomSelect(loadAwarePartitionLeaderSelector, 2000, brokerSet, brokerToRemove, brokerLoads);
+        Assertions.assertEquals(4000, brokerLoads.get(0));
+        Assertions.assertEquals(4000, brokerLoads.get(1));
+        Assertions.assertEquals(4000, brokerLoads.get(2));
+        Assertions.assertEquals(4000, brokerLoads.get(3));
+        Assertions.assertEquals(4000, brokerLoads.get(4));
 
         // load aware selector
-        Map<Integer, Double> brokerLoads = setUpCluster();
-        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(aliveBrokers, broker -> broker != brokerToRemove);
-
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 0)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 1)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 2)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(1, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 3)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-
-        Assertions.assertEquals(35.0, brokerLoads.get(0));
-        Assertions.assertEquals(25.0, brokerLoads.get(1));
-        Assertions.assertEquals(20.0, brokerLoads.get(2));
-        Assertions.assertEquals(30.0, brokerLoads.get(3));
-        Assertions.assertEquals(40.0, brokerLoads.get(4));
-        Assertions.assertEquals(50.0, brokerLoads.get(5));
+        brokerLoads = setUpCluster();
+        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(random, aliveBrokers, broker -> broker != brokerToRemove);
+        randomSelect(loadAwarePartitionLeaderSelector, 2000, brokerSet, brokerToRemove, brokerLoads);
+        Assertions.assertEquals(5990, brokerLoads.get(0));
+        Assertions.assertEquals(7660, brokerLoads.get(1));
+        Assertions.assertEquals(6720, brokerLoads.get(2));
+        Assertions.assertEquals(7460, brokerLoads.get(3));
+        Assertions.assertEquals(6170, brokerLoads.get(4));
 
         // test missing broker
         brokerLoads = setUpCluster();
         brokerLoads.remove(1);
         ClusterStats.getInstance().updateBrokerLoads(brokerLoads);
-        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(aliveBrokers, broker -> broker != brokerToRemove);
-
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 0)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 1)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 2)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 3)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(2, brokerId);
-
-        Assertions.assertEquals(30.0, brokerLoads.get(0));
-        Assertions.assertEquals(40.0, brokerLoads.get(2));
-        Assertions.assertEquals(30.0, brokerLoads.get(3));
-        Assertions.assertEquals(40.0, brokerLoads.get(4));
-        Assertions.assertEquals(50.0, brokerLoads.get(5));
-
+        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(random, aliveBrokers, broker -> broker != brokerToRemove);
+        randomSelect(loadAwarePartitionLeaderSelector, 2000, brokerSet, brokerToRemove, brokerLoads);
+        Assertions.assertEquals(6840, brokerLoads.get(0));
+        Assertions.assertEquals(7280, brokerLoads.get(2));
+        Assertions.assertEquals(7950, brokerLoads.get(3));
+        Assertions.assertEquals(6930, brokerLoads.get(4));
 
         // tests exclude broker
         brokerLoads = setUpCluster();
         ClusterStats.getInstance().updateExcludedBrokers(Set.of(1));
-        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(aliveBrokers, broker -> broker != brokerToRemove);
+        loadAwarePartitionLeaderSelector = new LoadAwarePartitionLeaderSelector(random, aliveBrokers, broker -> broker != brokerToRemove);
+        randomSelect(loadAwarePartitionLeaderSelector, 2000, brokerSet, brokerToRemove, brokerLoads);
+        Assertions.assertEquals(6970, brokerLoads.get(0));
+        Assertions.assertEquals(5000, brokerLoads.get(1));
+        Assertions.assertEquals(7210, brokerLoads.get(2));
+        Assertions.assertEquals(7820, brokerLoads.get(3));
+        Assertions.assertEquals(7000, brokerLoads.get(4));
+    }
 
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 0)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 1)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 2)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(0, brokerId);
-        brokerId = loadAwarePartitionLeaderSelector.select(new TopicPartition("topic", 3)).orElse(-1);
-        Assertions.assertTrue(brokerSet.contains(brokerId));
-        Assertions.assertEquals(2, brokerId);
-
-        Assertions.assertEquals(30.0, brokerLoads.get(0));
-        Assertions.assertEquals(10.0, brokerLoads.get(1));
-        Assertions.assertEquals(40.0, brokerLoads.get(2));
-        Assertions.assertEquals(30.0, brokerLoads.get(3));
-        Assertions.assertEquals(40.0, brokerLoads.get(4));
-        Assertions.assertEquals(50.0, brokerLoads.get(5));
+    private void randomSelect(LoadAwarePartitionLeaderSelector selector, int count, Set<Integer> brokerSet,
+        int brokerToRemove, Map<Integer, Double> brokerLoads) {
+        for (int i = 0; i < count; i++) {
+            TopicPartition tp = new TopicPartition("topic", 0);
+            int brokerId = selector.select(tp).orElse(-1);
+            double partitionLoad = ClusterStats.getInstance().partitionLoad(tp);
+            brokerLoads.compute(brokerId, (k, v) -> {
+                if (v == null) {
+                    return partitionLoad;
+                }
+                return v + partitionLoad;
+            });
+            Assertions.assertTrue(brokerSet.contains(brokerId));
+            Assertions.assertTrue(brokerId != brokerToRemove);
+        }
     }
 
     private Map<Integer, Double> setUpCluster() {
         Map<Integer, Double> brokerLoads = new HashMap<>();
         brokerLoads.put(0, 0.0);
-        brokerLoads.put(1, 10.0);
-        brokerLoads.put(2, 20.0);
-        brokerLoads.put(3, 30.0);
-        brokerLoads.put(4, 40.0);
-        brokerLoads.put(5, 50.0);
+        brokerLoads.put(1, 5000.0);
+        brokerLoads.put(2, 3000.0);
+        brokerLoads.put(3, 4000.0);
+        brokerLoads.put(4, 2000.0);
+        brokerLoads.put(5, 0.0);
         Map<TopicPartition, Double> partitionLoads = Map.of(
-                new TopicPartition("topic", 0), 5.0,
-                new TopicPartition("topic", 1), 10.0,
-                new TopicPartition("topic", 2), 15.0,
-                new TopicPartition("topic", 3), 20.0
+            new TopicPartition("topic", 0), 10.0
         );
         ClusterStats.getInstance().updateBrokerLoads(brokerLoads);
         ClusterStats.getInstance().updatePartitionLoads(partitionLoads);

--- a/server-common/src/main/java/org/apache/kafka/common/WeightedRandomList.java
+++ b/server-common/src/main/java/org/apache/kafka/common/WeightedRandomList.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class WeightedRandomList<T> {
+    private final List<Entity<T>> entityList = new ArrayList<>();
+    private final List<Double> cumulativeNormalizedWeights = new ArrayList<>();
+    private final Random r;
+
+    public WeightedRandomList() {
+        this(new Random());
+    }
+
+    public WeightedRandomList(Random r) {
+        this.r = r;
+    }
+
+    public void add(Entity<T> entity) {
+        entityList.add(entity);
+    }
+
+    public void update() {
+        double totalWeight = 0.0;
+        List<Double> cumulativeWeights = new ArrayList<>();
+        for (Entity<T> entity : entityList) {
+            totalWeight += entity.weight();
+            cumulativeWeights.add(totalWeight);
+        }
+        cumulativeNormalizedWeights.clear();
+        for (double cumulativeWeight : cumulativeWeights) {
+            cumulativeNormalizedWeights.add(cumulativeWeight / totalWeight);
+        }
+    }
+
+    public Entity<T> next() {
+        return entityList.get(nextIndex(this.r.nextDouble()));
+    }
+
+    private int nextIndex(double r) {
+        if (r < 0.0 || r > 1.0) {
+            throw new IllegalArgumentException("r must be in [0.0, 1.0]");
+        }
+        int result = Collections.binarySearch(cumulativeNormalizedWeights, r);
+        return Math.max(0, Math.min(entityList.size() - 1, result < 0 ? -result - 1 : result));
+    }
+
+    public int size() {
+        return entityList.size();
+    }
+
+    public static class Entity<T> {
+        private final T value;
+        private double weight;
+
+        public Entity(T value, double weight) {
+            this.value = value;
+            this.weight = weight;
+        }
+
+        public T entity() {
+            return value;
+        }
+
+        public void setWeight(double weight) {
+            this.weight = weight;
+        }
+
+        public double weight() {
+            return weight;
+        }
+    }
+}


### PR DESCRIPTION
assign partitions to brokers based on a probability that is inversely proportional to the broker's load to prevent over-concentrated distribution.
