### PR TITLE
feat(core): add quota metrics into jmx metrics mapping

### DIFF
--- a/core/src/main/resources/jmx/rules/broker.yaml
+++ b/core/src/main/resources/jmx/rules/broker.yaml
@@ -356,3 +356,39 @@ rules:
         metric: kafka.group.empty.count
         type: gauge
         desc: The number of groups that have no more members
+
+  # Broker Quota Metrics
+  - bean: kafka.server:type=*,domain=broker,nodeId=*
+    metricAttribute:
+      # Available type: Request, Produce, Fetch
+      type: param(type)
+    mapping:
+      broker-value-rate:
+        metric: kafka.broker.quota.value.record
+        type: gauge
+        desc: The number of value that quota manager records
+      broker-throttle-time:
+        metric: kafka.broker.quota.throttle.time
+        type: gauge
+        desc: The average throttle-time
+
+  - bean: kafka.server:type=socket-server-metrics
+    mapping:
+      broker-connection-accept-rate:
+        metric: kafka.broker.connection.accept.rate
+        type: gauge
+        desc: The connection creation rate pre broker
+
+  - bean: kafka.server:type=socket-server-metrics,listener=*
+    metricAttribute:
+      # listener name
+      listener: param(listener)
+    mapping:
+      connection-accept-rate:
+        metric: kafka.listener.connection.accept.rate
+        type: gauge
+        desc: The connection creation rate pre listener
+      connection-accept-throttle-time:
+        metric: kafka.listener.connection.accept.throttle.time
+        type: gauge
+        desc: The average throttle-time pre listener

--- a/core/src/main/scala/kafka/server/streamaspect/BrokerQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/BrokerQuotaManager.scala
@@ -176,13 +176,8 @@ class BrokerQuotaManager(private val config: BrokerQuotaManagerConfig,
   }
 
   protected def clientQuotaMetricName(quotaType: QuotaType, quotaMetricTags: Map[String, String]): MetricName = {
-    if (quotaType == QuotaType.Request) {
-      metrics.metricName("broker-request-rate", QuotaType.Request.toString,
-        "Tracking request-rate per broker", quotaMetricTags.asJava)
-    } else {
-      metrics.metricName("broker-byte-rate", quotaType.toString,
-        "Tracking byte-rate per broker", quotaMetricTags.asJava)
-    }
+    metrics.metricName("broker-value-rate", quotaType.toString,
+      "Tracking value-rate per broker", quotaMetricTags.asJava)
   }
 
   protected def throttleMetricName(quotaType: QuotaType, quotaMetricTags: Map[String, String]): MetricName = {


### PR DESCRIPTION
Export five new metrics:

- kafka_broker_quota_value_record
- kafka_broker_quota_throttle_time
- kafka_broker_connection_accept_rate
- kafka_listener_connection_accept_rate
- kafka_listener_connection_accept_throttle_time