### PR TITLE
fix(s3strea/wal): handle `IOException` during flushing WAL header

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
@@ -386,7 +386,7 @@ public class SlidingWindowService {
         StorageOperationStats.getInstance().appendWALWriteStats.record(TimerUtil.durationElapsedAs(start, TimeUnit.NANOSECONDS));
     }
 
-    private void makeWriteOffsetMatchWindow(long newWindowEndOffset) {
+    private void makeWriteOffsetMatchWindow(long newWindowEndOffset) throws IOException {
         // align to block size
         newWindowEndOffset = WALUtil.alignLargeByBlockSize(newWindowEndOffset);
         long windowStartOffset = windowCoreData.getStartOffset();
@@ -400,7 +400,7 @@ public class SlidingWindowService {
     }
 
     public interface WALHeaderFlusher {
-        void flush();
+        void flush() throws IOException;
     }
 
     public static class WindowCoreData {
@@ -442,7 +442,7 @@ public class SlidingWindowService {
             this.startOffset.accumulateAndGet(offset, Math::max);
         }
 
-        public void scaleOutWindow(WALHeaderFlusher flusher, long newMaxLength) {
+        public void scaleOutWindow(WALHeaderFlusher flusher, long newMaxLength) throws IOException {
             boolean scaleWindowHappened = false;
             scaleOutLock.lock();
             try {


### PR DESCRIPTION
The shutdown process gets stuck due to an `IOException` during shutdown:
![img_v3_02dp_7531e63a-d3c3-4fdb-832b-9415031dbe0g](https://github.com/user-attachments/assets/66f7013c-a2d2-41ff-9649-1f2bae778fa2)
