### PR TITLE
feat(build): Support Mount-Based Local Development Setup for AutoMQ with Docker Compose

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -95,13 +95,13 @@ Format Metadata Catalog:
 bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/server.properties
 ```
 ### IDE Start Configuration
-| Item            | Value    |
-|------------------------|------------|
-| Main | core/src/main/scala/kafka/Kafka.scala     |
-| ClassPath | -cp kafka.core.main |
-| VM Options   | -Xmx1 -Xms1G -server -XX:+UseZGC -XX:MaxDirectMemorySize=2G -Dkafka.logs.dir=logs/ -Dlog4j.configuration=file:config/log4j.properties -Dio.netty.leakDetection.level=paranoid    |
-| CLI Arguments | config/kraft/server.properties|
-| Environment | KAFKA_S3_ACCESS_KEY=test;KAFKA_S3_SECRET_KEY=test |
+| Item            | Value                                                                                                                                                                          |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Main | core/src/main/scala/kafka/Kafka.scala                                                                                                                                          |
+| ClassPath | -cp kafka.core.main                                                                                                                                                            |
+| VM Options   | -Xmx1G -Xms1G -server -XX:+UseZGC -XX:MaxDirectMemorySize=2G -Dkafka.logs.dir=logs/ -Dlog4j.configuration=file:config/log4j.properties -Dio.netty.leakDetection.level=paranoid |
+| CLI Arguments | config/kraft/server.properties                                                                                                                                                 |
+| Environment | KAFKA_S3_ACCESS_KEY=test;KAFKA_S3_SECRET_KEY=test                                                                                                                              |
 
 > tips: If you are using localstack, just use any value of access key and secret key. If you are using real S3 service, set `KAFKA_S3_ACCESS_KEY` and `KAFKA_S3_SECRET_KEY` to the real access key and secret key that have read/write permission of S3 service.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -213,3 +213,16 @@ python generate_kafka_pr_template.py --image-type=jvm
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow. `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka). 
   - **NOTE:** As of now [KIP-1028](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1028%3A+Docker+Official+Image+for+Apache+Kafka) only aims to release JVM based Docker Official Images and not GraalVM based native Apache Kafka docker image.
 
+Using local docker container for run and debug
+----------------------------------------------
+
+- First, make sure the project has been [built](/CONTRIBUTING_GUIDE.md#build).
+
+- Run `docker-compose` command with `docker/docker_for_local_develop/docker-compose.yml` file.
+
+```shell
+# Create and start the docker container
+docker-compose -f docker/docker_for_local_develop/docker-compose.yml up -d
+# Stop and remove the docker container
+docker-compose -f docker/docker_for_local_develop/docker-compose.yml down -v
+```

--- a/docker/docker_for_local_develop/.env
+++ b/docker/docker_for_local_develop/.env
@@ -1,0 +1,3 @@
+KAFKA_S3_SECRET_KEY: test
+KAFKA_S3_ACCESS_KEY: test
+KAFKA_CLUSTER_ID: "$(bin/kafka-storage.sh random-uuid)"

--- a/docker/docker_for_local_develop/docker-compose.yaml
+++ b/docker/docker_for_local_develop/docker-compose.yaml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  local_dev_broker:
+    container_name: "local-dev-broker1"
+    hostname: "local-dev-broker1"
+    stop_grace_period: 2m
+    image: gradle:jdk17
+    ports:
+      - "9094:9094"
+    working_dir: /tmp/automq
+    command:
+      - bash
+      - -c
+      - |
+        bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/server.properties
+        bin/kafka-server-start.sh config/kraft/server.properties
+    networks:
+      - automq_net
+    external_links:
+      - localstack
+      - aws-cli
+      - controller
+    volumes:
+      - ../../:/tmp/automq
+volumes:
+  s3_data:
+    driver: local
+networks:
+  automq_net:
+    name: automq_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.6.0.0/16"
+          gateway: "10.6.0.1"


### PR DESCRIPTION
Issue: #2374 

I added the `.env` environment variable file and the `docker-compose.yaml` file. I can mount the project into the Docker container and run related commands to start AutoMQ.

This does not require rebuilding the image, just restarting the container.

Image: gradle:jdk17

Secondly, a document writing error was fixed by the way.

- In the JDK virtual machine parameters, `-Xms` is greater than `-Xmx`, which will generate an error of `Initial heap size set to a larger value than the maximum heap size`