### PR TITLE
fix(network): prevent NullPointerException during broker shutdown on bootstrap failure

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -710,18 +710,12 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
 
   private def closeAll(): Unit = {
     debug("Closing server socket, selector, and any throttled sockets.")
-    
     // AutoMQ inject start
     // Ensure null-safe closure of serverChannel to avoid NullPointerException
-    Option(serverChannel).foreach { ch =>
-      CoreUtils.swallow(ch.close(), this, Level.ERROR)
-    }
+    Option(serverChannel).foreach { ch => CoreUtils.swallow(ch.close(), this, Level.ERROR) }
     // AutoMQ inject end
-
     CoreUtils.swallow(nioSelector.close(), this, Level.ERROR)
-    throttledSockets.foreach { throttledSocket =>
-      closeSocket(throttledSocket.socket, this)
-    }
+    throttledSockets.foreach(throttledSocket => closeSocket(throttledSocket.socket, this))
     throttledSockets.clear()
   }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -708,21 +708,21 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
     }
   }
 
-private def closeAll(): Unit = {
+  private def closeAll(): Unit = {
     debug("Closing server socket, selector, and any throttled sockets.")
-
+    
+    // AutoMQ inject start
+    // Ensure null-safe closure of serverChannel to avoid NullPointerException
     Option(serverChannel).foreach { ch =>
       CoreUtils.swallow(ch.close(), this, Level.ERROR)
     }
+    // AutoMQ inject end
 
-    Option(nioSelector).foreach { sel =>
-      CoreUtils.swallow(sel.close(), this, Level.ERROR)
+    CoreUtils.swallow(nioSelector.close(), this, Level.ERROR)
+    throttledSockets.foreach { throttledSocket =>
+      closeSocket(throttledSocket.socket, this)
     }
-
-    Option(throttledSockets).foreach { sockets =>
-      sockets.foreach(throttledSocket => closeSocket(throttledSocket.socket, this))
-      sockets.clear()
-    }
+    throttledSockets.clear()
   }
 
   /**

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -708,12 +708,21 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
     }
   }
 
-  private def closeAll(): Unit = {
+private def closeAll(): Unit = {
     debug("Closing server socket, selector, and any throttled sockets.")
-    CoreUtils.swallow(serverChannel.close(), this, Level.ERROR)
-    CoreUtils.swallow(nioSelector.close(), this, Level.ERROR)
-    throttledSockets.foreach(throttledSocket => closeSocket(throttledSocket.socket, this))
-    throttledSockets.clear()
+
+    Option(serverChannel).foreach { ch =>
+      CoreUtils.swallow(ch.close(), this, Level.ERROR)
+    }
+
+    Option(nioSelector).foreach { sel =>
+      CoreUtils.swallow(sel.close(), this, Level.ERROR)
+    }
+
+    Option(throttledSockets).foreach { sockets =>
+      sockets.foreach(throttledSocket => closeSocket(throttledSocket.socket, this))
+      sockets.clear()
+    }
   }
 
   /**


### PR DESCRIPTION
Use Option(variable).foreach  to avoid NullPointerException

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
