### PR TITLE
refactor(s3stream): refactor batch delete objects

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -110,7 +110,6 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         S3StreamMetricsManager.registerInflightS3WriteQuotaSupplier(inflightWriteLimiter::availablePermits, currentIndex);
 
         this.deleteObjectsAccumulator = newDeleteObjectsAccumulator();
-        this.deleteObjectsAccumulator.start();
 
         s3LatencyCalculator = new S3LatencyCalculator(
             new long[] {
@@ -458,7 +457,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             }
         }
 
-        deleteObjectsAccumulator.batchOrSubmitDeleteRequests(objectPaths, cf);
+        deleteObjectsAccumulator.batchDeleteObjects(objectPaths, cf);
 
         return cf;
     }
@@ -491,7 +490,6 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         scheduler.shutdown();
         timeoutDetect.stop();
         fastRetryTimer.stop();
-        deleteObjectsAccumulator.stop();
         doClose();
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -14,12 +14,12 @@ package com.automq.stream.s3.operator;
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
-import com.automq.stream.utils.CollectionHelper;
 import com.automq.stream.utils.FutureUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.ssl.OpenSsl;
+
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -83,6 +84,8 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     public static final String STATIC_AUTH_TYPE = "static";
     public static final String INSTANCE_AUTH_TYPE = "instance";
 
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
+    // The maximum number of keys that can be deleted in a single request is 1000.
     public static final int AWS_DEFAULT_BATCH_DELETE_OBJECTS_NUMBER = 1000;
 
     private final String bucket;
