### PR TITLE
feat(s3stream): support burst upload for upload WAL task to reduce failover time.

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
@@ -654,12 +654,12 @@ object ElasticLog extends Logging {
                 stream
             } else {
                 val metaStreamId = Unpooled.wrappedBuffer(value.get()).readLong()
-                awaitStreamReadyForOpen(openStreamChecker, topicId.get, topicPartition.partition(), metaStreamId, leaderEpoch, logIdent = logIdent)
+                val awaitCostMs = awaitStreamReadyForOpen(openStreamChecker, topicId.get, topicPartition.partition(), metaStreamId, leaderEpoch, logIdent = logIdent)
                 // open partition meta stream
                 val stream = client.streamClient().openStream(metaStreamId, OpenStreamOptions.builder().epoch(leaderEpoch).tags(streamTags).build())
                     .thenApply(stream => new MetaStream(stream, META_SCHEDULE_EXECUTOR, logIdent))
                     .get()
-                info(s"${logIdent}opened existing meta stream: streamId=$metaStreamId")
+                info(s"${logIdent}opened existing meta stream: streamId=$metaStreamId awaitCostMs=${TimeUnit.NANOSECONDS.toMillis(awaitCostMs)} ms")
                 stream
             }
             // fetch metas(log meta, producer snapshot, partition meta, ...) from meta stream
@@ -891,11 +891,12 @@ object ElasticLog extends Logging {
         resultCf
     }
 
