### PR TITLE
chore(config): update log4j properties

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -20,13 +20,13 @@ log4j.rootLogger=INFO, stdout, connectAppender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 
-# Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
-# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
-# and copied in the same directory but with a filename that ends in the `DatePattern` option.
+# Send the logs to a file, rolling the file when it reaches the specified size. For example, the `File` option specifies the
+# location of the log files (e.g. ${kafka.logs.dir}/connect.log). The `MaxFileSize` option specifies the maximum size of the log file,
+# and the `MaxBackupIndex` option specifies the number of backup files to keep.
 #
 log4j.appender.connectAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.connectAppender.MaxFileSize=10MB
-log4j.appender.kafkaAppender.MaxBackupIndex=11
+log4j.appender.connectAppender.MaxBackupIndex=11
 log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
 log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
 


### PR DESCRIPTION
Update the log4j properties file to roll the log file when it reaches the specified size. The `MaxFileSize` option is set to 10MB and the `MaxBackupIndex` option is set to 11 to keep 11 backup files.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
