### PR TITLE
fix(cli/deploy): override "controller.quorum.bootstrap.servers"

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/commands/cluster/Deploy.java
+++ b/automq-shell/src/main/java/com/automq/shell/commands/cluster/Deploy.java
@@ -159,6 +159,7 @@ public class Deploy implements Callable<Integer> {
         sb.append("--override cluster.id=").append(topo.getGlobal().getClusterId()).append(" ");
         sb.append("--override node.id=").append(node.getNodeId()).append(" ");
         sb.append("--override controller.quorum.voters=").append(getQuorumVoters(topo)).append(" ");
+        sb.append("--override controller.quorum.bootstrap.servers=").append(getBootstrapServers(topo)).append(" ");
         sb.append("--override advertised.listeners=").append("PLAINTEXT://").append(node.getHost()).append(":9092").append(" ");
     }
 
@@ -179,6 +180,16 @@ public class Deploy implements Callable<Integer> {
         }
         return nodes.stream()
             .map(node -> node.getNodeId() + "@" + node.getHost() + ":9093")
+            .collect(Collectors.joining(","));
+    }
+
+    private static String getBootstrapServers(ClusterTopology topo) {
+        List<Node> nodes = topo.getControllers();
+        if (!(nodes.size() == 1 || nodes.size() == 3)) {
+            throw new IllegalArgumentException("Only support 1 or 3 controllers");
+        }
+        return nodes.stream()
+            .map(node -> node.getHost() + ":9093")
             .collect(Collectors.joining(","));
     }
 }


### PR DESCRIPTION
Adapt to following Apache Kafka changes:
- KAFKA-16525; Dynamic KRaft network manager and channel: https://github.com/AutoMQ/automq/commit/459da479
- KAFKA-17048; Update docs for KIP-853: https://github.com/AutoMQ/automq/commit/c141acb6