### PR TITLE
feat(metrics): skip reporting metrics delay for newly created partition

### DIFF
--- a/core/src/main/java/kafka/autobalancer/model/AbstractInstanceUpdater.java
+++ b/core/src/main/java/kafka/autobalancer/model/AbstractInstanceUpdater.java
@@ -31,6 +31,15 @@ public abstract class AbstractInstanceUpdater {
     protected Map<Byte, Samples> metricSampleMap = new HashMap<>();
     protected long lastUpdateTimestamp = 0L;
     protected MetricVersion metricVersion = defaultVersion();
+    private final long createTimestamp;
+
+    public AbstractInstanceUpdater() {
+        this.createTimestamp = System.currentTimeMillis();
+    }
+
+    public long createTimestamp() {
+        return createTimestamp;
+    }
 
     public boolean update(Iterable<Map.Entry<Byte, Double>> metricsMap, long time) {
         lock.lock();

--- a/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
+++ b/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
@@ -32,7 +32,7 @@ public class ClusterModel {
     protected final Logger logger;
     private static final String DEFAULT_RACK_ID = "rack_default";
     private static final long DEFAULT_MAX_TOLERATED_METRICS_DELAY_MS = 60000L;
-
+    private static final long DEFAULT_METRICS_DELAY_EXEMPTION_TIME_MS = 60000L;
     /*
      * Guard the access on cluster structure (read/add/remove for brokers, replicas)
      */
@@ -78,6 +78,10 @@ public class ClusterModel {
                 Map<TopicPartition, TopicPartitionReplicaUpdater> replicaMap = entry.getValue();
                 for (Map.Entry<TopicPartition, TopicPartitionReplicaUpdater> tpEntry : replicaMap.entrySet()) {
                     TopicPartitionReplicaUpdater replicaUpdater = tpEntry.getValue();
+                    if (System.currentTimeMillis() - replicaUpdater.createTimestamp() <= DEFAULT_METRICS_DELAY_EXEMPTION_TIME_MS) {
+                        // exempt the newly created partition
+                        continue;
+                    }
                     metricsTimeMap.put(brokerId, Math.min(metricsTimeMap.get(brokerId), replicaUpdater.getLastUpdateTimestamp()));
                 }
             }

--- a/core/src/test/java/kafka/autobalancer/model/ClusterModelTest.java
+++ b/core/src/test/java/kafka/autobalancer/model/ClusterModelTest.java
@@ -392,7 +392,7 @@ public class ClusterModelTest {
 
         Map<Integer, Long> metricsTimeMap = clusterModel.calculateBrokerLatestMetricsTime();
         Assertions.assertEquals(1, metricsTimeMap.size());
-        Assertions.assertEquals(now - 2000, metricsTimeMap.get(brokerId));
+        Assertions.assertEquals(now, metricsTimeMap.get(brokerId));
     }
 
     @Test


### PR DESCRIPTION
give some exemption time (60s) for newly created partition to receive metrics before reporting it as out-of-sync to prevent false alert
