### PR TITLE
fix(ElasticLogManager): terminate the unending shutdown by completing `INIT_FUTURE`

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogManager.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogManager.scala
@@ -204,6 +204,7 @@ object ElasticLogManager {
   }
 
   def shutdown(): Unit = {
+    INIT_FUTURE.completeExceptionally(new IllegalStateException("ElasticLogManager is shutting down"))
     INSTANCE.foreach(_.shutdownNow())
   }
 }


### PR DESCRIPTION
fix #1749 