-    private def awaitStreamReadyForOpen(checker: OpenStreamChecker, topicId: Uuid, partition: Int, streamId: Long, epoch: Long, logIdent: String): Unit = {
+    private def awaitStreamReadyForOpen(checker: OpenStreamChecker, topicId: Uuid, partition: Int, streamId: Long, epoch: Long, logIdent: String): Long = {
+      val now = System.nanoTime()
       var round = 0
       while(true) {
         if (checker.check(topicId, partition, streamId, epoch)) {
-          return
+          return System.nanoTime() - now
         }
         round += 1
         if (round % 10 == 0) {
@@ -903,5 +904,6 @@ object ElasticLog extends Logging {
         }
         Thread.sleep(100)
       }
+      System.nanoTime() - now
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/DeltaWALUploadTask.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/DeltaWALUploadTask.java
@@ -58,8 +58,6 @@ public class DeltaWALUploadTask {
     private volatile CommitStreamSetObjectRequest commitStreamSetObjectRequest;
     private volatile boolean burst = false;
 
-    public S3Storage.DeltaWALUploadTaskContext ctx;
-
     public DeltaWALUploadTask(Config config, Map<Long, List<StreamRecordBatch>> streamRecordsMap,
                               ObjectManager objectManager, ObjectStorage objectStorage,
                               ExecutorService executor, boolean forceSplit, double rate) {
@@ -153,8 +151,7 @@ public class DeltaWALUploadTask {
                     }
                 }));
             } else {
-                streamSetWriteCfList.add(acquireLimiter(streamSize)
-                    .thenAccept(nil -> streamSetObject.write(streamId, streamRecords)));
+                streamSetWriteCfList.add(acquireLimiter(streamSize).thenAccept(nil -> streamSetObject.write(streamId, streamRecords)));
                 long startOffset = streamRecords.get(0).getBaseOffset();
                 long endOffset = streamRecords.get(streamRecords.size() - 1).getLastOffset();
                 request.addStreamRange(new ObjectStreamRange(streamId, -1L, startOffset, endOffset, streamSize));

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -80,10 +80,10 @@ import static com.automq.stream.utils.FutureUtil.suppress;
 public class S3Storage implements Storage {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Storage.class);
     private static final FastReadFailFastException FAST_READ_FAIL_FAST_EXCEPTION = new FastReadFailFastException();
-    private static boolean ENABLE_BURST_FORCE_UPLOAD = true;
+    private static boolean enableBurstForceUpload = true;
 
     static {
-        ENABLE_BURST_FORCE_UPLOAD = Systems.getEnvInt("AUTOMQ_ENABLE_BURST_FORCE_UPLOAD", 1) == 1;
+        enableBurstForceUpload = Systems.getEnvInt("AUTOMQ_ENABLE_BURST_FORCE_UPLOAD", 1) == 1;
     }
 
     private static final int NUM_STREAM_CALLBACK_LOCKS = 128;
@@ -602,7 +602,7 @@ public class S3Storage implements Storage {
         final long startTime = System.nanoTime();
         CompletableFuture<Void> cf = new CompletableFuture<>();
         // Wait for a while to group force upload tasks.
-        forceUploadTicker.tick(ENABLE_BURST_FORCE_UPLOAD && streamId != LogCache.MATCH_ALL_STREAMS).whenComplete((nil, ex) -> {
+        forceUploadTicker.tick(enableBurstForceUpload && streamId != LogCache.MATCH_ALL_STREAMS).whenComplete((nil, ex) -> {
             StorageOperationStats.getInstance().forceUploadWALAwaitStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
             uploadDeltaWAL(streamId, true);
             // Wait for all tasks contains streamId complete.
@@ -700,7 +700,7 @@ public class S3Storage implements Storage {
         long size = context.cache.size();
         pendingUploadBytes.addAndGet(size);
 
-        if (ENABLE_BURST_FORCE_UPLOAD && context.force) {
+        if (enableBurstForceUpload && context.force) {
             forceUploadTaskId.set(context.id);
 
             // trigger previous task burst.

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -755,7 +755,8 @@ public class S3Storage implements Storage {
             StorageOperationStats.getInstance().uploadWALPrepareStats.record(context.timer.elapsedAs(TimeUnit.NANOSECONDS));
             // 1. poll out current task and trigger upload.
             DeltaWALUploadTaskContext peek = walPrepareQueue.poll();
-            Objects.requireNonNull(peek).task.upload().thenAccept(nil2 -> StorageOperationStats.getInstance());
+            Objects.requireNonNull(peek).task.upload().thenAccept(nil2 -> StorageOperationStats.getInstance()
+                .uploadWALUploadStats.record(context.timer.elapsedAs(TimeUnit.NANOSECONDS)));
             // 2. add task to commit queue.
             boolean walObjectCommitQueueEmpty = walCommitQueue.isEmpty();
             walCommitQueue.add(peek);

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -111,7 +111,7 @@ public class S3Storage implements Storage {
      *
      * @see #forceUpload
      */
-    private final FutureTicker forceUploadTicker = new FutureTicker(500, TimeUnit.MILLISECONDS, backgroundExecutor);
+    private final FutureTicker forceUploadTicker = new FutureTicker(100, TimeUnit.MILLISECONDS, backgroundExecutor);
     private final Queue<WalWriteRequest> backoffRecords = new LinkedBlockingQueue<>();
     private final ScheduledFuture<?> drainBackoffTask;
     private final StreamManager streamManager;
@@ -600,7 +600,7 @@ public class S3Storage implements Storage {
         final long startTime = System.nanoTime();
         CompletableFuture<Void> cf = new CompletableFuture<>();
         // Wait for a while to group force upload tasks.
-        forceUploadTicker.tick(enableBurstForceUpload && streamId != LogCache.MATCH_ALL_STREAMS).whenComplete((nil, ex) -> {
+        forceUploadTicker.tick().whenComplete((nil, ex) -> {
             StorageOperationStats.getInstance().forceUploadWALAwaitStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
             uploadDeltaWAL(streamId, true);
             // Wait for all tasks contains streamId complete.

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -35,7 +35,6 @@ import com.automq.stream.s3.wal.WriteAheadLog;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
 import com.automq.stream.utils.FutureTicker;
 import com.automq.stream.utils.FutureUtil;
-import com.automq.stream.utils.Systems;
 import com.automq.stream.utils.ThreadUtils;
 import com.automq.stream.utils.Threads;
 import io.netty.buffer.ByteBuf;
@@ -80,11 +79,6 @@ import static com.automq.stream.utils.FutureUtil.suppress;
 public class S3Storage implements Storage {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Storage.class);
     private static final FastReadFailFastException FAST_READ_FAIL_FAST_EXCEPTION = new FastReadFailFastException();
-    private static boolean enableBurstForceUpload = true;
-
-    static {
-        enableBurstForceUpload = Systems.getEnvInt("AUTOMQ_ENABLE_BURST_FORCE_UPLOAD", 1) == 1;
-    }
 
     private static final int NUM_STREAM_CALLBACK_LOCKS = 128;
     private final long maxDeltaWALCacheSize;
@@ -698,7 +692,7 @@ public class S3Storage implements Storage {
         long size = context.cache.size();
         pendingUploadBytes.addAndGet(size);
 
-        if (enableBurstForceUpload && context.force) {
+        if (context.force) {
             // trigger previous task burst.
             inflightWALUploadTasks.forEach(ctx -> {
                 ctx.force = true;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -87,6 +87,7 @@ public class S3StreamMetricsConstant {
     public static final String P99_METRIC_NAME_SUFFIX = "_99p";
     public static final String MAX_METRIC_NAME_SUFFIX = "_max";
     public static final String WAL_START_OFFSET = "wal_start_offset";
+    public static final String WAL_PENDING_UPLOAD_BYTES = "wal_pending_upload_bytes";
     public static final String WAL_TRIMMED_OFFSET = "wal_trimmed_offset";
     public static final String DELTA_WAL_CACHE_SIZE = "delta_wal_cache_size";
     public static final String BLOCK_CACHE_SIZE = "block_cache_size";

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -65,6 +65,7 @@ public class S3StreamMetricsManager {
     private static HistogramInstrument getIndexTime;
     private static HistogramInstrument readBlockCacheTime;
     private static ObservableLongGauge deltaWalStartOffset = new NoopObservableLongGauge();
+    private static ObservableLongGauge pendUploadWalBytes = new NoopObservableLongGauge();
     private static ObservableLongGauge deltaWalTrimmedOffset = new NoopObservableLongGauge();
     private static ObservableLongGauge deltaWalCacheSize = new NoopObservableLongGauge();
     private static ObservableLongGauge blockCacheSize = new NoopObservableLongGauge();
@@ -84,6 +85,7 @@ public class S3StreamMetricsManager {
     private static Supplier<Integer> networkOutboundLimiterQueueSizeSupplier = () -> 0;
     private static Supplier<Integer> availableInflightReadAheadSizeSupplier = () -> 0;
     private static Supplier<Long> deltaWalStartOffsetSupplier = () -> 0L;
+    private static Supplier<Long> deltaWalPendingUploadBytesSupplier = () -> 0L;
     private static Supplier<Long> deltaWalTrimmedOffsetSupplier = () -> 0L;
     private static Supplier<Long> deltaWALCacheSizeSupplier = () -> 0L;
     private static Supplier<Long> blockCacheSizeSupplier = () -> 0L;
@@ -201,6 +203,14 @@ public class S3StreamMetricsManager {
                     result.record(deltaWalStartOffsetSupplier.get(), metricsConfig.getBaseAttributes());
                 }
             });
+
+        pendUploadWalBytes = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.WAL_PENDING_UPLOAD_BYTES)
+            .setDescription("Delta WAL pending upload bytes")
+            .ofLongs()
+            .buildWithCallback(result -> {
+                result.record(deltaWalPendingUploadBytesSupplier.get(), metricsConfig.getBaseAttributes());
+            });
+
         deltaWalTrimmedOffset = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.WAL_TRIMMED_OFFSET)
             .setDescription("Delta WAL trimmed offset")
             .ofLongs()
@@ -338,6 +348,10 @@ public class S3StreamMetricsManager {
         Supplier<Long> deltaWalTrimmedOffsetSupplier) {
         S3StreamMetricsManager.deltaWalStartOffsetSupplier = deltaWalStartOffsetSupplier;
         S3StreamMetricsManager.deltaWalTrimmedOffsetSupplier = deltaWalTrimmedOffsetSupplier;
+    }
+
+    public static void registerDeltaWalPendingUploadBytesSupplier(Supplier<Long> deltaWalPendingUploadBytesSupplier) {
+        S3StreamMetricsManager.deltaWalPendingUploadBytesSupplier = deltaWalPendingUploadBytesSupplier;
     }
 
     public static void registerDeltaWalCacheSizeSupplier(Supplier<Long> deltaWalCacheSizeSupplier) {

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/StorageOperationStats.java
@@ -48,17 +48,17 @@ public class StorageOperationStats {
     public final HistogramMetric appendLogCacheFullStats = S3StreamMetricsManager
             .buildOperationMetric(MetricsLevel.INFO, S3Operation.APPEND_STORAGE_LOG_CACHE_FULL);
     public final HistogramMetric uploadWALPrepareStats = S3StreamMetricsManager
-            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_PREPARE);
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.UPLOAD_WAL_PREPARE);
     public final HistogramMetric uploadWALUploadStats = S3StreamMetricsManager
-            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_UPLOAD);
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.UPLOAD_WAL_UPLOAD);
     public final HistogramMetric uploadWALCommitStats = S3StreamMetricsManager
-            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.UPLOAD_WAL_COMMIT);
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.UPLOAD_WAL_COMMIT);
     public final HistogramMetric uploadWALCompleteStats = S3StreamMetricsManager
             .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.UPLOAD_WAL_COMPLETE);
     public final HistogramMetric forceUploadWALAwaitStats = S3StreamMetricsManager
-            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_AWAIT);
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.FORCE_UPLOAD_WAL_AWAIT);
     public final HistogramMetric forceUploadWALCompleteStats = S3StreamMetricsManager
-            .buildStageOperationMetric(MetricsLevel.DEBUG, S3Stage.FORCE_UPLOAD_WAL_COMPLETE);
+            .buildStageOperationMetric(MetricsLevel.INFO, S3Stage.FORCE_UPLOAD_WAL_COMPLETE);
     public final HistogramMetric readStats = S3StreamMetricsManager
             .buildOperationMetric(MetricsLevel.INFO, S3Operation.READ_STORAGE);
     private final HistogramMetric readLogCacheHitStats = S3StreamMetricsManager

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/DeltaHistogram.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/DeltaHistogram.java
@@ -11,16 +11,20 @@
 
 package com.automq.stream.s3.metrics.wrapper;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiPredicate;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+
+import java.util.concurrent.atomic.LongAdder;
 
 public class DeltaHistogram {
     private static final Long DEFAULT_SNAPSHOT_INTERVAL_MS = 5000L;
-    private final AtomicLong cumulativeCount = new AtomicLong(0L);
-    private final AtomicLong cumulativeSum = new AtomicLong(0L);
-    private final AtomicLong min = new AtomicLong(Long.MAX_VALUE);
-    private final AtomicLong max = new AtomicLong(Long.MIN_VALUE);
-//    private final Sample sample = new ExponentiallyDecayingSample(1028, 0.015D);
+    private final LongAdder cumulativeCount = new LongAdder();
+    private final LongAdder cumulativeSum = new LongAdder();
+
+    private final Recorder recorder;
+    // the snapshot of histogram for recorder.
+    private Histogram intervalHistogram;
+
     private volatile long snapshotInterval;
     private SnapshotExt lastSnapshot;
     private long lastCount;
@@ -33,6 +37,7 @@ public class DeltaHistogram {
 
     public DeltaHistogram(long snapshotInterval) {
         this.snapshotInterval = snapshotInterval;
+        this.recorder = new Recorder(2);
     }
 
     public void setSnapshotInterval(long snapshotInterval) {
@@ -68,62 +73,57 @@ public class DeltaHistogram {
         return lastSnapshot.sum;
     }
 
-    private void updateMax(long value) {
-        update(value, max, (curr, candidate) -> candidate > curr);
-    }
-
-    private void updateMin(long value) {
-        update(value, min, (curr, candidate) -> candidate < curr);
-    }
-
-    private void update(long candidate, AtomicLong target, BiPredicate<Long, Long> predicate) {
-        long curr;
-        do {
-            curr = target.get();
-        }
-        while (predicate.test(curr, candidate) && !target.compareAndSet(curr, candidate));
-    }
-
     public void record(long value) {
-        cumulativeCount.incrementAndGet();
-        cumulativeSum.addAndGet(value);
-//        sample.update(value);
-        updateMax(value);
-        updateMin(value);
+        cumulativeCount.increment();
+        cumulativeSum.add(value);
+        this.recorder.recordValue(value);
     }
 
     public long cumulativeCount() {
-        return cumulativeCount.get();
+        return cumulativeCount.sum();
     }
 
     public long cumulativeSum() {
-        return cumulativeSum.get();
+        return cumulativeSum.sum();
     }
 
-//    public double p99() {
-//        snapshotAndReset();
-//        return lastSnapshot.snapshot.get99thPercentile();
-//    }
+    public double p99() {
+        snapshotAndReset();
+        return lastSnapshot.p99;
+    }
 
-//    public double p50() {
-//        snapshotAndReset();
-//        return lastSnapshot.snapshot.getMedian();
-//    }
+    public double p95() {
+        snapshotAndReset();
+        return lastSnapshot.p95;
+    }
+
+    public double p50() {
+        snapshotAndReset();
+        return lastSnapshot.p50;
+    }
 
     private void snapshotAndReset() {
         synchronized (this) {
             if (lastSnapshot == null || System.currentTimeMillis() - lastSnapshotTime > snapshotInterval) {
-//                Snapshot snapshot = sample.getSnapshot();
-                long snapshotMin = min.get();
-                long snapshotMax = max.get();
-                long snapshotCount = cumulativeCount.get() - lastCount;
-                long snapshotSum = cumulativeSum.get() - lastSum;
-                lastCount = cumulativeCount.get();
-                lastSum = cumulativeSum.get();
-//                sample.clear();
-                min.set(0);
-                max.set(0);
-                lastSnapshot = new SnapshotExt(snapshotMin, snapshotMax, snapshotCount, snapshotSum);
+                this.intervalHistogram = this.recorder.getIntervalHistogram(this.intervalHistogram);
+
+                long snapshotMin = this.intervalHistogram.getMinValue();
+                long snapshotMax = this.intervalHistogram.getMaxValue();
+
+                long newCount = cumulativeCount.sum();
+                long newSum = cumulativeSum.sum();
+
+                long snapshotCount = newCount - lastCount;
+                long snapshotSum = newSum - lastSum;
+
+                double p99 = intervalHistogram.getValueAtPercentile(0.99);
+                double p95 = intervalHistogram.getValueAtPercentile(0.95);
+                double p50 = intervalHistogram.getValueAtPercentile(0.50);
+
+                lastCount = newCount;
+                lastSum = newSum;
+
+                lastSnapshot = new SnapshotExt(snapshotMin, snapshotMax, snapshotCount, snapshotSum, p99, p95, p50);
                 lastSnapshotTime = System.currentTimeMillis();
             }
         }
@@ -134,14 +134,18 @@ public class DeltaHistogram {
         final long max;
         final long count;
         final long sum;
-//        final Snapshot snapshot;
+        final double p99;
+        final double p95;
+        final double p50;
 
-        public SnapshotExt(long min, long max, long count, long sum) {
+        public SnapshotExt(long min, long max, long count, long sum, double p99, double p95, double p50) {
             this.min = min;
             this.max = max;
             this.count = count;
             this.sum = sum;
-//            this.snapshot = snapshot;
+            this.p99 = p99;
+            this.p50 = p50;
+            this.p95 = p95;
         }
 
         double mean() {

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramInstrument.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramInstrument.java
@@ -27,8 +27,9 @@ import java.util.function.Supplier;
 public class HistogramInstrument {
     private final ObservableLongGauge count;
     private final ObservableLongGauge sum;
-//    private final ObservableDoubleGauge histP50Value;
-//    private final ObservableDoubleGauge histP99Value;
+    private final ObservableDoubleGauge histP50Value;
+    private final ObservableDoubleGauge histP95Value;
+    private final ObservableDoubleGauge histP99Value;
     private final ObservableDoubleGauge histMaxValue;
 
     public HistogramInstrument(Meter meter, String name, String desc, String unit, Supplier<List<HistogramMetric>> histogramsSupplier) {
@@ -55,28 +56,40 @@ public class HistogramInstrument {
                     }
                 });
             });
-//        this.histP50Value = meter.gaugeBuilder(name + S3StreamMetricsConstant.P50_METRIC_NAME_SUFFIX)
-//            .setDescription(desc + " (50th percentile)")
-//            .setUnit(unit)
-//            .buildWithCallback(result -> {
-//                List<HistogramMetric> histograms = histogramsSupplier.get();
-//                histograms.forEach(histogram -> {
-//                    if (histogram.shouldRecord()) {
-//                        result.record(histogram.p50(), histogram.attributes);
-//                    }
-//                });
-//            });
-//        this.histP99Value = meter.gaugeBuilder(name + S3StreamMetricsConstant.P99_METRIC_NAME_SUFFIX)
-//            .setDescription(desc + " (99th percentile)")
-//            .setUnit(unit)
-//            .buildWithCallback(result -> {
-//                List<HistogramMetric> histograms = histogramsSupplier.get();
-//                histograms.forEach(histogram -> {
-//                    if (histogram.shouldRecord()) {
-//                        result.record(histogram.p99(), histogram.attributes);
-//                    }
-//                });
-//            });
+        this.histP50Value = meter.gaugeBuilder(name + S3StreamMetricsConstant.P50_METRIC_NAME_SUFFIX)
+            .setDescription(desc + " (50th percentile)")
+            .setUnit(unit)
+            .buildWithCallback(result -> {
+                List<HistogramMetric> histograms = histogramsSupplier.get();
+                histograms.forEach(histogram -> {
+                    if (histogram.shouldRecord()) {
+                        result.record(histogram.p50(), histogram.attributes);
+                    }
+                });
+            });
+        this.histP99Value = meter.gaugeBuilder(name + S3StreamMetricsConstant.P99_METRIC_NAME_SUFFIX)
+            .setDescription(desc + " (99th percentile)")
+            .setUnit(unit)
+            .buildWithCallback(result -> {
+                List<HistogramMetric> histograms = histogramsSupplier.get();
+                histograms.forEach(histogram -> {
+                    if (histogram.shouldRecord()) {
+                        result.record(histogram.p99(), histogram.attributes);
+                    }
+                });
+            });
+
+        this.histP95Value = meter.gaugeBuilder(name + S3StreamMetricsConstant.P99_METRIC_NAME_SUFFIX)
+            .setDescription(desc + " (95th percentile)")
+            .setUnit(unit)
+            .buildWithCallback(result -> {
+                List<HistogramMetric> histograms = histogramsSupplier.get();
+                histograms.forEach(histogram -> {
+                    if (histogram.shouldRecord()) {
+                        result.record(histogram.p95(), histogram.attributes);
+                    }
+                });
+            });
         this.histMaxValue = meter.gaugeBuilder(name + S3StreamMetricsConstant.MAX_METRIC_NAME_SUFFIX)
             .setDescription(desc + " (max)")
             .setUnit(unit)

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramMetric.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/wrapper/HistogramMetric.java
@@ -37,13 +37,17 @@ public class HistogramMetric extends ConfigurableMetric {
         return deltaHistogram.cumulativeSum();
     }
 
-//    public double p50() {
-//        return deltaHistogram.p50();
-//    }
-//
-//    public double p99() {
-//        return deltaHistogram.p99();
-//    }
+    public double p50() {
+        return deltaHistogram.p50();
+    }
+
+    public double p95() {
+        return deltaHistogram.p95();
+    }
+
+    public double p99() {
+        return deltaHistogram.p99();
+    }
 
     public double max() {
         return deltaHistogram.max();

--- a/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
@@ -69,11 +69,13 @@ public class FutureTicker {
     /**
      * Generate a new tick if the current tick is done
      */
+    @SuppressWarnings("NP_NONNULL_PARAM_VIOLATION")
     private synchronized CompletableFuture<Void> maybeNextTick(boolean burstUpload) {
         if (currentTick.isDone()) {
             lastTickTime = System.currentTimeMillis();
 
             if (burstUpload) {
+                // spot bugs report the null can't pass but this is supported
                 currentTick = new CompletableFuture<Void>()
                     .completeOnTimeout(null, burstUploadTickTime, TimeUnit.MILLISECONDS);
             } else {

--- a/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
@@ -36,7 +36,7 @@ public class FutureTicker {
     private static long burstUploadTickTime = 100;
 
     static {
-        burstUploadTickTime = Systems.getEnvInt("AUTOMQ_BURST_UPLOAD_DELAY_TICK_TIME", 250);
+        burstUploadTickTime = Systems.getEnvInt("AUTOMQ_BURST_UPLOAD_DELAY_TICK_TIME", 100);
     }
 
     private final Executor delayedExecutor;

--- a/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
@@ -78,7 +78,8 @@ public class FutureTicker {
             if (burstUpload) {
                 // spot bugs report the null can't pass but this is supported
                 currentTick = new CompletableFuture<>()
-                    .completeOnTimeout(BURST_UPLOAD_OBJECT, burstUploadTickTime, TimeUnit.MILLISECONDS).thenAccept(__ -> {});
+                    .completeOnTimeout(BURST_UPLOAD_OBJECT, burstUploadTickTime, TimeUnit.MILLISECONDS).thenAccept(__ -> {
+                    });
             } else {
                 // a future which will complete after delay
                 currentTick = CompletableFuture.runAsync(() -> {

--- a/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/FutureTicker.java
@@ -31,18 +31,9 @@ import java.util.concurrent.TimeUnit;
  * Operations will be batched every 100ms.
  */
 public class FutureTicker {
-    public static final Object BURST_UPLOAD_OBJECT = new Object();
-
-    private static long burstUploadTickTime = 100;
-
-    static {
-        burstUploadTickTime = Systems.getEnvInt("AUTOMQ_BURST_UPLOAD_DELAY_TICK_TIME", 100);
-    }
-
     private final Executor delayedExecutor;
 
     private CompletableFuture<Void> currentTick = CompletableFuture.completedFuture(null);
-    private long lastTickTime = -1;
 
     /**
      * Create a ticker with a delay and a executor
@@ -60,41 +51,19 @@ public class FutureTicker {
      * If the ticker is already ticking, the same future will be returned.
      * It is thread safe to call this method.
      */
-    public CompletableFuture<Void> tick(boolean burstUpload) {
-        return maybeNextTick(burstUpload);
-    }
-
     public CompletableFuture<Void> tick() {
-        return maybeNextTick(false);
+        return maybeNextTick();
     }
 
     /**
      * Generate a new tick if the current tick is done
      */
-    private synchronized CompletableFuture<Void> maybeNextTick(boolean burstUpload) {
+    private synchronized CompletableFuture<Void> maybeNextTick() {
         if (currentTick.isDone()) {
-            lastTickTime = System.currentTimeMillis();
-
-            if (burstUpload) {
-                // spot bugs report the null can't pass but this is supported
-                currentTick = new CompletableFuture<>()
-                    .completeOnTimeout(BURST_UPLOAD_OBJECT, burstUploadTickTime, TimeUnit.MILLISECONDS).thenAccept(__ -> {
-                    });
-            } else {
-                // a future which will complete after delay
-                currentTick = CompletableFuture.runAsync(() -> {
-                }, delayedExecutor);
-            }
-
-            return currentTick;
+            // a future which will complete after delay
+            currentTick = CompletableFuture.runAsync(() -> {
+            }, delayedExecutor);
         }
-
-        if (burstUpload) {
-            if (System.currentTimeMillis() - lastTickTime > burstUploadTickTime) {
-                currentTick.complete(null);
-            }
-        }
-
         return currentTick;
     }
 }


### PR DESCRIPTION
# Why this patch
we want to optimize the partition failover time. and we found the main part in partition clean shutdown failover is stream close.

and the stream close is slow because of the Upload RateLimit when upload.
and the FutureTicker also will cause the force upload task finish in long time. which at most delay 500ms and the 500ms delay may cause the upload data amount much larger.

# What is changed
1. support p99, p95 p50 in DeltaHistogram. use HdrHistogram which calculate p99 in low overhead.
2. support DeltaWALUploadTask limiter burst mode which cal make all the acquire fast pass.
3. support FutureTicker to wait small time when force upload.

------

<img width="371" alt="image" src="https://github.com/user-attachments/assets/aa38cb7a-3711-4e66-baeb-64136283cacb">

kube800 the yellow line is enabled burst and wait at most 100ms when force upload.
kube801 the orange line is enabled burst and wait at most 500ms when force upload.
kube802 the blue line is no burst.

with this patch the s3stream close time p99 can drop from 3s to 500ms in our environment

# test case
3 node each 200MB/s in traffic 30 partition each node. 100 partition total.
submit reassign task each 2min which will change partition leader 100 -> 101, 101 -> 102, 102 -> 100.

