### PR TITLE
perf(s3stream): increase the object overhead of `StreamRecordBatch`

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.automq.stream.s3.cache.LogCache.StreamRange.NOOP_OFFSET;
-import static com.automq.stream.s3.model.StreamRecordBatch.OBJECT_OVERHEAD;
 import static com.automq.stream.utils.FutureUtil.suppress;
 
 public class LogCache {
@@ -86,7 +85,7 @@ public class LogCache {
     public boolean put(StreamRecordBatch recordBatch) {
         long startTime = System.nanoTime();
         tryRealFree();
-        size.addAndGet(recordBatch.size() + OBJECT_OVERHEAD);
+        size.addAndGet(recordBatch.occupiedSize());
         readLock.lock();
         boolean full;
         try {
@@ -341,8 +340,7 @@ public class LogCache {
                 cache.add(recordBatch);
                 return cache;
             });
-            int recordSize = recordBatch.size();
-            return size.addAndGet(recordSize + OBJECT_OVERHEAD) >= maxSize || map.size() >= maxStreamCount;
+            return size.addAndGet(recordBatch.occupiedSize()) >= maxSize || map.size() >= maxStreamCount;
         }
 
         public List<StreamRecordBatch> get(long streamId, long startOffset, long endOffset, int maxBytes) {

--- a/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
@@ -16,7 +16,7 @@ import com.automq.stream.utils.biniarysearch.ComparableItem;
 import io.netty.buffer.ByteBuf;
 
 public class StreamRecordBatch implements Comparable<StreamRecordBatch>, ComparableItem<Long> {
-    public static final int OBJECT_OVERHEAD = 48 /* fields */ + 48 /* ByteBuf payload */ + 48 /* ByteBuf encoded */;
+    private static final int OBJECT_OVERHEAD = 48 /* fields */ + 48 /* ByteBuf payload */ + 48 /* ByteBuf encoded */;
     private final long streamId;
     private final long epoch;
     private final long baseOffset;
@@ -69,6 +69,10 @@ public class StreamRecordBatch implements Comparable<StreamRecordBatch>, Compara
 
     public int size() {
         return payload.readableBytes();
+    }
+
+    public int occupiedSize() {
+        return size() + OBJECT_OVERHEAD;
     }
 
     public void retain() {

--- a/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
@@ -16,7 +16,7 @@ import com.automq.stream.utils.biniarysearch.ComparableItem;
 import io.netty.buffer.ByteBuf;
 
 public class StreamRecordBatch implements Comparable<StreamRecordBatch>, ComparableItem<Long> {
-    public static final int OBJECT_OVERHEAD = 52;
+    public static final int OBJECT_OVERHEAD = 48 /* fields */ + 48 /* ByteBuf payload */ + 48 /* ByteBuf encoded */;
     private final long streamId;
     private final long epoch;
     private final long baseOffset;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eff45fef-ec54-42db-9fc5-ec3499131363)
