### PR TITLE
chore: trigger build when the status of PR is ready_for_review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@
 name: Build
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
   push:
     branches: [ "main" ]
 


### PR DESCRIPTION
Just as the other "trial" commit I have thinking of ways to re-factor the _Github Actions_ build process.

This is just a minor add-on but I think it would be an important one to include.

- [x ] Verify design and implementation 
- [ x] Verify test coverage and CI build status
- [ x] Verify documentation (including upgrade notes)
