### PR TITLE
fix: using SecureRandom in perf tools

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 import static org.apache.kafka.tools.automq.perf.PerfConfig.IntegerArgumentType.between;
@@ -334,7 +335,7 @@ public class PerfConfig {
 
     private String randomString(int length) {
         final String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        Random r = ThreadLocalRandom.current();
+        Random r = new SecureRandom();
         StringBuilder sb = new StringBuilder(length);
         for (int i = 0; i < length; i++) {
             sb.append(characters.charAt(r.nextInt(characters.length())));


### PR DESCRIPTION
**Description**
This PR fixes a potential security vulnerability in the randomString method in PerfConfig.java by replacing ThreadLocalRandom with SecureRandom for generating random strings.

**Issue**
The current implementation uses ThreadLocalRandom which is not cryptographically secure and could lead to predictable tokens when used for security purposes.

**Fix**
Replace ThreadLocalRandom.current() with new SecureRandom() to ensure cryptographic strength.

**References**
Similar to vulnerability in CVE-2017-15911
Fixed in Openfire: https://github.com/igniterealtime/Openfire/commit/7ff1f73077cca1b3ec25d5897f31f15340c8fa4e