### PR TITLE
feat(s3stream): add strictBathLimit option for s3 wal

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALConfig.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALConfig.java
@@ -25,13 +25,15 @@ public class ObjectWALConfig {
     private final long epoch;
     private final boolean failover;
     private final short bucketId;
+    private final boolean strictBatchLimit;
 
     public static Builder builder() {
         return new Builder();
     }
 
     public ObjectWALConfig(long batchInterval, long maxBytesInBatch, long maxUnflushedBytes, int maxInflightUploadCount,
-        int readAheadObjectCount, String clusterId, int nodeId, long epoch, boolean failover, short bucketId) {
+        int readAheadObjectCount, String clusterId, int nodeId, long epoch, boolean failover, short bucketId,
+        boolean strictBatchLimit) {
         this.batchInterval = batchInterval;
         this.maxBytesInBatch = maxBytesInBatch;
         this.maxUnflushedBytes = maxUnflushedBytes;
@@ -42,6 +44,7 @@ public class ObjectWALConfig {
         this.epoch = epoch;
         this.failover = failover;
         this.bucketId = bucketId;
+        this.strictBatchLimit = strictBatchLimit;
     }
 
     public long batchInterval() {
@@ -84,6 +87,10 @@ public class ObjectWALConfig {
         return bucketId;
     }
 
+    public boolean strictBatchLimit() {
+        return strictBatchLimit;
+    }
+
     public static final class Builder {
         private long batchInterval = 100; // 100ms
         private long maxBytesInBatch = 4 * 1024 * 1024L; // 4MB
@@ -95,6 +102,7 @@ public class ObjectWALConfig {
         private long epoch;
         private boolean failover;
         private short bucketId;
+        private boolean strictBatchLimit = false;
 
         private Builder() {
         }
@@ -121,6 +129,10 @@ public class ObjectWALConfig {
             String readAheadObjectCount = uri.extensionString("readAheadObjectCount");
             if (StringUtils.isNumeric(readAheadObjectCount)) {
                 withReadAheadObjectCount(Integer.parseInt(readAheadObjectCount));
+            }
+            String strictBatchLimit = uri.extensionString("strictBatchLimit");
+            if (StringUtils.isNumeric(strictBatchLimit)) {
+                withStrictBatchLimit(Boolean.parseBoolean(strictBatchLimit));
             }
             return this;
         }
@@ -183,8 +195,13 @@ public class ObjectWALConfig {
             return this;
         }
 
+        public Builder withStrictBatchLimit(boolean strictBatchLimit) {
+            this.strictBatchLimit = strictBatchLimit;
+            return this;
+        }
+
         public ObjectWALConfig build() {
-            return new ObjectWALConfig(batchInterval, maxBytesInBatch, maxUnflushedBytes, maxInflightUploadCount, readAheadObjectCount, clusterId, nodeId, epoch, failover, bucketId);
+            return new ObjectWALConfig(batchInterval, maxBytesInBatch, maxUnflushedBytes, maxInflightUploadCount, readAheadObjectCount, clusterId, nodeId, epoch, failover, bucketId, strictBatchLimit);
         }
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -32,7 +32,12 @@ public class ObjectWALServiceTest {
     @BeforeEach
     public void setUp() throws IOException {
         objectStorage = new MemoryObjectStorage();
-        wal = new ObjectWALService(Time.SYSTEM, objectStorage, ObjectWALConfig.builder().withMaxBytesInBatch(110).withBatchInterval(Long.MAX_VALUE).build());
+        ObjectWALConfig config = ObjectWALConfig.builder()
+            .withMaxBytesInBatch(110)
+            .withBatchInterval(Long.MAX_VALUE)
+            .withStrictBatchLimit(true)
+            .build();
+        wal = new ObjectWALService(Time.SYSTEM, objectStorage, config);
         wal.start();
         random = new Random();
     }


### PR DESCRIPTION
Limiting the content length and split requests in the standard S3 service may cause unnecessary API request costs. Therefore, it recommends enabling this feature only in the S3 express service.