### PR TITLE
perf(core): batch persistent meta when delete large scale segment

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
@@ -189,6 +189,14 @@ public class ElasticLogSegmentManager {
                 }
 
                 if (maxOffset != NO_OP_OFFSET) {
+                    if (metaStream.isFenced()) {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("{} meta stream is closed, skip persisting log meta", logIdent);
+                        }
+
+                        return;
+                    }
+
                     long finalMaxOffset = maxOffset;
                     pendingPersistentMetaCf = asyncPersistLogMeta().whenCompleteAsync((res, e) -> {
                         if (e != null) {

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
@@ -14,11 +14,16 @@ package kafka.log.streamaspect;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -30,6 +35,7 @@ public class ElasticLogSegmentManagerTest {
     @Test
     public void testSegmentDelete() {
         ElasticLogMeta logMeta = mock(ElasticLogMeta.class);
+        ElasticLogSegment logSegment = mock(ElasticLogSegment.class);
         MetaStream metaStream = mock(MetaStream.class);
 
         when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
@@ -37,18 +43,22 @@ public class ElasticLogSegmentManagerTest {
         ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
 
         ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+
+        when(manager.remove(anyLong())).thenReturn(logSegment);
 
         when(manager.asyncPersistLogMeta()).thenReturn(CompletableFuture.completedFuture(logMeta));
 
         ElasticLogSegmentManager.EventListener listener = manager.new EventListener();
         listener.onEvent(1, ElasticLogSegmentEvent.SEGMENT_DELETE);
 
-        verify(manager, atMost(1)).asyncPersistLogMeta();
+        verify(manager, atLeastOnce()).asyncPersistLogMeta();
+        verify(manager, atMost(2)).asyncPersistLogMeta();
     }
 
     @Test
     public void testLargeScaleSegmentDelete() throws InterruptedException {
         ElasticLogMeta logMeta = mock(ElasticLogMeta.class);
+        ElasticLogSegment logSegment = mock(ElasticLogSegment.class);
         MetaStream metaStream = mock(MetaStream.class);
 
         when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
@@ -56,6 +66,15 @@ public class ElasticLogSegmentManagerTest {
         ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
 
         ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+
+        Set<Long> removedSegmentId = new HashSet<>();
+
+
+        when(manager.remove(anyLong())).thenAnswer(invocation -> {
+            long id = invocation.getArgument(0);
+            removedSegmentId.add(id);
+            return logSegment;
+        });
 
         Queue<CompletableFuture<ElasticLogMeta>> queue = new ConcurrentLinkedQueue<>();
 
@@ -66,14 +85,15 @@ public class ElasticLogSegmentManagerTest {
             return cf;
         });
 
-        ElasticLogSegmentManager.EventListener listener = manager.new EventListener();
+        ElasticLogSegmentManager.EventListener listener = spy(manager.new EventListener());
+
         for (long i = 0L; i < 1000L; i++) {
             listener.onEvent(i, ElasticLogSegmentEvent.SEGMENT_DELETE);
         }
 
         Thread.sleep(20);
 
-        for (long i = 1001L; i < 2000L; i++) {
+        for (long i = 1000L; i < 2000L; i++) {
             listener.onEvent(i, ElasticLogSegmentEvent.SEGMENT_DELETE);
         }
 
@@ -81,6 +101,13 @@ public class ElasticLogSegmentManagerTest {
             elasticLogMetaCompletableFuture.complete(logMeta);
         }
 
+        verify(manager, atLeastOnce()).asyncPersistLogMeta();
         verify(manager, atMost(2)).asyncPersistLogMeta();
+
+
+        for (long i = 0; i < 2000L; i++) {
+            assertTrue(removedSegmentId.contains(i));
+        }
+
     }
 }

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package kafka.log.streamaspect;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("S3Unit")
+public class ElasticLogSegmentManagerTest {
+    @Test
+    public void testSegmentDelete() {
+        ElasticLogMeta logMeta = mock(ElasticLogMeta.class);
+        MetaStream metaStream = mock(MetaStream.class);
+
+        when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+        ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
+
+        ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+
+        when(manager.asyncPersistLogMeta()).thenReturn(CompletableFuture.completedFuture(logMeta));
+
+        ElasticLogSegmentManager.EventListener listener = manager.new EventListener();
+        listener.onEvent(1, ElasticLogSegmentEvent.SEGMENT_DELETE);
+
+        verify(manager, atMost(1)).asyncPersistLogMeta();
+    }
+
+    @Test
+    public void testLargeScaleSegmentDelete() throws InterruptedException {
+        ElasticLogMeta logMeta = mock(ElasticLogMeta.class);
+        MetaStream metaStream = mock(MetaStream.class);
+
+        when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+        ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
+
+        ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+
+        Queue<CompletableFuture<ElasticLogMeta>> queue = new ConcurrentLinkedQueue<>();
+
+        when(manager.asyncPersistLogMeta()).thenAnswer(invocation -> {
+            CompletableFuture<ElasticLogMeta> cf = new CompletableFuture<>();
+            queue.add(cf);
+
+            return cf;
+        });
+
+        ElasticLogSegmentManager.EventListener listener = manager.new EventListener();
+        for (long i = 0L; i < 1000L; i++) {
+            listener.onEvent(i, ElasticLogSegmentEvent.SEGMENT_DELETE);
+        }
+
+        Thread.sleep(20);
+
+        for (long i = 1001L; i < 2000L; i++) {
+            listener.onEvent(i, ElasticLogSegmentEvent.SEGMENT_DELETE);
+        }
+
+        for (CompletableFuture<ElasticLogMeta> elasticLogMetaCompletableFuture : queue) {
+            elasticLogMetaCompletableFuture.complete(logMeta);
+        }
+
+        verify(manager, atMost(2)).asyncPersistLogMeta();
+    }
+}


### PR DESCRIPTION
log 
```java
[2024-07-22 10:30:21,309] ERROR Uncaught exception in scheduled task 'delete-file' (org.apache.kafka.server.util.KafkaScheduler)
java.lang.OutOfMemoryError: Java heap space
        at com.fasterxml.jackson.core.util.ByteArrayBuilder.toByteArray(ByteArrayBuilder.java:163)
        at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsBytes(ObjectWriter.java:1164)
        at kafka.log.streamaspect.ElasticLogMeta.encode(ElasticLogMeta.java:53)
        at kafka.log.streamaspect.ElasticLogSegmentManager.asyncPersistLogMeta(ElasticLogSegmentManager.java:80)
        at kafka.log.streamaspect.ElasticLogSegmentManager$EventListener.onEvent(ElasticLogSegmentManager.java:153)
        at kafka.log.streamaspect.ElasticLogSegment.deleteIfExists(ElasticLogSegment.java:410)
        at kafka.log.LocalLog$.$anonfun$deleteSegmentFiles$5(LocalLog.scala:950)
        at kafka.log.LocalLog$.$anonfun$deleteSegmentFiles$5$adapted(LocalLog.scala:949)
        at kafka.log.LocalLog$$$Lambda$5148/0x0000000801ba09c0.apply(Unknown Source)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at kafka.log.LocalLog$.$anonfun$deleteSegmentFiles$4(LocalLog.scala:949)
        at kafka.log.LocalLog$.deleteSegments$1(LocalLog.scala:739)
        at kafka.log.LocalLog$.$anonfun$deleteSegmentFiles$6(LocalLog.scala:956)
        at kafka.log.LocalLog$$$Lambda$5145/0x0000000801455d88.run(Unknown Source)
        at org.apache.kafka.server.util.KafkaScheduler.lambda$schedule$1(KafkaScheduler.java:150)
        at org.apache.kafka.server.util.KafkaScheduler$$Lambda$1237/0x000000080155c7c8.run(Unknown Source)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

this cause one of broker OOM when 1gb/s topic retention time change from 3 days to 12h. after the delete change from 200TB to 18TB. the partition number is 100.
the delete segment at the same time is very very big.

and the OOM cause the kraft ping packet will be error and the broker remain in fence can't recover