### PR TITLE
feat(s3stream): support limit write bandwidth for WALBlockDeviceChannel

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -53,7 +53,7 @@ public class AutoMQConfig {
     public static final String S3_OPS_BUCKETS_DOC = "With the same format as s3.data.buckets";
 
     public static final String S3_WAL_PATH_CONFIG = "s3.wal.path";
-    public static final String S3_WAL_PATH_DOC = "The local WAL path for AutoMQ can be set to a block device path such as 0@file:///dev/xxx?iops=3000&iodepth=8 or a filesystem file path." +
+    public static final String S3_WAL_PATH_DOC = "The local WAL path for AutoMQ can be set to a block device path such as 0@file:///dev/xxx?iops=3000&iodepth=8&iobandwidth=157286400 or a filesystem file path." +
         "It is recommended to use a block device for better write performance.";
 
     public static final String S3_WAL_CACHE_SIZE_CONFIG = "s3.wal.cache.size";

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -717,6 +717,7 @@ public class BlockWALService implements WriteAheadLog {
                 + ", slidingWindowScaleUnit=" + slidingWindowScaleUnit
                 + ", blockSoftLimit=" + blockSoftLimit
                 + ", writeRateLimit=" + writeRateLimit
+                + ", writeBandwidthLimit=" + writeBandwidthLimit
                 + ", nodeId=" + nodeId
                 + ", epoch=" + epoch
                 + ", recoveryMode=" + recoveryMode

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -557,7 +557,7 @@ public class BlockWALService implements WriteAheadLog {
         // wal io request limit
         private int writeRateLimit = 3000;
         // wal io bandwidth limit
-        private long writeBandwidthLimit = 500 * 1024 * 1024; // 500MB/s
+        private long writeBandwidthLimit = 1024 * 1024 * 1024; // 1GB/s
         private int nodeId = NOOP_NODE_ID;
         private long epoch = NOOP_EPOCH;
         private boolean recoveryMode = false;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -155,7 +155,7 @@ public class BlockWALService implements WriteAheadLog {
         BlockWALService.BlockWALServiceBuilder builder = BlockWALService.builder(uri.path(), uri.extensionLong("capacity", 2147483648L));
         Optional.ofNullable(uri.extensionString("iops")).filter(StringUtils::isNumeric).ifPresent(v -> builder.writeRateLimit(Integer.parseInt(v)));
         Optional.ofNullable(uri.extensionString("iodepth")).filter(StringUtils::isNumeric).ifPresent(v -> builder.ioThreadNums(Integer.parseInt(v)));
-        Optional.ofNullable(uri.extensionString("iobandwidth")).filter(StringUtils::isNumeric).ifPresent(v -> builder.writeBandwidthLimit(Integer.parseInt(v)));
+        Optional.ofNullable(uri.extensionString("iobandwidth")).filter(StringUtils::isNumeric).ifPresent(v -> builder.writeBandwidthLimit(Long.parseLong(v)));
         return builder;
     }
 
@@ -557,7 +557,7 @@ public class BlockWALService implements WriteAheadLog {
         // wal io request limit
         private int writeRateLimit = 3000;
         // wal io bandwidth limit
-        private int writeBandwidthLimit = 500 * 1024 * 1024; // 500MB/s
+        private long writeBandwidthLimit = 500 * 1024 * 1024; // 500MB/s
         private int nodeId = NOOP_NODE_ID;
         private long epoch = NOOP_EPOCH;
         private boolean recoveryMode = false;
@@ -632,7 +632,7 @@ public class BlockWALService implements WriteAheadLog {
             return this;
         }
 
-        public BlockWALServiceBuilder writeBandwidthLimit(int writeBandwidthLimit) {
+        public BlockWALServiceBuilder writeBandwidthLimit(long writeBandwidthLimit) {
             this.writeBandwidthLimit = writeBandwidthLimit;
             return this;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -71,7 +71,8 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
     private final BlockingBucket bucket;
 
     public WALBlockDeviceChannel(String path, long capacityWant) {
-        this(path, capacityWant, 0, 0, false, Long.MAX_VALUE);
+        this(path, capacityWant, 0, 0, false,
+            MAX_RATE_LIMIT_BYTES_PER_MS * 1000L);
     }
 
     public WALBlockDeviceChannel(String path, long capacityWant, int initTempBufferSize, int maxTempBufferSize,

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -16,6 +16,7 @@ import com.automq.stream.s3.wal.exception.WALNotInitializedException;
 import com.automq.stream.thirdparty.moe.cnkirito.kdio.DirectIOLib;
 import com.automq.stream.thirdparty.moe.cnkirito.kdio.DirectIOUtils;
 import com.automq.stream.thirdparty.moe.cnkirito.kdio.DirectRandomAccessFile;
+import com.google.common.annotations.VisibleForTesting;
 import io.github.bucket4j.BlockingBucket;
 import io.github.bucket4j.Bucket;
 import io.netty.buffer.ByteBuf;
@@ -35,6 +36,9 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
     private static final Logger LOGGER = LoggerFactory.getLogger(WALBlockDeviceChannel.class);
     private static final String CHECK_DIRECT_IO_AVAILABLE_FORMAT = "%s.check_direct_io_available";
     public static final long MAX_RATE_LIMIT_BYTES_PER_MS = 1_000_000L;
+    // the write size is expected to be at least BLOCK_SIZE (4096)
+    // use scale when acquire bandwidth rate limiter.
+    public static final long BANDWIDTH_RATE_LIMIT_SCALE_FACTOR = 2;
     final String path;
     final long capacityWant;
     final boolean recoveryMode;
@@ -95,17 +99,42 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
             throw new RuntimeException(String.format("block size %d is not a multiple of %d, update it by jvm option: -D%s=%d",
                 WALUtil.BLOCK_SIZE, blockSize, WALUtil.BLOCK_SIZE_PROPERTY, blockSize));
         }
-        this.directIOLib = lib;
 
         this.writeBandwidthLimit = writeBandwidthBytePerSecondLimit;
+        this.bucket = buildBandWidthRateLimiter(writeBandwidthBytePerSecondLimit, blockSize).asBlocking();
+        this.directIOLib = lib;
+    }
 
-        // max 1 token/nanosecond = 953.67MB/s
-        long refillPerMs = Math.min(writeBandwidthBytePerSecondLimit / 1000, MAX_RATE_LIMIT_BYTES_PER_MS);
+    /**
+     * bucket4j limit max 1 token/nanosecond
+     * after scale real limit is 4 bytes/nanosecond = 3814.7 MB/s.
+     */
+    @VisibleForTesting
+    public static long validRefillPerMs(long writeBandwidthBytePerSecondLimit, int blockSize) {
+        if (WALUtil.BLOCK_SIZE % BANDWIDTH_RATE_LIMIT_SCALE_FACTOR != 0
+            || WALUtil.BLOCK_SIZE >> BANDWIDTH_RATE_LIMIT_SCALE_FACTOR <= 0) {
+            throw new RuntimeException(String.format("block size %d is not a multiple of %d, update it by jvm option: -D%s=%d",
+                WALUtil.BLOCK_SIZE, BANDWIDTH_RATE_LIMIT_SCALE_FACTOR, WALUtil.BLOCK_SIZE_PROPERTY, blockSize));
+        }
 
-        this.bucket = Bucket.builder()
-            .addLimit(limit -> limit.capacity(writeBandwidthBytePerSecondLimit).refillIntervally(refillPerMs, Duration.ofMillis(1)))
-            .build()
-            .asBlocking();
+        long refillPerMs = (writeBandwidthBytePerSecondLimit / 1000) >> BANDWIDTH_RATE_LIMIT_SCALE_FACTOR;
+
+        if (refillPerMs > MAX_RATE_LIMIT_BYTES_PER_MS || refillPerMs <= 0) {
+            throw new RuntimeException(String.format("block device writeBandwidthLimit %d not valid after scale by %d refillPerMs %d",
+                writeBandwidthBytePerSecondLimit, BANDWIDTH_RATE_LIMIT_SCALE_FACTOR, refillPerMs));
+        }
+
+        return refillPerMs;
+    }
+
+    @VisibleForTesting
+    public static Bucket buildBandWidthRateLimiter(long writeBandwidthBytePerSecondLimit, int blockSize) {
+        long refillPerMs = validRefillPerMs(writeBandwidthBytePerSecondLimit, blockSize);
+
+        return Bucket.builder().addLimit(limit -> limit
+            .capacity(writeBandwidthBytePerSecondLimit >> BANDWIDTH_RATE_LIMIT_SCALE_FACTOR)
+            .refillIntervally(refillPerMs, Duration.ofMillis(1)))
+            .build();
     }
 
     /**
@@ -305,7 +334,8 @@ public class WALBlockDeviceChannel extends AbstractWALChannel {
 
         if (size > 0) {
             try {
-                bucket.consume(size);
+                // the write size is isAligned to BLOCK_SIZE so it is ok to scale
+                bucket.consume(size >> BANDWIDTH_RATE_LIMIT_SCALE_FACTOR);
             } catch (InterruptedException e) {
                 throw new IOException("write rate limit consume interrupted", e);
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
+import static com.automq.stream.s3.wal.util.WALBlockDeviceChannel.MAX_RATE_LIMIT_BYTES_PER_MS;
 import static com.automq.stream.s3.wal.util.WALUtil.isBlockDevice;
 
 /**
@@ -131,7 +132,7 @@ public interface WALChannel {
         private int initBufferSize;
         private int maxBufferSize;
         private boolean recoveryMode;
-        private long writeBandwidthLimit = Long.MAX_VALUE;
+        private long writeBandwidthLimit = MAX_RATE_LIMIT_BYTES_PER_MS * 1000L;
 
         private WALChannelBuilder(String path) {
             this.path = path;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -131,7 +131,7 @@ public interface WALChannel {
         private int initBufferSize;
         private int maxBufferSize;
         private boolean recoveryMode;
-        private int writeBandwidthLimit;
+        private long writeBandwidthLimit = Long.MAX_VALUE;
 
         private WALChannelBuilder(String path) {
             this.path = path;
@@ -164,7 +164,7 @@ public interface WALChannel {
         }
 
 
-        public WALChannelBuilder writeBandWidthLimit(int writeBandwidthLimit) {
+        public WALChannelBuilder writeBandWidthLimit(long writeBandwidthLimit) {
             this.writeBandwidthLimit = writeBandwidthLimit;
             return this;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -131,6 +131,7 @@ public interface WALChannel {
         private int initBufferSize;
         private int maxBufferSize;
         private boolean recoveryMode;
+        private int writeBandwidthLimit;
 
         private WALChannelBuilder(String path) {
             this.path = path;
@@ -162,6 +163,12 @@ public interface WALChannel {
             return this;
         }
 
+
+        public WALChannelBuilder writeBandWidthLimit(int writeBandwidthLimit) {
+            this.writeBandwidthLimit = writeBandwidthLimit;
+            return this;
+        }
+
         public WALChannel build() {
             String directNotAvailableMsg = WALBlockDeviceChannel.checkAvailable(path);
             boolean isBlockDevice = isBlockDevice(path);
@@ -186,7 +193,7 @@ public interface WALChannel {
             }
 
             if (useDirect) {
-                return new WALBlockDeviceChannel(path, capacity, initBufferSize, maxBufferSize, recoveryMode);
+                return new WALBlockDeviceChannel(path, capacity, initBufferSize, maxBufferSize, recoveryMode, writeBandwidthLimit);
             } else {
                 LOGGER.warn("Direct IO not used for WAL, which may cause performance degradation. path: {}, isBlockDevice: {}, reason: {}",
                     new File(path).getAbsolutePath(), isBlockDevice, directNotAvailableMsg);

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
@@ -12,18 +12,27 @@
 package com.automq.stream.s3.wal.util;
 
 import com.automq.stream.s3.TestUtils;
+import io.github.bucket4j.Bucket;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @Tag("S3Unit")
 public class WALChannelTest {
     public static final String TEST_BLOCK_DEVICE_KEY = "WAL_TEST_BLOCK_DEVICE";
+
+    long gbPerSeconds = 1024 * 1024 * 1024L;
+    long mbPerSeconds = 1024 * 1024;
 
     WALChannel walChannel;
 
@@ -77,5 +86,56 @@ public class WALChannelTest {
 
         assert read == content.length();
         assert readString.equals(content);
+    }
+
+    @Test
+    void testWALBandwidthLimit() throws InterruptedException {
+        Bucket bucket = WALBlockDeviceChannel.buildBandWidthRateLimiter(150 * mbPerSeconds, 4096);
+        TimeUnit.MILLISECONDS.sleep(10);
+        Assertions.assertFalse(bucket.tryConsume((150 * mbPerSeconds >> WALBlockDeviceChannel.BANDWIDTH_RATE_LIMIT_SCALE_FACTOR) + 2));
+        Assertions.assertTrue(bucket.tryConsume(150 * mbPerSeconds >> WALBlockDeviceChannel.BANDWIDTH_RATE_LIMIT_SCALE_FACTOR));
+    }
+
+    @Test
+    void testWALBandwidthLimitConfig() {
+        try {
+            WALBlockDeviceChannel.validRefillPerMs(
+                150 * mbPerSeconds,
+                512);
+
+            WALBlockDeviceChannel.validRefillPerMs(
+                150 * mbPerSeconds,
+                4096);
+
+            WALBlockDeviceChannel.validRefillPerMs(
+                3 * gbPerSeconds,
+                512);
+
+            WALBlockDeviceChannel.validRefillPerMs(
+                3 * gbPerSeconds,
+                4096);
+
+            WALBlockDeviceChannel.validRefillPerMs(
+                WALBlockDeviceChannel.MAX_RATE_LIMIT_BYTES_PER_MS * 1000L,
+                512);
+
+            WALBlockDeviceChannel.validRefillPerMs(
+                WALBlockDeviceChannel.MAX_RATE_LIMIT_BYTES_PER_MS * 1000L,
+                4096);
+
+        } catch (Exception e) {
+            Assertions.fail("should not throw exception", e);
+        }
+
+        boolean exceptionThrows = false;
+        try {
+            WALBlockDeviceChannel.validRefillPerMs(Long.MAX_VALUE, 4096);
+        } catch (Exception e) {
+            // expected.
+            exceptionThrows = true;
+        }
+
+        assertTrue(exceptionThrows);
+
     }
 }


### PR DESCRIPTION
### why need this?
1. the block device provider have limit on iobandwidth and iops. either one exceed the limit the write block channel time goes very high (cause by the block device qos)
2. when single node write request number is high. the write may exceed the limit iobandwidth for a little time but can cause the pending request accumlate and finally the broker will have very long write latency.

