### PR TITLE
feat(core): default configuration optimization

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -232,7 +232,7 @@ public final class QuorumController implements Controller {
     /**
      * The maximum records that the controller will write in a single batch.
      */
-    private final static int MAX_RECORDS_PER_BATCH = 25000;
+    private final static int MAX_RECORDS_PER_BATCH = 50000;
 
     /**
      * The maximum records any user-initiated operation is allowed to generate.

--- a/server/src/main/java/org/apache/kafka/server/config/Defaults.java
+++ b/server/src/main/java/org/apache/kafka/server/config/Defaults.java
@@ -284,7 +284,7 @@ public class Defaults {
     public static final long S3_STREAM_SET_OBJECT_COMPACTION_STREAM_SPLIT_SIZE = 8 * 1024 * 1024; // 8MB
     public static final int S3_STREAM_SET_OBJECT_COMPACTION_FORCE_SPLIT_MINUTES = 120; // 120min
     public static final int S3_STREAM_SET_OBJECT_COMPACTION_MAX_OBJECT_NUM = 500;
-    public static final int S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT = 100000;
+    public static final int S3_MAX_STREAM_NUM_PER_STREAM_SET_OBJECT = 20000;
     public static final int S3_MAX_STREAM_OBJECT_NUM_PER_COMMIT = 10000;
     public static final long S3_OBJECT_DELETE_RETENTION_MINUTES = 1; // 1min
     public static final long S3_NETWORK_BASELINE_BANDWIDTH = 100 * 1024 * 1024; // 100MB/s


### PR DESCRIPTION
1. decrease default max stream number per sso config to 20k, corresponds to 15k streams per node as recommended upper limit
2. increase single batch record size limit to 50k for worst case to force split a sso with 20k streams
