### PR TITLE
fix: use the "adjusted" `maxSize` in `ElasticLogSegment#readAsync`

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
@@ -269,7 +269,7 @@ public class ElasticLogSegment extends LogSegment implements Comparable<ElasticL
             return CompletableFuture.completedFuture(new FetchDataInfo(offsetMetadata, MemoryRecords.EMPTY));
         }
 
-        return log.read(startOffset, maxOffset, maxSize)
+        return log.read(startOffset, maxOffset, adjustedMaxSize)
             .thenApply(records -> new FetchDataInfo(offsetMetadata, records));
     }
 


### PR DESCRIPTION
The same as #2184 