### PR TITLE
ci(main):  fix start sh

### DIFF
--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -265,8 +265,8 @@ kafka_up() {
   for role in "broker" "controller" "server"; do
       setup_value "node.id" "${node_id}" "${kafka_dir}/config/kraft/${role}.properties"
       setup_value "controller.quorum.voters" "${quorum_voters}" "${kafka_dir}/config/kraft/${role}.properties"
-      setup_value "s3.data.bucket" "0@s3://${s3_bucket}?region=${s3_region}&endpoint=${s3_endpoint}&accessKey=static" "${kafka_dir}/config/kraft/${role}.properties"
-      setup_value "s3.ops.bucket" "0@s3://${s3_bucket}?region=${s3_region}&endpoint=${s3_endpoint}&accessKey=static" "${kafka_dir}/config/kraft/${role}.properties"
+      setup_value "s3.data.buckets" "0@s3://${s3_bucket}?region=${s3_region}&endpoint=${s3_endpoint}&authType=static" "${kafka_dir}/config/kraft/${role}.properties"
+      setup_value "s3.ops.buckets" "0@s3://${s3_bucket}?region=${s3_region}&endpoint=${s3_endpoint}&authType=static" "${kafka_dir}/config/kraft/${role}.properties"
       setup_value "log.dirs" "${data_path}/kraft-${role}-logs" "${kafka_dir}/config/kraft/${role}.properties"
       setup_value "s3.wal.path" "0@file://${data_path}/wal?capacity=2147483648" "${kafka_dir}/config/kraft/${role}.properties"
       # turn on auto_balancer


### PR DESCRIPTION
This pull request includes a change in the `docker/scripts/start.sh` file to update the S3 bucket configuration for Kafka roles. The most important change is the modification of the S3 bucket configuration properties to use `authType=static` instead of `accessKey=static`.

Configuration updates:

* [`docker/scripts/start.sh`](diffhunk://#diff-4c4be7114665bf713eb5aa82e0c67369bd9c7fcea84ed16fe5d0b51ac07204dbL268-R269): Changed `s3.data.bucket` to `s3.data.buckets` and `s3.ops.bucket` to `s3.ops.buckets`, updating the S3 configuration to use `authType=static` instead of `accessKey=static`.