### PR TITLE
revert: enable `LocalStreamRangeIndexCacheTest#testEvict`

### DIFF
--- a/s3stream/src/test/java/com/automq/stream/s3/index/LocalStreamRangeIndexCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/index/LocalStreamRangeIndexCacheTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-@Timeout(10)
+@Timeout(30)
 public class LocalStreamRangeIndexCacheTest {
     private static final int NODE_0 = 10;
     private static final long STREAM_0 = 0;

--- a/s3stream/src/test/java/com/automq/stream/s3/index/LocalStreamRangeIndexCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/index/LocalStreamRangeIndexCacheTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -142,7 +141,6 @@ public class LocalStreamRangeIndexCacheTest {
     }
 
     @Test
-    @Disabled("FIXME: This test is not stable")
     public void testEvict() {
         ObjectStorage objectStorage = new MemoryObjectStorage();
         LocalStreamRangeIndexCache cache = new LocalStreamRangeIndexCache();


### PR DESCRIPTION
The same as #1869 