### PR TITLE
perf: use a new `GrowableMultiBufferSupplier` to avoid memory waste

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/BufferSupplier.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/BufferSupplier.java
@@ -156,7 +156,7 @@ public abstract class BufferSupplier implements AutoCloseable {
         @Override
         public void release(ByteBuffer buffer) {
             buffer.clear();
-            buffers.addLast(buffer);
+            buffers.addFirst(buffer);
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/utils/GrowableMultiBufferSupplierTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/GrowableMultiBufferSupplierTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package org.apache.kafka.common.utils;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GrowableMultiBufferSupplierTest {
+
+    private BufferSupplier.GrowableMultiBufferSupplier bufferSupplier;
+
+    @BeforeEach
+    void setUp() {
+        bufferSupplier = new BufferSupplier.GrowableMultiBufferSupplier();
+    }
+
+    @Test
+    void testGetWhenNoBuffersAvailable() {
+        ByteBuffer result = bufferSupplier.get(10);
+        assertEquals(10, result.capacity());
+    }
+
+    @Test
+    void testGetWithSufficientCapacity() {
+        ByteBuffer buffer = bufferSupplier.get(10);
+        bufferSupplier.release(buffer);
+
+        ByteBuffer result = bufferSupplier.get(5);
+        assertSame(buffer, result);
+        assertEquals(0, result.position());
+        assertEquals(10, result.capacity());
+    }
+
+    @Test
+    void testGetWithInsufficientCapacity() {
+        ByteBuffer buffer = bufferSupplier.get(10);
+        bufferSupplier.release(buffer);
+
+        ByteBuffer result = bufferSupplier.get(15);
+        assertNotSame(buffer, result);
+        assertEquals(15, result.capacity());
+    }
+
+    @Test
+    void testGetAndReleaseMultipleBuffers() {
+        ByteBuffer buffer1 = bufferSupplier.get(10);
+        ByteBuffer buffer2 = bufferSupplier.get(15);
+        bufferSupplier.release(buffer1);
+        bufferSupplier.release(buffer2);
+
+        ByteBuffer result1 = bufferSupplier.get(5);
+        ByteBuffer result2 = bufferSupplier.get(10);
+        assertSame(buffer1, result1);
+        assertSame(buffer2, result2);
+        assertEquals(0, result1.position());
+        assertEquals(0, result2.position());
+    }
+
+    @Test
+    void testRelease() {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        buffer.put((byte) 1);
+        bufferSupplier.release(buffer);
+
+        ByteBuffer result = bufferSupplier.get(5);
+        assertSame(buffer, result);
+        assertEquals(0, result.position());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/GrowableMultiBufferSupplierTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/GrowableMultiBufferSupplierTest.java
@@ -62,8 +62,8 @@ class GrowableMultiBufferSupplierTest {
         bufferSupplier.release(buffer1);
         bufferSupplier.release(buffer2);
 
-        ByteBuffer result1 = bufferSupplier.get(5);
-        ByteBuffer result2 = bufferSupplier.get(10);
+        ByteBuffer result2 = bufferSupplier.get(5);
+        ByteBuffer result1 = bufferSupplier.get(10);
         assertSame(buffer1, result1);
         assertSame(buffer2, result2);
         assertEquals(0, result1.position());

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -347,7 +347,10 @@ final public class KafkaRaftClient<T> implements RaftClient<T> {
         return log.latestSnapshot().map(reader ->
             RecordsSnapshotReader.of(reader,
                 serde,
-                BufferSupplier.create(),
+                // AutoMQ for Kafka inject start
+                // BufferSupplier.create(),
+                new BufferSupplier.GrowableMultiBufferSupplier(),
+                // AutoMQ for Kafka inject end
                 MAX_BATCH_SIZE_BYTES,
                 true /* Validate batch CRC*/
             )
@@ -386,7 +389,10 @@ final public class KafkaRaftClient<T> implements RaftClient<T> {
             Optional.of(VoterSet.fromInetSocketAddresses(listenerName, voterAddresses)),
             log,
             serde,
-            BufferSupplier.create(),
+            // AutoMQ for Kafka inject start
+            // BufferSupplier.create(),
+            new BufferSupplier.GrowableMultiBufferSupplier(),
+            // AutoMQ for Kafka inject end
             MAX_BATCH_SIZE_BYTES,
             logContext
         );
@@ -2700,7 +2706,10 @@ final public class KafkaRaftClient<T> implements RaftClient<T> {
                     baseOffset,
                     records,
                     serde,
-                    BufferSupplier.create(),
+                    // AutoMQ for Kafka inject start
+                    // BufferSupplier.create(),
+                    new BufferSupplier.GrowableMultiBufferSupplier(),
+                    // AutoMQ for Kafka inject end
                     MAX_BATCH_SIZE_BYTES,
                     this,
                     true /* Validate batch CRC*/


### PR DESCRIPTION
resolve #1787 