### PR TITLE
fix(stream): release `FetchResult`s if the subsequent fetch fails

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
@@ -159,6 +159,7 @@ public class ElasticLogFileRecords implements AutoCloseable {
                         } else {
                             LOGGER.error("Invalid record batch, last offset {} is less than next offset {}",
                                     recordBatchWithContext.lastOffset(), nextFetchOffset);
+                            rst.free();
                             throw new IllegalStateException();
                         }
                         readSize += recordBatchWithContext.rawPayload().remaining();
@@ -168,6 +169,10 @@ public class ElasticLogFileRecords implements AutoCloseable {
                                 // add to first since we need to reverse the order.
                                 rstList.addFirst(rst);
                                 return rstList;
+                            }).whenComplete((r, e) -> {
+                                if (e != null) {
+                                    rst.free();
+                                }
                             });
                 });
     }

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
@@ -142,6 +142,12 @@ public class ElasticLogFileRecords implements AutoCloseable {
         }
         List<FetchResult> results = new LinkedList<>();
         return fetch0(context, nextFetchOffset, endOffset, maxSize, results)
+                .whenComplete((nil, e) -> {
+                    if (e != null) {
+                        results.forEach(FetchResult::free);
+                        results.clear();
+                    }
+                })
                 .thenApply(nil -> PooledMemoryRecords.of(baseOffset, results, context.readOptions().pooledBuf()));
     }
 

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
@@ -159,7 +159,6 @@ public class ElasticLogFileRecords implements AutoCloseable {
                         } else {
                             LOGGER.error("Invalid record batch, last offset {} is less than next offset {}",
                                     recordBatchWithContext.lastOffset(), nextFetchOffset);
-                            rst.free();
                             throw new IllegalStateException();
                         }
                         readSize += recordBatchWithContext.rawPayload().remaining();
@@ -169,10 +168,6 @@ public class ElasticLogFileRecords implements AutoCloseable {
                                 // add to first since we need to reverse the order.
                                 rstList.addFirst(rst);
                                 return rstList;
-                            }).whenComplete((r, e) -> {
-                                if (e != null) {
-                                    rst.free();
-                                }
                             });
                 });
     }


### PR DESCRIPTION
fix #2171 