### PR TITLE
perf(s3stream/wal): reuse the `ByteBuf` for record headers

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
+++ b/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * A pool of fixed-size {@link ByteBuf}.
- * Note: For performance reasons, there is no size limit for this pool. Callers should ensure the pool size is reasonable.
  */
 public class FixedSizeByteBufPool {
 
@@ -26,10 +25,16 @@ public class FixedSizeByteBufPool {
      * The size of the {@link ByteBuf} in this pool.
      */
     private final int bufferSize;
+    /**
+     * The max size of the pool.
+     * It is possible that the pool size exceeds this limit in some rare cases.
+     */
+    private final int maxPoolSize;
     private final Queue<ByteBuf> pool = new ConcurrentLinkedQueue<>();
 
-    public FixedSizeByteBufPool(int bufferSize) {
+    public FixedSizeByteBufPool(int bufferSize, int maxPoolSize) {
         this.bufferSize = bufferSize;
+        this.maxPoolSize = maxPoolSize;
     }
 
     /**
@@ -51,6 +56,12 @@ public class FixedSizeByteBufPool {
      */
     public void release(ByteBuf buffer) {
         assert buffer.capacity() == bufferSize;
+
+        if (pool.size() >= maxPoolSize) {
+            buffer.release();
+            return;
+        }
+
         buffer.clear();
         pool.offer(buffer);
     }

--- a/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
+++ b/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import io.netty.buffer.ByteBuf;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A pool of fixed-size {@link ByteBuf}.
+ */
+public class FixedSizeByteBufPool {
+
+    /**
+     * The size of the {@link ByteBuf} in this pool.
+     */
+    private final int bufferSize;
+    /**
+     * The max size of the pool.
+     * It is possible that the pool size exceeds this limit in some rare cases.
+     */
+    private final int maxPoolSize;
+    private final Queue<ByteBuf> pool = new ConcurrentLinkedQueue<>();
+
+    public FixedSizeByteBufPool(int bufferSize, int maxPoolSize) {
+        this.bufferSize = bufferSize;
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    /**
+     * Get a {@link ByteBuf} from the pool.
+     * If the pool is empty, a new {@link ByteBuf} will be allocated.
+     */
+    public ByteBuf get() {
+        ByteBuf buffer = pool.poll();
+        return buffer == null ? allocate() : buffer;
+    }
+
+    private ByteBuf allocate() {
+        return ByteBufAlloc.byteBuffer(bufferSize);
+    }
+
+    /**
+     * Release a {@link ByteBuf} to the pool.
+     * Note: the buffer MUST be gotten from this pool.
+     */
+    public void release(ByteBuf buffer) {
+        assert buffer.capacity() == bufferSize;
+
+        if (pool.size() >= maxPoolSize) {
+            buffer.release();
+            return;
+        }
+
+        buffer.clear();
+        pool.offer(buffer);
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
+++ b/s3stream/src/main/java/com/automq/stream/FixedSizeByteBufPool.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * A pool of fixed-size {@link ByteBuf}.
+ * Note: For performance reasons, there is no size limit for this pool. Callers should ensure the pool size is reasonable.
  */
 public class FixedSizeByteBufPool {
 
@@ -25,16 +26,10 @@ public class FixedSizeByteBufPool {
      * The size of the {@link ByteBuf} in this pool.
      */
     private final int bufferSize;
-    /**
-     * The max size of the pool.
-     * It is possible that the pool size exceeds this limit in some rare cases.
-     */
-    private final int maxPoolSize;
     private final Queue<ByteBuf> pool = new ConcurrentLinkedQueue<>();
 
-    public FixedSizeByteBufPool(int bufferSize, int maxPoolSize) {
+    public FixedSizeByteBufPool(int bufferSize) {
         this.bufferSize = bufferSize;
-        this.maxPoolSize = maxPoolSize;
     }
 
     /**
@@ -56,12 +51,6 @@ public class FixedSizeByteBufPool {
      */
     public void release(ByteBuf buffer) {
         assert buffer.capacity() == bufferSize;
-
-        if (pool.size() >= maxPoolSize) {
-            buffer.release();
-            return;
-        }
-
         buffer.clear();
         pool.offer(buffer);
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/common/Record.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/common/Record.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.wal.common;
+
+import io.netty.buffer.ByteBuf;
+
+public class Record {
+
+    private final ByteBuf header;
+    private final ByteBuf body;
+
+    public Record(ByteBuf header, ByteBuf body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public ByteBuf header() {
+        return header;
+    }
+
+    public ByteBuf body() {
+        return body;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/common/RecordHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/common/RecordHeader.java
@@ -11,7 +11,6 @@
 
 package com.automq.stream.s3.wal.common;
 
-import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.wal.util.WALUtil;
 import io.netty.buffer.ByteBuf;
 
@@ -81,16 +80,15 @@ public class RecordHeader {
     @Override
     public String toString() {
         return "RecordHeaderCoreData{" +
-               "magicCode=" + magicCode0 +
-               ", recordBodyLength=" + recordBodyLength1 +
-               ", recordBodyOffset=" + recordBodyOffset2 +
-               ", recordBodyCRC=" + recordBodyCRC3 +
-               ", recordHeaderCRC=" + recordHeaderCRC4 +
-               '}';
+            "magicCode=" + magicCode0 +
+            ", recordBodyLength=" + recordBodyLength1 +
+            ", recordBodyOffset=" + recordBodyOffset2 +
+            ", recordBodyCRC=" + recordBodyCRC3 +
+            ", recordHeaderCRC=" + recordHeaderCRC4 +
+            '}';
     }
 
-    private ByteBuf marshalHeaderExceptCRC() {
-        ByteBuf buf = ByteBufAlloc.byteBuffer(RECORD_HEADER_SIZE);
+    private ByteBuf marshalHeaderExceptCRC(ByteBuf buf) {
         buf.writeInt(magicCode0);
         buf.writeInt(recordBodyLength1);
         buf.writeLong(recordBodyOffset2);
@@ -98,8 +96,9 @@ public class RecordHeader {
         return buf;
     }
 
-    public ByteBuf marshal() {
-        ByteBuf buf = marshalHeaderExceptCRC();
+    public ByteBuf marshal(ByteBuf emptyBuf) {
+        assert emptyBuf.writableBytes() == RECORD_HEADER_SIZE;
+        ByteBuf buf = marshalHeaderExceptCRC(emptyBuf);
         buf.writeInt(WALUtil.crc32(buf, RECORD_HEADER_WITHOUT_CRC_SIZE));
         return buf;
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
@@ -34,7 +34,7 @@ public class BlockImpl implements Block {
     /**
      * The pool for record headers.
      */
-    private static final FixedSizeByteBufPool HEADER_POOL = new FixedSizeByteBufPool(RECORD_HEADER_SIZE, 1024);
+    private static final FixedSizeByteBufPool HEADER_POOL = new FixedSizeByteBufPool(RECORD_HEADER_SIZE);
 
     private final long startOffset;
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
@@ -34,7 +34,7 @@ public class BlockImpl implements Block {
     /**
      * The pool for record headers.
      */
-    private static final FixedSizeByteBufPool HEADER_POOL = new FixedSizeByteBufPool(RECORD_HEADER_SIZE);
+    private static final FixedSizeByteBufPool HEADER_POOL = new FixedSizeByteBufPool(RECORD_HEADER_SIZE, 1024);
 
     private final long startOffset;
     /**

--- a/s3stream/src/test/java/com/automq/stream/FixedSizeByteBufPoolTest.java
+++ b/s3stream/src/test/java/com/automq/stream/FixedSizeByteBufPoolTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FixedSizeByteBufPoolTest {
+
+    private static final int BUFFER_SIZE = 42;
+
+    private FixedSizeByteBufPool pool;
+
+    @BeforeEach
+    void setUp() {
+        pool = new FixedSizeByteBufPool(BUFFER_SIZE);
+    }
+
+    @Test
+    void testGetBufferFromEmptyPool() {
+        ByteBuf buffer = pool.get();
+        assertNotNull(buffer, "Buffer should not be null");
+        assertEquals(BUFFER_SIZE, buffer.capacity(), "Buffer size should be " + BUFFER_SIZE);
+    }
+
+    @Test
+    void testReleaseAndReuseBuffer() {
+        ByteBuf buffer = pool.get();
+        assertNotNull(buffer, "Buffer should not be null");
+        assertEquals(BUFFER_SIZE, buffer.capacity(), "Buffer size should be " + BUFFER_SIZE);
+
+        buffer.writeInt(42);
+        pool.release(buffer);
+
+        ByteBuf buffer2 = pool.get();
+        assertSame(buffer, buffer2, "Buffer should be reused from the pool");
+        assertEquals(0, buffer2.readableBytes(), "Buffer should be cleared on release");
+        assertEquals(BUFFER_SIZE, buffer2.writableBytes(), "Buffer should be cleared on release");
+    }
+
+    @Test
+    void testReleaseBufferWithDifferentSizeThrowsAssertionError() {
+        ByteBuf buffer = Unpooled.buffer(128); // Different size
+        assertThrows(AssertionError.class, () -> pool.release(buffer), "Should throw AssertionError for different buffer size");
+    }
+
+    @Test
+    void testMultipleBuffers() {
+        ByteBuf buffer1 = pool.get();
+        ByteBuf buffer2 = pool.get();
+
+        assertNotSame(buffer1, buffer2, "Different calls to get() should return different buffers");
+
+        pool.release(buffer1);
+        pool.release(buffer2);
+
+        ByteBuf buffer3 = pool.get();
+        ByteBuf buffer4 = pool.get();
+
+        assertTrue(buffer3 == buffer1 || buffer3 == buffer2, "Buffer3 should be one of the released buffers");
+        assertTrue(buffer4 == buffer1 || buffer4 == buffer2, "Buffer4 should be one of the released buffers");
+        assertNotSame(buffer3, buffer4, "Buffer3 and Buffer4 should not be the same after release");
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/FixedSizeByteBufPoolTest.java
+++ b/s3stream/src/test/java/com/automq/stream/FixedSizeByteBufPoolTest.java
@@ -31,7 +31,7 @@ class FixedSizeByteBufPoolTest {
 
     @BeforeEach
     void setUp() {
-        pool = new FixedSizeByteBufPool(BUFFER_SIZE);
+        pool = new FixedSizeByteBufPool(BUFFER_SIZE, 2);
     }
 
     @Test
@@ -78,5 +78,24 @@ class FixedSizeByteBufPoolTest {
         assertTrue(buffer3 == buffer1 || buffer3 == buffer2, "Buffer3 should be one of the released buffers");
         assertTrue(buffer4 == buffer1 || buffer4 == buffer2, "Buffer4 should be one of the released buffers");
         assertNotSame(buffer3, buffer4, "Buffer3 and Buffer4 should not be the same after release");
+    }
+
+    @Test
+    void testOverCapacity() {
+        ByteBuf buffer1 = pool.get();
+        ByteBuf buffer2 = pool.get();
+        ByteBuf buffer3 = pool.get();
+
+        pool.release(buffer1);
+        pool.release(buffer2);
+        pool.release(buffer3);
+
+        ByteBuf buffer4 = pool.get();
+        ByteBuf buffer5 = pool.get();
+        ByteBuf buffer6 = pool.get();
+
+        assertSame(buffer4, buffer1, "Buffer4 should be reused from the pool");
+        assertSame(buffer5, buffer2, "Buffer5 should be reused from the pool");
+        assertNotSame(buffer6, buffer3, "Buffer6 should not be reused from the pool");
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/block/BlockWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/block/BlockWALServiceTest.java
@@ -903,7 +903,7 @@ class BlockWALServiceTest {
             .setRecordBodyLength(body.readableBytes())
             .setRecordBodyOffset(offset + RECORD_HEADER_SIZE)
             .setRecordBodyCRC(WALUtil.crc32(body))
-            .marshal();
+            .marshal(ByteBufAlloc.byteBuffer(RECORD_HEADER_SIZE));
     }
 
     private void write(WALChannel walChannel, long logicOffset, int recordSize) throws IOException {


### PR DESCRIPTION
Part of #1874 