@@ -222,13 +225,6 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     }
 
     public CompletableFuture<Void> doDeleteObjects(List<String> objectKeys) {
-        return CompletableFuture.allOf(
-            CollectionHelper.groupListByBatchSizeAsStream(objectKeys, AWS_DEFAULT_BATCH_DELETE_OBJECTS_NUMBER)
-                .map(this::doDeleteObjects0).toArray(CompletableFuture[]::new)
-        );
-    }
-
-    private CompletableFuture<Void> doDeleteObjects0(List<String> objectKeys) {
         ObjectIdentifier[] toDeleteKeys = objectKeys.stream().map(key ->
             ObjectIdentifier.builder()
                 .key(key)
@@ -301,6 +297,11 @@ public class AwsObjectStorage extends AbstractObjectStorage {
                     .stream()
                     .map(object -> new ObjectInfo(bucketURI.bucketId(), object.key(), object.lastModified().toEpochMilli(), object.size()))
                     .collect(Collectors.toList()));
+    }
+
+    @Override
+    protected DeleteObjectsAccumulator newDeleteObjectsAccumulator() {
+        return new DeleteObjectsAccumulator(AWS_DEFAULT_BATCH_DELETE_OBJECTS_NUMBER, getMaxObjectStorageConcurrency(), this::doDeleteObjects);
     }
 
     protected List<AwsCredentialsProvider> credentialsProviders() {

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
@@ -13,32 +13,25 @@ package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.metrics.stats.S3OperationStats;
-import com.automq.stream.utils.Threads;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class DeleteObjectsAccumulator implements Runnable {
+public class DeleteObjectsAccumulator {
     static final Logger LOGGER = LoggerFactory.getLogger(DeleteObjectsAccumulator.class);
     public static final int DEFAULT_DELETE_OBJECTS_MAX_BATCH_SIZE = 1000;
     public static final int DEFAULT_DELETE_OBJECTS_MAX_CONCURRENT_REQUEST_NUMBER = 100;
-    private final ExecutorService batchDeleteCheckExecutor = Threads.newFixedThreadPoolWithMonitor(1,
-        "s3-batch-delete-executor", true, LOGGER);
     private final Function<List<String>, CompletableFuture<Void>> deleteObjectsFunction;
-    private final BlockingQueue<PendingDeleteRequest> deleteBatchQueue = new LinkedBlockingQueue<>();
-    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final ConcurrentLinkedQueue<PendingDeleteRequest> deleteRequestQueue = new ConcurrentLinkedQueue<>();
 
     private final int maxBatchSize;
     private final Semaphore concurrentRequestLimiter;
@@ -48,8 +41,8 @@ public class DeleteObjectsAccumulator implements Runnable {
     }
 
     public DeleteObjectsAccumulator(int maxBatchSize,
-                                    int maxConcurrentRequestNumber,
-                                    Function<List<String>, CompletableFuture<Void>> deleteObjectsFunction) {
+        int maxConcurrentRequestNumber,
+        Function<List<String>, CompletableFuture<Void>> deleteObjectsFunction) {
         this.deleteObjectsFunction = deleteObjectsFunction;
         this.maxBatchSize = maxBatchSize;
         this.concurrentRequestLimiter = new Semaphore(maxConcurrentRequestNumber);
@@ -65,88 +58,79 @@ public class DeleteObjectsAccumulator implements Runnable {
         }
     }
 
-    public void start() {
-        this.batchDeleteCheckExecutor.submit(this);
+    /**
+     * Batch delete objects, if the number of objects is greater than {@link #maxBatchSize}, they will be deleted in batches
+     * The number of delete requests initiated at the same time will be limited by {@link #concurrentRequestLimiter}
+     *
+     * @param objectPaths list of object paths to delete
+     * @param cf CompletableFuture to complete when all objects are deleted, or an exception occurs
+     */
+    public void batchDeleteObjects(List<ObjectStorage.ObjectPath> objectPaths, CompletableFuture<Void> cf) {
+        ArrayList<CompletableFuture<Void>> subBatchCfList = new ArrayList<>();
+        int startIndex = 0;
+        while (startIndex < objectPaths.size()) {
+            int endIndex = Math.min(startIndex + this.maxBatchSize, objectPaths.size());
+            List<ObjectStorage.ObjectPath> subBatchList = objectPaths.subList(startIndex, endIndex);
+            CompletableFuture<Void> subBatchCf = new CompletableFuture<>();
+            subBatchCfList.add(subBatchCf);
+            submitDeleteObjectsRequest(subBatchList, subBatchCf);
+            startIndex = endIndex;
+        }
+        CompletableFuture.allOf(subBatchCfList.toArray(new CompletableFuture[0]))
+            .thenApply(nil -> {
+                cf.complete(null);
+                return null;
+            }).exceptionally(cf::completeExceptionally);
     }
 
-    private void submitDeleteObjectsRequest(List<ObjectStorage.ObjectPath> objectPaths,
-                                            CompletableFuture<Void> subBatchCf) throws InterruptedException {
+    private void submitDeleteObjectsRequest(List<ObjectStorage.ObjectPath> objectPaths, CompletableFuture<Void> subBatchCf) {
         List<String> objectKeys = objectPaths.stream().map(ObjectStorage.ObjectPath::key).collect(Collectors.toList());
-
         TimerUtil timerUtil = new TimerUtil();
-
-        concurrentRequestLimiter.acquire();
-        deleteObjectsFunction.apply(objectKeys).whenComplete((res, e) -> {
-            concurrentRequestLimiter.release();
-        }).thenAccept(nil -> {
-            LOGGER.info("Delete objects finished, count: {}, cost: {}ms", objectKeys.size(), timerUtil.elapsedAs(TimeUnit.MILLISECONDS));
-            S3OperationStats.getInstance().deleteObjectsStats(true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-            subBatchCf.complete(null);
-        }).exceptionally(ex -> {
-            if (ex instanceof AbstractObjectStorage.DeleteObjectsException) {
-                AbstractObjectStorage.DeleteObjectsException deleteObjectsException = (AbstractObjectStorage.DeleteObjectsException) ex;
-                LOGGER.warn("Delete objects failed, count: {}, cost: {}, failedKeys: {}",
-                    deleteObjectsException.getFailedKeys().size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS),
-                    deleteObjectsException.getFailedKeys());
-            } else {
-                S3OperationStats.getInstance().deleteObjectsStats(false)
-                    .record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-                LOGGER.info("Delete objects failed, count: {}, cost: {}, ex: {}",
-                    objectKeys.size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS), ex.getMessage());
-            }
-            subBatchCf.completeExceptionally(ex);
-
-            return null;
-        });
+        if (!concurrentRequestLimiter.tryAcquire()) {
+            deleteRequestQueue.add(new PendingDeleteRequest(objectPaths, subBatchCf));
+            return;
+        }
+        deleteObjectsFunction.apply(objectKeys)
+            .whenComplete((res, e) -> concurrentRequestLimiter.release())
+            .thenAccept(nil -> {
+                LOGGER.info("Delete objects finished, count: {}, cost: {}ms", objectKeys.size(), timerUtil.elapsedAs(TimeUnit.MILLISECONDS));
+                S3OperationStats.getInstance().deleteObjectsStats(true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+                subBatchCf.complete(null);
+                handleDeleteRequestQueue();
+            }).exceptionally(ex -> {
+                if (ex instanceof AbstractObjectStorage.DeleteObjectsException) {
+                    AbstractObjectStorage.DeleteObjectsException deleteObjectsException = (AbstractObjectStorage.DeleteObjectsException) ex;
+                    LOGGER.warn("Delete objects failed, count: {}, cost: {}, failedKeys: {}",
+                        deleteObjectsException.getFailedKeys().size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS),
+                        deleteObjectsException.getFailedKeys());
+                } else {
+                    S3OperationStats.getInstance().deleteObjectsStats(false)
+                        .record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+                    LOGGER.info("Delete objects failed, count: {}, cost: {}, ex: {}",
+                        objectKeys.size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS), ex.getMessage());
+                }
+                subBatchCf.completeExceptionally(ex);
+                handleDeleteRequestQueue();
+                return null;
+            });
     }
 
-    public void run() {
-        while (running.get()) {
-            PendingDeleteRequest item;
-            try {
-                item = deleteBatchQueue.poll(500, TimeUnit.MICROSECONDS);
-                if (item == null) {
-                    continue;
+    private void handleDeleteRequestQueue() {
+        while (true) {
+            if (concurrentRequestLimiter.availablePermits() > 0) {
+                PendingDeleteRequest pendingDeleteRequest = deleteRequestQueue.poll();
+                if (pendingDeleteRequest == null) {
+                    break;
                 }
-                ArrayList<CompletableFuture<Void>> subBatchCfList = new ArrayList<>();
-                int startIndex = 0;
-                while (startIndex < item.deleteObjectPath.size()) {
-                    int endIndex = Math.min(startIndex + this.maxBatchSize, item.deleteObjectPath.size());
-                    List<ObjectStorage.ObjectPath> subBatchList = item.deleteObjectPath.subList(startIndex, endIndex);
-                    CompletableFuture<Void> subBatchCf = new CompletableFuture<>();
-                    subBatchCfList.add(subBatchCf);
-                    submitDeleteObjectsRequest(subBatchList, subBatchCf);
-                    startIndex = endIndex;
-                }
-                CompletableFuture.allOf(subBatchCfList.toArray(new CompletableFuture[0]))
-                    .thenApply(nil -> {
-                        item.future.complete(null);
-                        return null;
-                    }).exceptionally(ex -> item.future.completeExceptionally(ex));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
+                submitDeleteObjectsRequest(pendingDeleteRequest.deleteObjectPath, pendingDeleteRequest.future);
+            } else {
+                break;
             }
         }
-    }
-
-    public void stop() {
-        this.running.set(false);
-        this.batchDeleteCheckExecutor.shutdownNow();
     }
 
     @VisibleForTesting
     public int availablePermits() {
         return this.concurrentRequestLimiter.availablePermits();
     }
-
-    /**
-     * batchOrSubmitDeleteRequests
-     * the request will be limited by max concurrent request here
-     */
-    public void batchOrSubmitDeleteRequests(List<ObjectStorage.ObjectPath> objectPaths,
-                                            CompletableFuture<Void> ioCf) {
-        deleteBatchQueue.add(new PendingDeleteRequest(objectPaths, ioCf));
-    }
-
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
@@ -117,11 +117,11 @@ public class DeleteObjectsAccumulator {
     }
 
     private boolean submitDeleteObjectsRequest(List<ObjectStorage.ObjectPath> objectPaths, List<CompletableFuture<Void>> subBatchCf) {
-        List<String> objectKeys = objectPaths.stream().map(ObjectStorage.ObjectPath::key).collect(Collectors.toList());
-        TimerUtil timerUtil = new TimerUtil();
         if (!concurrentRequestLimiter.tryAcquire()) {
             return false;
         }
+        List<String> objectKeys = objectPaths.stream().map(ObjectStorage.ObjectPath::key).collect(Collectors.toList());
+        TimerUtil timerUtil = new TimerUtil();
         deleteObjectsFunction.apply(objectKeys)
             .whenComplete((res, e) -> concurrentRequestLimiter.release())
             .thenAccept(nil -> {


### PR DESCRIPTION
* limit the number of deletions in a single batch and the maximum concurrency of deletion requests