### PR TITLE
feat(wal): avoid creating 3000 useless block objects per second by default 

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
@@ -339,8 +339,6 @@ public class SlidingWindowService {
             pendingBlocks = new LinkedList<>();
         } else {
             blocks = new LinkedList<>();
-        }
-        if (!isCurrentBlockEmpty) {
             blocks.add(currentBlock);
             setCurrentBlockLocked(nextBlock(currentBlock));
         }


### PR DESCRIPTION
[issue](https://github.com/AutoMQ/automq/issues/1721)