### PR TITLE
perf(s3stream): check the logger level before `trace` and `debug`

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -419,7 +419,9 @@ public class S3Stream implements Stream {
                 break;
             }
             if (confirmOffset.compareAndSet(oldConfirmOffset, newOffset)) {
-                LOGGER.trace("{} stream update confirm offset from {} to {}", logIdent, oldConfirmOffset, newOffset);
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("{} stream update confirm offset from {} to {}", logIdent, oldConfirmOffset, newOffset);
+                }
                 break;
             }
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -176,7 +176,9 @@ public class BlockWALService implements WriteAheadLog {
         this.walChannel.retryFlush();
         buf.release();
         walHeader.updateFlushedTrimOffset(trimOffset);
-        LOGGER.debug("WAL header flushed, position: {}, header: {}", position, walHeader);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("WAL header flushed, position: {}, header: {}", position, walHeader);
+        }
     }
 
     /**


### PR DESCRIPTION
The same as #1875 