### PR TITLE
feat(s3stream): optimize the execution order of the release method for ByteBuf

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -419,7 +419,6 @@ public class S3Storage implements Storage {
         handleAppendRequest(writeRequest);
         append0(context, writeRequest, false);
         cf.whenComplete((nil, ex) -> {
-            streamRecord.release();
             StorageOperationStats.getInstance().appendStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
         });
         return cf;

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -413,8 +413,6 @@ public class S3Storage implements Storage {
     public CompletableFuture<Void> append(AppendContext context, StreamRecordBatch streamRecord) {
         final long startTime = System.nanoTime();
         CompletableFuture<Void> cf = new CompletableFuture<>();
-        // encoded before append to free heap ByteBuf.
-        streamRecord.encoded();
         WalWriteRequest writeRequest = new WalWriteRequest(streamRecord, -1L, cf, context);
         handleAppendRequest(writeRequest);
         append0(context, writeRequest, false);

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -185,6 +185,7 @@ public class S3Stream implements Stream {
             return new DefaultAppendResult(offset);
         });
         return cf.whenComplete((rst, ex) -> {
+            streamRecordBatch.release();
             if (ex == null) {
                 return;
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -180,6 +180,7 @@ public class S3Stream implements Stream {
         }
         long offset = nextOffset.getAndAdd(recordBatch.count());
         StreamRecordBatch streamRecordBatch = new StreamRecordBatch(streamId, epoch, offset, recordBatch.count(), Unpooled.wrappedBuffer(recordBatch.rawPayload()));
+        streamRecordBatch.encoded();
         CompletableFuture<AppendResult> cf = storage.append(context, streamRecordBatch).thenApply(nil -> {
             updateConfirmOffset(offset + recordBatch.count());
             return new DefaultAppendResult(offset);

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -180,13 +180,11 @@ public class S3Stream implements Stream {
         }
         long offset = nextOffset.getAndAdd(recordBatch.count());
         StreamRecordBatch streamRecordBatch = new StreamRecordBatch(streamId, epoch, offset, recordBatch.count(), Unpooled.wrappedBuffer(recordBatch.rawPayload()));
-        streamRecordBatch.encoded();
         CompletableFuture<AppendResult> cf = storage.append(context, streamRecordBatch).thenApply(nil -> {
             updateConfirmOffset(offset + recordBatch.count());
             return new DefaultAppendResult(offset);
         });
         return cf.whenComplete((rst, ex) -> {
-            streamRecordBatch.release();
             if (ex == null) {
                 return;
             }


### PR DESCRIPTION
**Background**:

Due to the fact that the callback order of `CompletableFuture` follows a LIFO (Last In First Out) pattern, it leads to uncertainty and potentially significant delays in the execution timing of the `release` method for the current `StreamRecordBatch`.

We should ensure that such methods are executed with priority whenever possible.
com.automq.stream.s3.S3Storage#append
com.automq.stream.s3.S3Stream#append0