### PR TITLE
feat(tools/perf): run benchmark without consumer

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
@@ -116,6 +116,12 @@ public class ConsumerService implements AutoCloseable {
         }
     }
 
+    public int consumerCount() {
+        return groups.stream()
+            .mapToInt(Group::consumerCount)
+            .sum();
+    }
+
     @Override
     public void close() {
         admin.close();


### PR DESCRIPTION
The same as #2134 