### PR TITLE
fix(s3stream/wal): increase max record size from 16MiB to 64MiB

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/block/BlockWALService.java
@@ -556,7 +556,7 @@ public class BlockWALService implements WriteAheadLog {
         private long blockDeviceCapacityWant = CAPACITY_NOT_SET;
         private Boolean direct = null;
         private int initBufferSize = 1 << 20; // 1MiB
-        private int maxBufferSize = 1 << 24; // 16MiB
+        private int maxBufferSize = 1 << 26; // 64MiB
         private int ioThreadNums = 8;
         private long slidingWindowInitialSize = 1 << 20; // 1MiB
         private long slidingWindowUpperLimit = 1 << 29; // 512MiB


### PR DESCRIPTION
The same as #2296 