### PR TITLE
feat(wal): failoverTest optimization

### DIFF
--- a/s3stream/src/test/java/com/automq/stream/s3/failover/FailoverTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/failover/FailoverTest.java
@@ -61,7 +61,8 @@ public class FailoverTest {
         request.setDevice(path);
         request.setVolumeId("test_volume_id");
 
-        when(failoverFactory.getWal(any())).thenReturn(BlockWALService.builder(path, 1024 * 1024).nodeId(233).epoch(100).build());
+        when(failoverFactory.getWal(any())).thenAnswer(s ->
+            BlockWALService.builder(path, 1024 * 1024).nodeId(233).epoch(100).build());
 
         boolean exceptionThrown = false;
         try {


### PR DESCRIPTION
**Background:** 
 The FailoverFactory#getWal method creates a new BlockWALService object each time it is called. Here, thenAnswer should be used instead of thenReturn,
however, the use of thenReturn did not affect the subsequent tests.
This also exposes the existing issues with the BlockWALService closed-loop.
This  [PR](https://github.com/AutoMQ/automq/pull/1625) contains an optimization plan for the current problem.