### PR TITLE
feat(core): default configuration optimization

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -117,7 +117,7 @@ public class AutoMQConfig {
 
     public static final String S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT_CONFIG = "s3.max.stream.num.per.stream.set.object";
     public static final String S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT_DOC = "The maximum number of streams allowed in single stream set object";
-    public static final int S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT = 100000;
+    public static final int S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT = 20000;
 
     public static final String S3_MAX_STREAM_OBJECT_NUM_PER_COMMIT_CONFIG = "s3.max.stream.object.num.per.commit";
     public static final String S3_MAX_STREAM_OBJECT_NUM_PER_COMMIT_DOC = "The maximum number of stream objects in single commit request";

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -239,7 +239,7 @@ public final class QuorumController implements Controller {
     /**
      * The maximum records that the controller will write in a single batch.
      */
-    private final static int MAX_RECORDS_PER_BATCH = 25000;
+    private final static int MAX_RECORDS_PER_BATCH = 50000;
 
     /**
      * The maximum records any user-initiated operation is allowed to generate.


### PR DESCRIPTION
1. decrease default max stream number per sso config to 20k, corresponds to 15k streams per node as recommended upper limit
2. increase single batch record size limit to 50k for worst case to force split a sso with 20k streams