### PR TITLE
Add "testing" to github-actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "testing" ]
 
 jobs:
   build-automq:


### PR DESCRIPTION
This is the beginning stagings for having the the github actions build pipelines given the ability to run over various other branches without the need to necessarily "release" or "version-bump".

Once I have more comprehensive test-suites in place I will begin to highlight the obvious usecases and utility in having more than one standard build pipeline.

[x] Verify design and implementation 
[x] Verify test coverage and CI build status
[x] Verify documentation (including upgrade notes)
