### PR TITLE
fix(s3stream): Add unit tests for WALCallbackSequencer (#2368)

### DIFF
--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -52,6 +52,7 @@ import io.netty.buffer.ByteBuf;
 
 import static com.automq.stream.s3.TestUtils.random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -177,6 +178,94 @@ public class S3StorageTest {
         assertEquals(List.of(r2, r3), seq.after(r2));
         assertEquals(List.of(r0), seq.after(r0));
         assertEquals(List.of(r1), seq.after(r1));
+    }
+
+    /**
+     * WALCallbackSequencer
+     */
+    @Test
+    public void testTryFreeWithEmptyQueue() {
+        S3Storage.WALCallbackSequencer seq = new S3Storage.WALCallbackSequencer();
+        long streamId = 200L;
+
+        // Create a request and process it, emptying the queue
+        WalWriteRequest request = new WalWriteRequest(newRecord(streamId, 20L), 200L, new CompletableFuture<>());
+        seq.before(request);
+        seq.after(request);
+
+        // Call tryFree to remove the empty queue
+        seq.tryFree(streamId);
+
+        // If the queue was removed correctly, a new queue will be created and processed normally
+        WalWriteRequest newRequest = new WalWriteRequest(newRecord(streamId, 21L), 201L, new CompletableFuture<>());
+        seq.before(newRequest);
+        List<WalWriteRequest> result = seq.after(newRequest);
+        assertEquals(List.of(newRequest), result);
+    }
+
+    /**
+     * WALCallbackSequencer
+     */
+    @Test
+    public void testTryFreeWithNonEmptyQueue() {
+        S3Storage.WALCallbackSequencer seq = new S3Storage.WALCallbackSequencer();
+        long streamId = 300L;
+
+        // Add multiple requests
+        WalWriteRequest r0 = new WalWriteRequest(newRecord(streamId, 30L), 300L, new CompletableFuture<>());
+        WalWriteRequest r1 = new WalWriteRequest(newRecord(streamId, 31L), 301L, new CompletableFuture<>());
+
+        seq.before(r0);
+        seq.before(r1);
+
+        // Only process the first request, the queue should be non-empty
+        seq.after(r0);
+
+        // Call tryFree, but the queue should not be removed
+        seq.tryFree(streamId);
+
+        // The second request should still in the queue
+        List<WalWriteRequest> result = seq.after(r1);
+        assertEquals(List.of(r1), result);
+    }
+
+    /**
+     * WALCallbackSequencer
+     */
+    @Test
+    public void testBeforeExceptionHandling() {
+        S3Storage.WALCallbackSequencer seq = new S3Storage.WALCallbackSequencer();
+
+        // Create a request that will cause the before method to throw an exception,
+        // For example, let record be null
+        WalWriteRequest request = new WalWriteRequest(null, 500L, new CompletableFuture<>());
+
+        seq.before(request);
+
+        // Verify that the future has been completed abnormally
+        assertTrue(request.cf.isCompletedExceptionally());
+    }
+
+    /**
+     * WALCallbackSequencer
+     */
+    @Test
+    public void testAfterWithDifferentOffset() {
+        S3Storage.WALCallbackSequencer seq = new S3Storage.WALCallbackSequencer();
+        long streamId = 600L;
+
+        WalWriteRequest r0 = new WalWriteRequest(newRecord(streamId, 60L), 600L, new CompletableFuture<>());
+        seq.before(r0);
+
+        // Create a request with the same streamId but a different offset
+        WalWriteRequest r1 = new WalWriteRequest(newRecord(streamId, 61L), 601L, new CompletableFuture<>());
+
+        // Process r1, but it is not in the queue, so after should return an empty list
+        List<WalWriteRequest> result = seq.after(r1);
+        assertEquals(Collections.emptyList(), result);
+
+        // Verify that r1 is marked as persistent
+        assertTrue(r1.persisted);
     }
 
     @Test

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -181,6 +181,31 @@ public class S3StorageTest {
     }
 
     /**
+     * WALCallbackSequencer - Test after() when a stream's queue becomes empty
+     */
+    @Test
+    public void testAfterWhenQueueBecomesEmpty() {
+        S3Storage.WALCallbackSequencer seq = new S3Storage.WALCallbackSequencer();
+        long streamId = 700L;
+
+        WalWriteRequest request = new WalWriteRequest(newRecord(streamId, 70L), 700L, new CompletableFuture<>());
+        seq.before(request);
+
+        // Process the request, making the queue empty
+        List<WalWriteRequest> result = seq.after(request);
+        assertEquals(List.of(request), result);
+
+        // Verify that subsequent processing works correctly after the queue became empty
+        // Add a new request to the same stream
+        WalWriteRequest newRequest = new WalWriteRequest(newRecord(streamId, 71L), 701L, new CompletableFuture<>());
+        seq.before(newRequest);
+
+        // Process the new request
+        List<WalWriteRequest> newResult = seq.after(newRequest);
+        assertEquals(List.of(newRequest), newResult);
+    }
+
+    /**
      * WALCallbackSequencer
      */
     @Test


### PR DESCRIPTION
## Description
Added comprehensive unit tests for the WALCallbackSequencer class to improve code coverage and test edge cases. The new tests focus on:

- Testing `after()` method behavior when a stream queue becomes empty
- Testing `tryFree()` method with both empty and non-empty queues
- Testing exception handling in the `before()` method
- Testing `after()` method with requests having different offsets than expected

## Changes Made
- Added 5 new test methods to S3StorageTest.java to cover different edge cases
- Ensured tests verify behavior through public APIs since some fields are private
- Verified correct sequencing behavior for WAL callbacks, particularly in edge cases