### PR TITLE
feat(metadata): add metrics for sparse index cache monitor

### DIFF
--- a/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
+++ b/core/src/main/java/kafka/autobalancer/detector/AnomalyDetector.java
@@ -211,6 +211,8 @@ public class AnomalyDetector extends AbstractResumableService {
             if (configs.containsKey(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_GOALS)) {
                 reconfigureGoals(configs);
             }
+            logger.info("Reconfigured anomaly detector with detectInterval: {}ms, executionConcurrency: {}, executionIntervalMs: {}ms, goals: {}, excluded brokers: {}, excluded topics: {}",
+                    this.detectInterval, this.executionConcurrency, this.executionIntervalMs, this.goalsByPriority, this.excludedBrokers, this.excludedTopics);
         } finally {
             configChangeLock.unlock();
         }

--- a/core/src/main/java/kafka/autobalancer/model/BrokerUpdater.java
+++ b/core/src/main/java/kafka/autobalancer/model/BrokerUpdater.java
@@ -166,6 +166,7 @@ public class BrokerUpdater extends AbstractInstanceUpdater {
         public String shortString() {
             return "Broker{" +
                     "brokerId=" + brokerId +
+                    "outOfDate=" + metricsOutOfDate +
                     ", slow=" + isSlowBroker +
                     ", " + timeString() +
                     ", " + loadString() +
@@ -183,6 +184,7 @@ public class BrokerUpdater extends AbstractInstanceUpdater {
         public String toString() {
             return "Broker{" +
                     "brokerId=" + brokerId +
+                    "outOfDate=" + metricsOutOfDate +
                     ", slow=" + isSlowBroker +
                     ", " + super.toString() +
                     "}";

--- a/core/src/main/java/kafka/autobalancer/model/TopicPartitionReplicaUpdater.java
+++ b/core/src/main/java/kafka/autobalancer/model/TopicPartitionReplicaUpdater.java
@@ -109,6 +109,7 @@ public class TopicPartitionReplicaUpdater extends AbstractInstanceUpdater {
         public String shortString() {
             return "TopicPartitionReplica{" +
                     "tp=" + tp +
+                    "outOfDate=" + metricsOutOfDate +
                     ", " + timeString() +
                     ", " + loadString() +
                     "}";
@@ -123,7 +124,9 @@ public class TopicPartitionReplicaUpdater extends AbstractInstanceUpdater {
 
         @Override
         public String toString() {
-            return "{TopicPartition=" + tp +
+            return "TopicPartitionReplica{" +
+                    "tp=" + tp +
+                    "outOfDate=" + metricsOutOfDate +
                     ", " + super.toString() +
                     "}";
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -420,7 +420,7 @@ public class S3Storage implements Storage {
         append0(context, writeRequest, false);
         return cf.whenComplete((nil, ex) -> {
             streamRecord.release();
-            StorageOperationStats.getInstance().appendStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+            StorageOperationStats.getInstance().appendStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
         });
     }
 
@@ -526,7 +526,7 @@ public class S3Storage implements Storage {
         final long startTime = System.nanoTime();
         CompletableFuture<ReadDataBlock> cf = new CompletableFuture<>();
         FutureUtil.propagate(read0(context, streamId, startOffset, endOffset, maxBytes), cf);
-        cf.whenComplete((nil, ex) -> StorageOperationStats.getInstance().readStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS)));
+        cf.whenComplete((nil, ex) -> StorageOperationStats.getInstance().readStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS)));
         return cf;
     }
 
@@ -613,7 +613,7 @@ public class S3Storage implements Storage {
         CompletableFuture<Void> cf = new CompletableFuture<>();
         // Wait for a while to group force upload tasks.
         forceUploadTicker.tick().whenComplete((nil, ex) -> {
-            StorageOperationStats.getInstance().forceUploadWALAwaitStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+            StorageOperationStats.getInstance().forceUploadWALAwaitStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
             uploadDeltaWAL(streamId, true);
             // Wait for all tasks contains streamId complete.
             FutureUtil.propagate(CompletableFuture.allOf(this.inflightWALUploadTasks.stream()
@@ -624,7 +624,7 @@ public class S3Storage implements Storage {
             }
         });
         cf.whenComplete((nil, ex) -> StorageOperationStats.getInstance().forceUploadWALCompleteStats.record(
-            TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS)));
+            TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS)));
         return cf;
     }
 
@@ -658,7 +658,7 @@ public class S3Storage implements Storage {
         for (WalWriteRequest waitingAckRequest : waitingAckRequests) {
             waitingAckRequest.cf.complete(null);
         }
-        StorageOperationStats.getInstance().appendCallbackStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+        StorageOperationStats.getInstance().appendCallbackStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
     }
 
     private Lock getStreamCallbackLock(long streamId) {

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -164,7 +164,7 @@ public class S3Stream implements Stream {
             pendingAppends.add(cf);
             pendingAppendTimestamps.push(startTimeNanos);
             return cf.whenComplete((nil, ex) -> {
-                StreamOperationStats.getInstance().appendStreamLatency.record(TimerUtil.durationElapsedAs(startTimeNanos, TimeUnit.NANOSECONDS));
+                StreamOperationStats.getInstance().appendStreamLatency.record(TimerUtil.timeElapsedSince(startTimeNanos, TimeUnit.NANOSECONDS));
                 pendingAppends.remove(cf);
                 pendingAppendTimestamps.pop();
             });

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -93,7 +93,7 @@ public class LogCache {
         } finally {
             readLock.unlock();
         }
-        StorageOperationStats.getInstance().appendLogCacheStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+        StorageOperationStats.getInstance().appendLogCacheStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
         return full;
     }
 
@@ -142,7 +142,7 @@ public class LogCache {
             readLock.unlock();
         }
 
-        long timeElapsed = TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS);
+        long timeElapsed = TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS);
         boolean isCacheHit = !records.isEmpty() && records.get(0).getBaseOffset() <= startOffset;
         StorageOperationStats.getInstance().readLogCacheStats(isCacheHit).record(timeElapsed);
         return records;

--- a/s3stream/src/main/java/com/automq/stream/s3/index/NodeRangeIndexCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/index/NodeRangeIndexCache.java
@@ -13,6 +13,8 @@ package com.automq.stream.s3.index;
 
 import com.automq.stream.s3.cache.AsyncMeasurable;
 import com.automq.stream.s3.cache.AsyncLRUCache;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.stats.MetadataStats;
 import com.automq.stream.utils.Time;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +86,7 @@ public class NodeRangeIndexCache {
             }
             indexCache = new StreamRangeIndexCache(cacheSupplier.get());
             this.nodeRangeIndexMap.put(nodeId, indexCache);
+            MetadataStats.getInstance().getRangeIndexUpdateCountStats().add(MetricsLevel.INFO, 1);
             LOGGER.info("Update stream range index for node {}", nodeId);
         }
         return indexCache.searchObjectId(streamId, startOffset);

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsConstant.java
@@ -118,6 +118,11 @@ public class S3StreamMetricsConstant {
     public static final String READ_BLOCK_CACHE_METRIC_NAME = "read_block_cache_stage_time";
     public static final String READ_BLOCK_CACHE_THROUGHPUT_METRIC_NAME = "block_cache_ops_throughput";
     public static final String COMPACTION_DELAY_TIME_METRIC_NAME = "compaction_delay_time";
+    public static final String GET_OBJECTS_TIME_METRIC_NAME = "get_objects_time";
+    public static final String OBJECTS_SEARCH_COUNT_METRIC_NAME = "objects_search_count";
+    public static final String LOCAL_STREAM_RANGE_INDEX_CACHE_SIZE_METRIC_NAME = "local_stream_range_index_cache_size";
+    public static final String LOCAL_STREAM_RANGE_INDEX_CACHE_STREAM_NUM_METRIC_NAME = "local_stream_range_index_cache_stream_num";
+    public static final String NODE_RANGE_INDEX_CACHE_OPERATION_COUNT_METRIC_NAME = "node_range_index_cache_operation_count";
     public static final AttributeKey<String> LABEL_OPERATION_TYPE = AttributeKey.stringKey("operation_type");
     public static final AttributeKey<String> LABEL_OPERATION_NAME = AttributeKey.stringKey("operation_name");
     public static final AttributeKey<String> LABEL_SIZE_NAME = AttributeKey.stringKey("size");
@@ -130,6 +135,8 @@ public class S3StreamMetricsConstant {
     public static final String LABEL_STATUS_FAILED = "failed";
     public static final String LABEL_STATUS_HIT = "hit";
     public static final String LABEL_STATUS_MISS = "miss";
+    public static final String LABEL_STATUS_UPDATE = "update";
+    public static final String LABEL_STATUS_INVALIDATE = "invalidate";
     public static final String LABEL_STATUS_SYNC = "sync";
     public static final String LABEL_STATUS_ASYNC = "async";
 

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/TimerUtil.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/TimerUtil.java
@@ -38,7 +38,7 @@ public final class TimerUtil {
         return timeUnit.convert(now - last.getAndSet(now), TimeUnit.NANOSECONDS);
     }
 
-    public static long durationElapsedAs(long statNanoTime, TimeUnit timeUnit) {
+    public static long timeElapsedSince(long statNanoTime, TimeUnit timeUnit) {
         return timeUnit.convert(System.nanoTime() - statNanoTime, TimeUnit.NANOSECONDS);
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/MetadataStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/MetadataStats.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.metrics.stats;
+
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.S3StreamMetricsConstant;
+import com.automq.stream.s3.metrics.S3StreamMetricsManager;
+import com.automq.stream.s3.metrics.wrapper.CounterMetric;
+import com.automq.stream.s3.metrics.wrapper.HistogramMetric;
+
+public class MetadataStats {
+    private volatile static MetadataStats instance = null;
+    private final HistogramMetric getObjectsTimeSuccessStats = S3StreamMetricsManager.buildGetObjectsTimeMetric(MetricsLevel.INFO,
+        S3StreamMetricsConstant.LABEL_STATUS_SUCCESS);
+    private final HistogramMetric getObjectsTimeFailedStats = S3StreamMetricsManager.buildGetObjectsTimeMetric(MetricsLevel.INFO,
+        S3StreamMetricsConstant.LABEL_STATUS_FAILED);
+    private final CounterMetric rangeIndexUpdateCountStats = S3StreamMetricsManager.buildRangeIndexCacheOperationMetric(S3StreamMetricsConstant.LABEL_STATUS_UPDATE);
+    private final CounterMetric rangeIndexInvalidateCountStats = S3StreamMetricsManager.buildRangeIndexCacheOperationMetric(S3StreamMetricsConstant.LABEL_STATUS_INVALIDATE);
+    private final CounterMetric rangeIndexHitCountStats = S3StreamMetricsManager.buildRangeIndexCacheOperationMetric(S3StreamMetricsConstant.LABEL_STATUS_HIT);
+    private final CounterMetric rangeIndexMissCountStats = S3StreamMetricsManager.buildRangeIndexCacheOperationMetric(S3StreamMetricsConstant.LABEL_STATUS_MISS);
+    private final HistogramMetric rangeIndexSkippedObjectNumStats = S3StreamMetricsManager.buildObjectsToSearchMetric(MetricsLevel.INFO);
+
+    private MetadataStats() {
+    }
+
+    public static MetadataStats getInstance() {
+        if (instance == null) {
+            synchronized (MetadataStats.class) {
+                if (instance == null) {
+                    instance = new MetadataStats();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public HistogramMetric getObjectsTimeSuccessStats() {
+        return getObjectsTimeSuccessStats;
+    }
+
+    public HistogramMetric getObjectsTimeFailedStats() {
+        return getObjectsTimeFailedStats;
+    }
+
+    public CounterMetric getRangeIndexUpdateCountStats() {
+        return rangeIndexUpdateCountStats;
+    }
+
+    public CounterMetric getRangeIndexInvalidateCountStats() {
+        return rangeIndexInvalidateCountStats;
+    }
+
+    public CounterMetric getRangeIndexHitCountStats() {
+        return rangeIndexHitCountStats;
+    }
+
+    public CounterMetric getRangeIndexMissCountStats() {
+        return rangeIndexMissCountStats;
+    }
+
+    public HistogramMetric getRangeIndexSkippedObjectNumStats() {
+        return rangeIndexSkippedObjectNumStats;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -170,7 +170,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
                     .whenComplete((v, ex) ->
                         NetworkStats.getInstance()
                             .networkLimiterQueueTimeStats(AsyncNetworkBandwidthLimiter.Type.INBOUND, throttleStrategy)
-                            .record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS)));
+                            .record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS)));
 
             };
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockImpl.java
@@ -156,6 +156,6 @@ public class BlockImpl implements Block {
 
     @Override
     public void polled() {
-        StorageOperationStats.getInstance().appendWALBlockPolledStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+        StorageOperationStats.getInstance().appendWALBlockPolledStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -423,7 +423,7 @@ public class BlockWALService implements WriteAheadLog {
             return result;
         } catch (OverCapacityException ex) {
             buf.release();
-            StorageOperationStats.getInstance().appendWALFullStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+            StorageOperationStats.getInstance().appendWALFullStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
             TraceUtils.endSpan(scope, ex);
             throw ex;
         }
@@ -456,8 +456,8 @@ public class BlockWALService implements WriteAheadLog {
         slidingWindowService.tryWriteBlock();
 
         final AppendResult appendResult = new AppendResultImpl(expectedWriteOffset, appendResultFuture);
-        appendResult.future().whenComplete((nil, ex) -> StorageOperationStats.getInstance().appendWALCompleteStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS)));
-        StorageOperationStats.getInstance().appendWALBeforeStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+        appendResult.future().whenComplete((nil, ex) -> StorageOperationStats.getInstance().appendWALCompleteStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS)));
+        StorageOperationStats.getInstance().appendWALBeforeStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
         return appendResult;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/SlidingWindowService.java
@@ -383,7 +383,7 @@ public class SlidingWindowService {
             walChannel.retryWrite(block.data(), position);
         }
         walChannel.retryFlush();
-        StorageOperationStats.getInstance().appendWALWriteStats.record(TimerUtil.durationElapsedAs(start, TimeUnit.NANOSECONDS));
+        StorageOperationStats.getInstance().appendWALWriteStats.record(TimerUtil.timeElapsedSince(start, TimeUnit.NANOSECONDS));
     }
 
     private void makeWriteOffsetMatchWindow(long newWindowEndOffset) throws IOException {
@@ -476,7 +476,7 @@ public class SlidingWindowService {
 
         @Override
         public void run() {
-            StorageOperationStats.getInstance().appendWALAwaitStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+            StorageOperationStats.getInstance().appendWALAwaitStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
             try {
                 writeBlock(this.blocks);
             } catch (Exception e) {
@@ -507,7 +507,7 @@ public class SlidingWindowService {
                     return "CallbackResult{" + "flushedOffset=" + flushedOffset() + '}';
                 }
             });
-            StorageOperationStats.getInstance().appendWALAfterStats.record(TimerUtil.durationElapsedAs(startTime, TimeUnit.NANOSECONDS));
+            StorageOperationStats.getInstance().appendWALAfterStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
         }
     }
 }


### PR DESCRIPTION
metrics added:
- kafka_stream_local_stream_range_index_cache_stream_num: The number of streams cached in local sparse index
- kafka_stream_local_stream_range_index_cache_size_bytes: The total size in bytes of local sparse index
- kafka_stream_node_range_index_cache_operation_count_total: The cumulative count of different type of operations on sparse index cache (update/invalidate/hit/miss)
- kafka_stream_get_objects_time_sum(50p/99p/max)_nanosecond: The delta time spend on determining which s3 objects to read from for a certain stream range
- kafka_stream_get_objects_time_count: The delta num of invoking getObjects method 