### PR TITLE
fix(s3stream/wal): fail all IO operations once the WAL is failed

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -172,7 +172,8 @@ public class BlockWALService implements WriteAheadLog {
         walHeader.setLastWriteTimestamp(System.nanoTime());
         long trimOffset = walHeader.getTrimOffset();
         ByteBuf buf = walHeader.marshal();
-        this.walChannel.retryWriteAndFlush(buf, position);
+        this.walChannel.retryWrite(buf, position);
+        this.walChannel.retryFlush();
         buf.release();
         walHeader.updateFlushedTrimOffset(trimOffset);
         LOGGER.debug("WAL header flushed, position: {}, header: {}", position, walHeader);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/AbstractWALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/AbstractWALChannel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.wal.util;
+
+import com.automq.stream.utils.Threads;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractWALChannel implements WALChannel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWALChannel.class);
+
+    @Override
+    public void retryWrite(ByteBuf src, long position, long retryIntervalMillis,
+        long retryTimeoutMillis) throws IOException {
+        retry(() -> write(src, position), retryIntervalMillis, retryTimeoutMillis);
+    }
+
+    @Override
+    public void retryFlush(long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
+        retry(this::flush, retryIntervalMillis, retryTimeoutMillis);
+    }
+
+    @Override
+    public int retryRead(ByteBuf dst, long position, long retryIntervalMillis,
+        long retryTimeoutMillis) throws IOException {
+        return retry(() -> read(dst, position), retryIntervalMillis, retryTimeoutMillis);
+    }
+
+    private void retry(IORunnable runnable, long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
+        retry(IOSupplier.from(runnable), retryIntervalMillis, retryTimeoutMillis);
+    }
+
+    private <T> T retry(IOSupplier<T> supplier, long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
+        long start = System.nanoTime();
+        long retryTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(retryTimeoutMillis);
+        while (true) {
+            try {
+                return supplier.get();
+            } catch (IOException e) {
+                if (System.nanoTime() - start > retryTimeoutNanos) {
+                    LOGGER.error("Failed to execute IO operation, retry timeout", e);
+                    throw e;
+                } else {
+                    LOGGER.warn("Failed to execute IO operation, retrying in {}ms, error: {}", retryIntervalMillis, e.getMessage());
+                    Threads.sleep(retryIntervalMillis);
+                }
+            }
+        }
+    }
+
+    private interface IOSupplier<T> {
+        T get() throws IOException;
+
+        static IOSupplier<Void> from(IORunnable runnable) {
+            return () -> {
+                runnable.run();
+                return null;
+            };
+        }
+    }
+
+    private interface IORunnable {
+        void run() throws IOException;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/AbstractWALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/AbstractWALChannel.java
@@ -38,6 +38,7 @@ public abstract class AbstractWALChannel implements WALChannel {
     @Override
     public void retryWrite(ByteBuf src, long position, long retryIntervalMillis,
         long retryTimeoutMillis) throws IOException {
+        checkFailed();
         retry(() -> write(src, position), retryIntervalMillis, retryTimeoutMillis);
     }
 
@@ -49,6 +50,7 @@ public abstract class AbstractWALChannel implements WALChannel {
 
     @Override
     public void retryFlush(long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
+        checkFailed();
         retry(this::flush, retryIntervalMillis, retryTimeoutMillis);
     }
 
@@ -61,6 +63,7 @@ public abstract class AbstractWALChannel implements WALChannel {
     @Override
     public int retryRead(ByteBuf dst, long position, int length, long retryIntervalMillis,
         long retryTimeoutMillis) throws IOException {
+        checkFailed();
         return retry(() -> read(dst, position, length), retryIntervalMillis, retryTimeoutMillis);
     }
 
@@ -69,7 +72,6 @@ public abstract class AbstractWALChannel implements WALChannel {
     }
 
     private <T> T retry(IOSupplier<T> supplier, long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
-        checkFailed();
         long start = System.nanoTime();
         long retryTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(retryTimeoutMillis);
         while (true) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
 import static com.automq.stream.s3.wal.util.WALUtil.isBlockDevice;
 
-public class WALBlockDeviceChannel implements WALChannel {
+public class WALBlockDeviceChannel extends AbstractWALChannel {
     private static final Logger LOGGER = LoggerFactory.getLogger(WALBlockDeviceChannel.class);
     private static final String CHECK_DIRECT_IO_AVAILABLE_FORMAT = "%s.check_direct_io_available";
     final String path;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -237,7 +237,7 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
     }
 
     @Override
-    public void write(ByteBuf src, long position) throws IOException {
+    public void doWrite(ByteBuf src, long position) throws IOException {
         if (unalignedWrite) {
             // unaligned write, just used for testing
             unalignedWrite(src, position);
@@ -295,11 +295,11 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
     }
 
     @Override
-    public void flush() {
+    public void doFlush() {
     }
 
     @Override
-    public int read(ByteBuf dst, long position, int length) throws IOException {
+    public int doRead(ByteBuf dst, long position, int length) throws IOException {
         long start = position;
         length = Math.min(length, dst.writableBytes());
         long end = position + length;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
@@ -20,7 +20,7 @@ import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
 /**
  * A wrapper of {@link WALChannel} that caches for read to reduce I/O.
  */
-public class WALCachedChannel implements WALChannel {
+public class WALCachedChannel extends AbstractWALChannel {
 
     private static final int DEFAULT_CACHE_SIZE = 1 << 20;
 
@@ -128,8 +128,19 @@ public class WALCachedChannel implements WALChannel {
     }
 
     @Override
+    public void retryWrite(ByteBuf src, long position, long retryIntervalMillis,
+        long retryTimeoutMillis) throws IOException {
+        channel.retryWrite(src, position, retryIntervalMillis, retryTimeoutMillis);
+    }
+
+    @Override
     public void flush() throws IOException {
         this.channel.flush();
+    }
+
+    @Override
+    public void retryFlush(long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
+        channel.retryFlush(retryIntervalMillis, retryTimeoutMillis);
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -90,6 +90,10 @@ public interface WALChannel {
      */
     void retryFlush(long retryIntervalMillis, long retryTimeoutMillis) throws IOException;
 
+    default int read(ByteBuf dst, long position) throws IOException {
+        return read(dst, position, dst.writableBytes());
+    }
+
     /**
      * Read bytes from the given position of the channel to the given buffer from the current writer index
      * until reaching the given length or the end of the channel.
@@ -100,18 +104,14 @@ public interface WALChannel {
      */
     int read(ByteBuf dst, long position, int length) throws IOException;
 
-    default int read(ByteBuf dst, long position) throws IOException {
-        return read(dst, position, dst.writableBytes());
-    }
-
     default int retryRead(ByteBuf dst, long position) throws IOException {
-        return retryRead(dst, position, DEFAULT_RETRY_INTERVAL, DEFAULT_RETRY_TIMEOUT);
+        return retryRead(dst, position, dst.writableBytes(), DEFAULT_RETRY_INTERVAL, DEFAULT_RETRY_TIMEOUT);
     }
 
     /**
-     * Retry {@link #read(ByteBuf, long)} with the given interval until success or timeout.
+     * Retry {@link #read(ByteBuf, long, int)} with the given interval until success or timeout.
      */
-    int retryRead(ByteBuf dst, long position, long retryIntervalMillis, long retryTimeoutMillis) throws IOException;
+    int retryRead(ByteBuf dst, long position, int length, long retryIntervalMillis, long retryTimeoutMillis) throws IOException;
 
     boolean useDirectIO();
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -128,40 +128,6 @@ public interface WALChannel {
     }
 
     /**
-     * Call {@link #write(ByteBuf, long)} and {@link #flush()}.
-     */
-    default void writeAndFlush(ByteBuf src, long position) throws IOException {
-        write(src, position);
-        flush();
-    }
-
-    default void retryWriteAndFlush(ByteBuf src, long position) throws IOException {
-        retryWriteAndFlush(src, position, DEFAULT_RETRY_INTERVAL, DEFAULT_RETRY_TIMEOUT);
-    }
-
-    /**
-     * Retry {@link #writeAndFlush(ByteBuf, long)} with the given interval until success or timeout.
-     */
-    default void retryWriteAndFlush(ByteBuf src, long position, long retryIntervalMillis, long retryTimeoutMillis) throws IOException {
-        long start = System.nanoTime();
-        long retryTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(retryTimeoutMillis);
-        while (true) {
-            try {
-                writeAndFlush(src, position);
-                break;
-            } catch (IOException e) {
-                if (System.nanoTime() - start > retryTimeoutNanos) {
-                    LOGGER.error("Failed to write and flush, retry timeout", e);
-                    throw e;
-                } else {
-                    LOGGER.error("Failed to write and flush, retrying in {}ms", retryIntervalMillis, e);
-                    Threads.sleep(retryIntervalMillis);
-                }
-            }
-        }
-    }
-
-    /**
      * Read bytes from the given position of the channel to the given buffer from the current writer index
      * until reaching the given length or the end of the channel.
      * This method will change the writer index of the given buffer to the end of the read bytes.

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
@@ -22,7 +22,7 @@ import java.nio.channels.FileChannel;
 
 import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
 
-public class WALFileChannel implements WALChannel {
+public class WALFileChannel extends AbstractWALChannel {
     final String filePath;
     final long fileCapacityWant;
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
@@ -107,7 +107,7 @@ public class WALFileChannel extends AbstractWALChannel {
     }
 
     @Override
-    public void write(ByteBuf src, long position) throws IOException {
+    public void doWrite(ByteBuf src, long position) throws IOException {
         assert src.readableBytes() + position <= capacity();
         ByteBuffer[] nioBuffers = src.nioBuffers();
         for (ByteBuffer nioBuffer : nioBuffers) {
@@ -117,12 +117,12 @@ public class WALFileChannel extends AbstractWALChannel {
     }
 
     @Override
-    public void flush() throws IOException {
+    public void doFlush() throws IOException {
         fileChannel.force(false);
     }
 
     @Override
-    public int read(ByteBuf dst, long position, int length) throws IOException {
+    public int doRead(ByteBuf dst, long position, int length) throws IOException {
         length = Math.min(length, dst.writableBytes());
         assert position + length <= capacity();
         int bytesRead = 0;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannelTest.java
@@ -54,7 +54,7 @@ public class WALBlockDeviceChannelTest {
         for (int i = 0; i < count; i++) {
             ByteBuf data = TestUtils.random(size);
             long pos = WALUtil.alignLargeByBlockSize(size) * i;
-            channel.writeAndFlush(data, pos);
+            writeAndFlush(channel, data, pos);
         }
 
         channel.close();
@@ -77,7 +77,7 @@ public class WALBlockDeviceChannelTest {
                 data.addComponent(true, TestUtils.random(size));
             }
             long pos = WALUtil.alignLargeByBlockSize(maxSize) * i;
-            channel.writeAndFlush(data, pos);
+            writeAndFlush(channel, data, pos);
         }
 
         channel.close();
@@ -101,7 +101,7 @@ public class WALBlockDeviceChannelTest {
                 ByteBuf data = TestUtils.random(size);
                 long pos = WALUtil.alignLargeByBlockSize(size) * index;
                 try {
-                    channel.writeAndFlush(data, pos);
+                    writeAndFlush(channel, data, pos);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -120,7 +120,7 @@ public class WALBlockDeviceChannelTest {
 
         ByteBuf data = TestUtils.random(42);
         // It's ok to do this
-        assertDoesNotThrow(() -> channel.writeAndFlush(data, 0));
+        assertDoesNotThrow(() -> writeAndFlush(channel, data, 0));
 
         channel.close();
     }
@@ -131,7 +131,7 @@ public class WALBlockDeviceChannelTest {
         channel.open();
 
         ByteBuf data = TestUtils.random(4096);
-        assertThrows(AssertionError.class, () -> channel.writeAndFlush(data, 42));
+        assertThrows(AssertionError.class, () -> writeAndFlush(channel, data, 42));
 
         channel.close();
     }
@@ -142,7 +142,7 @@ public class WALBlockDeviceChannelTest {
         channel.open();
 
         ByteBuf data = TestUtils.random(4096);
-        assertThrows(AssertionError.class, () -> channel.writeAndFlush(data, 8192));
+        assertThrows(AssertionError.class, () -> writeAndFlush(channel, data, 8192));
 
         channel.close();
     }
@@ -163,7 +163,7 @@ public class WALBlockDeviceChannelTest {
             ByteBuf data = TestUtils.random(size);
             long pos = ThreadLocalRandom.current().nextLong(0, capacity - size);
             pos = WALUtil.alignSmallByBlockSize(pos);
-            wChannel.writeAndFlush(data, pos);
+            writeAndFlush(wChannel, data, pos);
 
             ByteBuf buf = Unpooled.buffer(size);
             int read = rChannel.read(buf, pos);
@@ -191,7 +191,7 @@ public class WALBlockDeviceChannelTest {
             ByteBuf data = TestUtils.random(size);
             long pos = ThreadLocalRandom.current().nextLong(0, capacity - size);
             pos = WALUtil.alignSmallByBlockSize(pos);
-            wChannel.writeAndFlush(data, pos);
+            writeAndFlush(wChannel, data, pos);
 
             int start = ThreadLocalRandom.current().nextInt(0, size - 1);
             int end = ThreadLocalRandom.current().nextInt(start + 1, size);
@@ -227,5 +227,10 @@ public class WALBlockDeviceChannelTest {
         assertDoesNotThrow(() -> channel.read(data, 42));
 
         channel.close();
+    }
+
+    private void writeAndFlush(WALChannel channel, ByteBuf src, long position) throws IOException {
+        channel.write(src, position);
+        channel.flush();
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
@@ -57,14 +57,16 @@ public class WALChannelTest {
         ByteBuf data = TestUtils.random(1024 * 3);
         for (int i = 0; i < 100; i++) {
             try {
-                walChannel.writeAndFlush(data, (long) i * data.readableBytes());
+                walChannel.write(data, (long) i * data.readableBytes());
+                walChannel.flush();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
 
         final String content = "Hello World";
-        walChannel.writeAndFlush(Unpooled.wrappedBuffer(content.getBytes()), 100);
+        walChannel.write(Unpooled.wrappedBuffer(content.getBytes()), 100);
+        walChannel.flush();
 
         ByteBuf readBuffer = Unpooled.buffer(content.length());
         int read = walChannel.read(readBuffer, 100);


### PR DESCRIPTION
## Summary

- **Summarize miss suppression logs by key**: Replace the single global suppression counter in `OffsetTimestampMissLogger` with per-key (`topic + reason`) counters. Suppression summary logs now report the count, topic, and reason individually, making it easier to diagnose which topics are experiencing lookup misses.

- **Use `TopicPartition` as `indexes` map key in `OffsetTimestampService`**: The internal `indexes` map was keyed by `TopicIdPartition`, but `TopicPartition` is more stable — Fetch v13 below may carry `ZERO_UUID` as the topicId while the topic name is always valid once the request passes broker validation (`handleFetchRequest` filters out null-name partitions as `UNKNOWN_TOPIC_ID` before they reach `interesting`). Public method signatures remain unchanged (`TopicIdPartition` params), so callers are unaffected.

- **Guard warmup write-back against index replacement**: Capture the index reference at warmup submission time and verify identity before writing back, preventing stale data from leaking into a recreated index after topic delete/recreate.

## Test plan

- [x] `OffsetTimestampMissLoggerTest` updated to verify per-key suppression counts
- [x] `OffsetTimestampServiceTest` passes (47 tests, including `testWarmupDoesNotWriteBackAfterTopicRecreate`)