### PR TITLE
refactor(s3stream/object-wal): complete appends sequentially

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -77,7 +77,7 @@ public class ObjectWALService implements WriteAheadLog {
     }
 
     // Visible for testing.
-    protected RecordAccumulator accumulator() {
+    RecordAccumulator accumulator() {
         return accumulator;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -226,7 +226,7 @@ public class ObjectWALService implements WriteAheadLog {
             ObjectStorage.ReadOptions options = new ObjectStorage.ReadOptions()
                 .throttleStrategy(ThrottleStrategy.BYPASS)
                 .bucket(object.bucketId());
-            ByteBuf buffer = objectStorage.rangeRead(options, object.path(), 0, WALObjectHeader.DEFAULT_WAL_HEADER_SIZE).join();
+            ByteBuf buffer = objectStorage.rangeRead(options, object.path(), 0, object.length()).join();
             WALObjectHeader header = WALObjectHeader.unmarshal(buffer);
             buffer.release();
             return header.trimOffset();

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -245,7 +245,7 @@ public class ObjectWALService implements WriteAheadLog {
 
             // Check header
             WALObjectHeader header = WALObjectHeader.unmarshal(dataBuffer);
-            dataBuffer.skipBytes(WALObjectHeader.WAL_HEADER_SIZE);
+            dataBuffer.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
 
             if (skipStickyRecord && header.stickyRecordLength() != 0) {
                 dataBuffer.skipBytes((int) header.stickyRecordLength());

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -245,7 +245,7 @@ public class ObjectWALService implements WriteAheadLog {
 
             // Check header
             WALObjectHeader header = WALObjectHeader.unmarshal(dataBuffer);
-            dataBuffer.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
+            dataBuffer.skipBytes(header.size());
 
             if (skipStickyRecord && header.stickyRecordLength() != 0) {
                 dataBuffer.skipBytes((int) header.stickyRecordLength());

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -200,6 +200,7 @@ public class ObjectWALService implements WriteAheadLog {
 
         public RecoverIterator(List<RecordAccumulator.WALObject> objectList, ObjectStorage objectStorage,
             int readAheadObjectSize) {
+            // TODO: check and drop discontinuous objects.
             this.objectList = objectList;
             this.objectStorage = objectStorage;
             this.readAheadObjectSize = readAheadObjectSize;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -232,12 +232,13 @@ public class ObjectWALService implements WriteAheadLog {
             return header.trimOffset();
         }
 
-        private static List<RecordAccumulator.WALObject> getContinuousFromTrimOffset(List<RecordAccumulator.WALObject> objectList, long trimOffset) {
+        // Visible for testing.
+        static List<RecordAccumulator.WALObject> getContinuousFromTrimOffset(List<RecordAccumulator.WALObject> objectList, long trimOffset) {
             if (objectList.isEmpty()) {
                 return Collections.emptyList();
             }
 
-            int startIndex = 0;
+            int startIndex = objectList.size();
             for (int i = 0; i < objectList.size(); i++) {
                 if (objectList.get(i).endOffset() > trimOffset) {
                     startIndex = i;
@@ -248,6 +249,9 @@ public class ObjectWALService implements WriteAheadLog {
                 for (int i = 0; i < startIndex; i++) {
                     log.warn("drop trimmed object: {}", objectList.get(i));
                 }
+            }
+            if (startIndex >= objectList.size()) {
+                return Collections.emptyList();
             }
 
             int endIndex = startIndex + 1;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -255,7 +255,7 @@ public class RecordAccumulator implements Closeable {
     }
 
     // Visible for testing
-    public ScheduledExecutorService executorService() {
+    ScheduledExecutorService executorService() {
         return executorService;
     }
 
@@ -418,7 +418,7 @@ public class RecordAccumulator implements Closeable {
 
     // Not thread safe, caller should hold lock.
     // Visible for testing.
-    public void unsafeUpload(boolean force) throws WALFencedException {
+    void unsafeUpload(boolean force) throws WALFencedException {
         if (!force) {
             checkWriteStatus();
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -688,8 +689,22 @@ public class RecordAccumulator implements Closeable {
                 "bucketId=" + bucketId +
                 ", path='" + path + '\'' +
                 ", startOffset=" + startOffset +
+                ", endOffset=" + endOffset +
                 ", length=" + length +
                 '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof WALObject))
+                return false;
+            WALObject object = (WALObject) o;
+            return bucketId == object.bucketId && startOffset == object.startOffset && endOffset == object.endOffset && length == object.length && Objects.equals(path, object.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(bucketId, path, startOffset, endOffset, length);
         }
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -523,6 +523,7 @@ public class RecordAccumulator implements Closeable {
                     objectMap.put(endOffset, new WALObject(result.bucket(), path, firstOffset, objectLength));
                     objectDataBytes.addAndGet(objectLength);
 
+                    // TODO: only remove records when all upload tasks before `firstOffset` is finished
                     List<Record> uploadedRecords = uploadMap.remove(firstOffset);
 
                     // Update flushed offset

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -232,7 +232,7 @@ public class RecordAccumulator implements Closeable {
         if (utilityService != null && !utilityService.isShutdown()) {
             utilityService.shutdown();
             try {
-                if (!utilityService.awaitTermination(30, TimeUnit.SECONDS)) {
+                if (!utilityService.awaitTermination(1, TimeUnit.SECONDS)) {
                     log.error("Monitor executor {} did not terminate in time", executorService);
                     utilityService.shutdownNow();
                 }
@@ -273,6 +273,11 @@ public class RecordAccumulator implements Closeable {
         list.addAll(previousObjectMap.values());
         list.addAll(objectMap.values());
         return list;
+    }
+
+    // Visible for testing
+    String objectPrefix() {
+        return objectPrefix;
     }
 
     // Visible for testing

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -118,12 +118,12 @@ public class RecordAccumulator implements Closeable {
                     }
 
                     long length = object.size();
-                    long endOffset = firstOffset + length - WALObjectHeader.WAL_HEADER_SIZE;
+                    WALObject walObject = new WALObject(object.bucketId(), path, firstOffset, length);
 
                     if (epoch != config.epoch()) {
-                        previousObjectMap.put(Pair.of(epoch, endOffset), new WALObject(object.bucketId(), path, firstOffset, length));
+                        previousObjectMap.put(Pair.of(epoch, walObject.endOffset()), walObject);
                     } else {
-                        objectMap.put(endOffset, new WALObject(object.bucketId(), path, firstOffset, length));
+                        objectMap.put(walObject.endOffset(), walObject);
                     }
                     objectDataBytes.addAndGet(length);
                 } catch (NumberFormatException e) {
@@ -645,6 +645,20 @@ public class RecordAccumulator implements Closeable {
 
         public long length() {
             return length;
+        }
+
+        public long endOffset() {
+            return startOffset + length - WALObjectHeader.WAL_HEADER_SIZE;
+        }
+
+        @Override
+        public String toString() {
+            return "WALObject{" +
+                "bucketId=" + bucketId +
+                ", path='" + path + '\'' +
+                ", startOffset=" + startOffset +
+                ", length=" + length +
+                '}';
         }
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecordAccumulator.java
@@ -480,7 +480,7 @@ public class RecordAccumulator implements Closeable {
 
         while (!recordQueue.isEmpty()) {
             // The retained bytes in the batch must larger than record header size.
-            long retainedBytesInBatch = config.maxBytesInBatch() - dataBuffer.readableBytes() - WALObjectHeader.WAL_HEADER_SIZE;
+            long retainedBytesInBatch = config.maxBytesInBatch() - dataBuffer.readableBytes() - WALObjectHeader.WAL_HEADER_SIZE_V0;
             if (config.strictBatchLimit() && retainedBytesInBatch <= RecordHeader.RECORD_HEADER_SIZE) {
                 break;
             }
@@ -489,7 +489,7 @@ public class RecordAccumulator implements Closeable {
 
             // Records larger than the batch size will be uploaded immediately.
             assert record != null;
-            if (config.strictBatchLimit() && record.record.readableBytes() >= config.maxBytesInBatch() - WALObjectHeader.WAL_HEADER_SIZE) {
+            if (config.strictBatchLimit() && record.record.readableBytes() >= config.maxBytesInBatch() - WALObjectHeader.WAL_HEADER_SIZE_V0) {
                 dataBuffer.addComponent(true, record.record);
                 recordList.add(record);
                 break;
@@ -518,6 +518,7 @@ public class RecordAccumulator implements Closeable {
         long endOffset = firstOffset + dataLength;
 
         CompositeByteBuf objectBuffer = ByteBufAlloc.compositeByteBuffer();
+        // TODO: set trim offset
         WALObjectHeader header = new WALObjectHeader(firstOffset, dataLength, stickyRecordLength, config.nodeId(), config.epoch());
         objectBuffer.addComponent(true, header.marshal());
         objectBuffer.addComponent(true, dataBuffer);
@@ -644,7 +645,7 @@ public class RecordAccumulator implements Closeable {
             this.path = path;
             this.startOffset = startOffset;
             // TODO: comment this line to avoid confusion
-            this.endOffset = startOffset + length - WALObjectHeader.WAL_HEADER_SIZE;
+            this.endOffset = startOffset + length - WALObjectHeader.WAL_HEADER_SIZE_V0;
             this.length = length;
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
@@ -23,20 +23,23 @@ import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.wal.exception.UnmarshalException;
 
 import java.util.Map;
+import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 
 public class WALObjectHeader {
-    private static final int WAL_HEADER_MAGIC_CODE_V0 = 0x12345678;
-    private static final int WAL_HEADER_SIZE_V0 = 4 // magic code
-                                              + 8 // start offset
-                                              + 8 // body length
-                                              + 8 // sticky record length
-                                              + 4 // node id
-                                              + 8; // node epoch
-    private static final int WAL_HEADER_MAGIC_CODE_V1 = 0xEDCBA987;
-    private static final int WAL_HEADER_SIZE_V1 = WAL_HEADER_SIZE_V0
-                                              + 8; // trim offset
+    // Visible for testing.
+    static final int WAL_HEADER_MAGIC_CODE_V0 = 0x12345678;
+    static final int WAL_HEADER_SIZE_V0 = 4 // magic code
+                                        + 8 // start offset
+                                        + 8 // body length
+                                        + 8 // sticky record length
+                                        + 4 // node id
+                                        + 8; // node epoch
+    static final int WAL_HEADER_MAGIC_CODE_V1 = 0xEDCBA987;
+    static final int WAL_HEADER_SIZE_V1 = WAL_HEADER_SIZE_V0
+                                        + 8; // trim offset
+
     private static final Map<Integer, Integer> WAL_HEADER_SIZES = Map.of(
             WAL_HEADER_MAGIC_CODE_V0, WAL_HEADER_SIZE_V0,
             WAL_HEADER_MAGIC_CODE_V1, WAL_HEADER_SIZE_V1
@@ -175,5 +178,18 @@ public class WALObjectHeader {
 
     public long trimOffset() {
         return trimOffset6;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof WALObjectHeader))
+            return false;
+        WALObjectHeader header = (WALObjectHeader) o;
+        return magicCode0 == header.magicCode0 && startOffset1 == header.startOffset1 && length2 == header.length2 && stickyRecordLength3 == header.stickyRecordLength3 && nodeId4 == header.nodeId4 && epoch5 == header.epoch5 && trimOffset6 == header.trimOffset6;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(magicCode0, startOffset1, length2, stickyRecordLength3, nodeId4, epoch5, trimOffset6);
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
@@ -40,9 +40,6 @@ public class WALObjectHeader {
     private int nodeId4;
     private long epoch5;
 
-    public WALObjectHeader() {
-    }
-
     public WALObjectHeader(long startOffset, long length, long stickyRecordLength, int nodeId, long epoch) {
         this.startOffset1 = startOffset;
         this.length2 = length;
@@ -56,21 +53,22 @@ public class WALObjectHeader {
             throw new UnmarshalException(String.format("WALHeader does not have enough bytes, Recovered: [%d] expect: [%d]", buf.readableBytes(), WAL_HEADER_SIZE));
         }
 
-        WALObjectHeader walObjectHeader = new WALObjectHeader();
         buf.markReaderIndex();
-        walObjectHeader.magicCode0 = buf.readInt();
-        if (walObjectHeader.magicCode0 != WAL_HEADER_MAGIC_CODE) {
-            throw new UnmarshalException(String.format("WALHeader magic code not match, Recovered: [%d] expect: [%d]", walObjectHeader.magicCode0, WAL_HEADER_MAGIC_CODE));
+
+        int magicCode = buf.readInt();
+        if (magicCode != WAL_HEADER_MAGIC_CODE) {
+            throw new UnmarshalException(String.format("WALHeader magic code not match, Recovered: [%d] expect: [%d]", magicCode, WAL_HEADER_MAGIC_CODE));
         }
 
-        walObjectHeader.startOffset1 = buf.readLong();
-        walObjectHeader.length2 = buf.readLong();
-        walObjectHeader.stickyRecordLength3 = buf.readLong();
-        walObjectHeader.nodeId4 = buf.readInt();
-        walObjectHeader.epoch5 = buf.readLong();
+        long startOffset = buf.readLong();
+        long length = buf.readLong();
+        long stickyRecordLength = buf.readLong();
+        int nodeId = buf.readInt();
+        long epoch = buf.readLong();
+
         buf.resetReaderIndex();
 
-        return walObjectHeader;
+        return new WALObjectHeader(startOffset, length, stickyRecordLength, nodeId, epoch);
     }
 
     public ByteBuf marshal() {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
@@ -30,11 +30,11 @@ import io.netty.buffer.ByteBuf;
 public class WALObjectHeader {
     // Visible for testing.
     static final int WAL_HEADER_MAGIC_CODE_V0 = 0x12345678;
-    static final int WAL_HEADER_SIZE_V0 = 4 // magic code
-                                        + 8 // start offset
-                                        + 8 // body length
-                                        + 8 // sticky record length
-                                        + 4 // node id
+    static final int WAL_HEADER_SIZE_V0 = 4  // magic code
+                                        + 8  // start offset
+                                        + 8  // body length
+                                        + 8  // sticky record length
+                                        + 4  // node id
                                         + 8; // node epoch
     static final int WAL_HEADER_MAGIC_CODE_V1 = 0xEDCBA987;
     static final int WAL_HEADER_SIZE_V1 = WAL_HEADER_SIZE_V0
@@ -85,7 +85,7 @@ public class WALObjectHeader {
      * @return the end offset of the WAL object
      */
     public static long calculateEndOffsetV0(long startOffset, long length) {
-        return startOffset + length - WAL_HEADER_MAGIC_CODE_V0;
+        return startOffset + length - WAL_HEADER_SIZE_V0;
     }
 
     public static WALObjectHeader unmarshal(ByteBuf buf) throws UnmarshalException {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/WALObjectHeader.java
@@ -23,62 +23,110 @@ import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.wal.exception.UnmarshalException;
 
 import io.netty.buffer.ByteBuf;
+import java.util.Map;
 
 public class WALObjectHeader {
-    public static final int WAL_HEADER_MAGIC_CODE = 0x12345678;
-    public static final int WAL_HEADER_SIZE = 4 // magic code
+    // TODO: find usage and fix
+    public static final int WAL_HEADER_MAGIC_CODE_V0 = 0x12345678;
+    // TODO: find usage and fix
+    public static final int WAL_HEADER_SIZE_V0 = 4 // magic code
                                               + 8 // start offset
                                               + 8 // body length
                                               + 8 // sticky record length
                                               + 4 // node id
                                               + 8; // node epoch
+    public static final int WAL_HEADER_MAGIC_CODE_V1 = 0xEDCBA987;
+    public static final int WAL_HEADER_SIZE_V1 = WAL_HEADER_SIZE_V0
+                                              + 8; // trim offset
+    private static final Map<Integer, Integer> WAL_HEADER_SIZES = Map.of(
+            WAL_HEADER_MAGIC_CODE_V0, WAL_HEADER_SIZE_V0,
+            WAL_HEADER_MAGIC_CODE_V1, WAL_HEADER_SIZE_V1
+    );
 
-    private int magicCode0 = WAL_HEADER_MAGIC_CODE;
-    private long startOffset1;
-    private long length2;
-    private long stickyRecordLength3;
-    private int nodeId4;
-    private long epoch5;
+    private final int magicCode0;
+    private final long startOffset1;
+    private final long length2;
+    private final long stickyRecordLength3;
+    private final int nodeId4;
+    private final long epoch5;
+    private final long trimOffset6;
 
     public WALObjectHeader(long startOffset, long length, long stickyRecordLength, int nodeId, long epoch) {
+        this.magicCode0 = WAL_HEADER_MAGIC_CODE_V0;
         this.startOffset1 = startOffset;
         this.length2 = length;
         this.stickyRecordLength3 = stickyRecordLength;
         this.nodeId4 = nodeId;
         this.epoch5 = epoch;
+        this.trimOffset6 = -1;
+    }
+
+    public WALObjectHeader(long startOffset, long length, long stickyRecordLength, int nodeId, long epoch, long trimOffset) {
+        this.magicCode0 = WAL_HEADER_MAGIC_CODE_V1;
+        this.startOffset1 = startOffset;
+        this.length2 = length;
+        this.stickyRecordLength3 = stickyRecordLength;
+        this.nodeId4 = nodeId;
+        this.epoch5 = epoch;
+        this.trimOffset6 = trimOffset;
     }
 
     public static WALObjectHeader unmarshal(ByteBuf buf) throws UnmarshalException {
-        if (buf.readableBytes() < WAL_HEADER_SIZE) {
-            throw new UnmarshalException(String.format("WALHeader does not have enough bytes, Recovered: [%d] expect: [%d]", buf.readableBytes(), WAL_HEADER_SIZE));
-        }
-
         buf.markReaderIndex();
 
-        int magicCode = buf.readInt();
-        if (magicCode != WAL_HEADER_MAGIC_CODE) {
-            throw new UnmarshalException(String.format("WALHeader magic code not match, Recovered: [%d] expect: [%d]", magicCode, WAL_HEADER_MAGIC_CODE));
+        if (buf.readableBytes() < 4) {
+            throw new UnmarshalException(String.format("Insufficient bytes to read magic code, Recovered: [%d] expect: [%d]", buf.readableBytes(), 4));
         }
 
-        long startOffset = buf.readLong();
-        long length = buf.readLong();
-        long stickyRecordLength = buf.readLong();
-        int nodeId = buf.readInt();
-        long epoch = buf.readLong();
+        int magicCode = buf.readInt();
+        if (!WAL_HEADER_SIZES.containsKey(magicCode)) {
+            throw new UnmarshalException(String.format("WALHeader magic code not match, Recovered: [%d] expect: [%s]", magicCode, WAL_HEADER_SIZES.keySet()));
+        }
+        if (buf.readableBytes() < WAL_HEADER_SIZES.get(magicCode)) {
+            throw new UnmarshalException(String.format("WALHeader does not have enough bytes, Recovered: [%d] expect: [%d]", buf.readableBytes(), WAL_HEADER_SIZES.get(magicCode)));
+        }
+
+        WALObjectHeader header = null;
+        if (magicCode == WAL_HEADER_MAGIC_CODE_V1) {
+            header = new WALObjectHeader(buf.readLong(), buf.readLong(), buf.readLong(), buf.readInt(), buf.readLong(), buf.readLong());
+        } else if (magicCode == WAL_HEADER_MAGIC_CODE_V0) {
+            header = new WALObjectHeader(buf.readLong(), buf.readLong(), buf.readLong(), buf.readInt(), buf.readLong());
+        }
 
         buf.resetReaderIndex();
-
-        return new WALObjectHeader(startOffset, length, stickyRecordLength, nodeId, epoch);
+        return header;
     }
 
     public ByteBuf marshal() {
-        ByteBuf buf = ByteBufAlloc.byteBuffer(WAL_HEADER_SIZE);
+        if (magicCode0 == WAL_HEADER_MAGIC_CODE_V1) {
+            return marshalV1();
+        } else if (magicCode0 == WAL_HEADER_MAGIC_CODE_V0) {
+            return marshalV0();
+        } else {
+            throw new IllegalStateException("Invalid magic code: " + magicCode0);
+        }
+    }
+
+    private ByteBuf marshalV0() {
+        ByteBuf buf = ByteBufAlloc.byteBuffer(WAL_HEADER_SIZE_V0);
         buf.writeInt(magicCode0);
         buf.writeLong(startOffset1);
         buf.writeLong(length2);
         buf.writeLong(stickyRecordLength3);
         buf.writeInt(nodeId4);
         buf.writeLong(epoch5);
+        return buf;
+    }
+
+    private ByteBuf marshalV1() {
+        ByteBuf buf = ByteBufAlloc.byteBuffer(WAL_HEADER_SIZE_V1);
+        buf.writeInt(magicCode0);
+        buf.writeLong(startOffset1);
+        buf.writeLong(length2);
+        buf.writeLong(stickyRecordLength3);
+        buf.writeInt(nodeId4);
+        buf.writeLong(epoch5);
+        buf.writeLong(trimOffset6);
         return buf;
     }
 
@@ -104,5 +152,9 @@ public class WALObjectHeader {
 
     public long epoch() {
         return epoch5;
+    }
+
+    public long trimOffset() {
+        return trimOffset6;
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
@@ -22,7 +22,8 @@ public class MockObjectStorage extends MemoryObjectStorage {
         }
 
         CompletableFuture<WriteResult> mockFuture = new CompletableFuture<>();
-        pendingWrites.put(objectPath, new PendingWrite(mockFuture, pendingWrite));
+        String offset = objectPath.substring(objectPath.lastIndexOf('/') + 1);
+        pendingWrites.put(offset, new PendingWrite(mockFuture, pendingWrite));
 
         return mockFuture;
     }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
@@ -1,11 +1,13 @@
 package com.automq.stream.s3.wal.impl.object;
 
 import com.automq.stream.s3.operator.MemoryObjectStorage;
-import io.netty.buffer.ByteBuf;
+
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+
+import io.netty.buffer.ByteBuf;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
@@ -1,0 +1,60 @@
+package com.automq.stream.s3.wal.impl.object;
+
+import com.automq.stream.s3.operator.MemoryObjectStorage;
+import io.netty.buffer.ByteBuf;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MockObjectStorage extends MemoryObjectStorage {
+
+    private final Map<String, PendingWrite> pendingWrites = new ConcurrentHashMap<>();
+    private boolean manualWrite = false;
+
+    @Override
+    public CompletableFuture<WriteResult> write(WriteOptions options, String objectPath, ByteBuf data) {
+        Supplier<CompletableFuture<WriteResult>> pendingWrite = () -> super.write(options, objectPath, data);
+        if (!manualWrite) {
+            return pendingWrite.get();
+        }
+
+        CompletableFuture<WriteResult> mockFuture = new CompletableFuture<>();
+        pendingWrites.put(objectPath, new PendingWrite(mockFuture, pendingWrite));
+
+        return mockFuture;
+    }
+
+    public void markManualWrite() {
+        manualWrite = true;
+    }
+
+    public void triggerWrite(String objectPath) {
+        PendingWrite pendingWrite = pendingWrites.remove(objectPath);
+        assertNotNull(pendingWrite);
+        pendingWrite.trigger();
+    }
+
+    private static class PendingWrite {
+        public final CompletableFuture<WriteResult> mockFuture;
+        public final Supplier<CompletableFuture<WriteResult>> originalFuture;
+
+        public PendingWrite(CompletableFuture<WriteResult> mockFuture,
+            Supplier<CompletableFuture<WriteResult>> originalFuture) {
+            this.mockFuture = mockFuture;
+            this.originalFuture = originalFuture;
+        }
+
+        public void trigger() {
+            originalFuture.get().whenComplete((result, error) -> {
+                if (error != null) {
+                    mockFuture.completeExceptionally(error);
+                } else {
+                    mockFuture.complete(result);
+                }
+            });
+        }
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/MockObjectStorage.java
@@ -34,6 +34,11 @@ public class MockObjectStorage extends MemoryObjectStorage {
         manualWrite = true;
     }
 
+    public void triggerAll() {
+        pendingWrites.values().forEach(PendingWrite::trigger);
+        pendingWrites.clear();
+    }
+
     public void triggerWrite(String objectPath) {
         PendingWrite pendingWrite = pendingWrites.remove(objectPath);
         assertNotNull(pendingWrite);

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -13,7 +13,6 @@ import com.automq.stream.s3.wal.exception.OverCapacityException;
 import com.automq.stream.s3.wal.util.WALUtil;
 import com.automq.stream.utils.Time;
 
-import io.netty.buffer.CompositeByteBuf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 
 import static com.automq.stream.s3.wal.common.RecordHeader.RECORD_HEADER_SIZE;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -41,7 +41,7 @@ public class ObjectWALServiceTest {
     public void setUp() throws IOException {
         objectStorage = new MemoryObjectStorage();
         ObjectWALConfig config = ObjectWALConfig.builder()
-            .withMaxBytesInBatch(110)
+            .withMaxBytesInBatch(118)
             .withBatchInterval(Long.MAX_VALUE)
             .withStrictBatchLimit(true)
             .build();

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
@@ -75,6 +75,7 @@ public class RecordAccumulatorTest {
 
     @AfterEach
     public void tearDown() {
+        objectStorage.triggerAll();
         recordAccumulator.close();
         objectStorage.close();
     }
@@ -434,28 +435,28 @@ public class RecordAccumulatorTest {
         recordAccumulator.unsafeUpload(true);
 
         // sleep to wait for potential async callback
-        Thread.sleep(10);
+        Thread.sleep(100);
         assertFalse(future0.isDone());
         assertFalse(future1.isDone());
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
         objectStorage.triggerWrite("1-3");
-        Thread.sleep(10);
+        Thread.sleep(100);
         assertFalse(future0.isDone());
         assertFalse(future1.isDone());
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
         objectStorage.triggerWrite("0-1");
-        Thread.sleep(10);
+        Thread.sleep(100);
         assertTrue(future0.isDone());
         assertTrue(future1.isDone());
         assertTrue(future2.isDone());
         assertFalse(future3.isDone());
 
         objectStorage.triggerWrite("3-4");
-        Thread.sleep(10);
+        Thread.sleep(100);
         assertTrue(future0.isDone());
         assertTrue(future1.isDone());
         assertTrue(future2.isDone());

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
@@ -103,12 +103,12 @@ public class RecordAccumulatorTest {
         assertEquals(1, objectList.size());
 
         RecordAccumulator.WALObject object = objectList.get(0);
-        assertEquals(WALObjectHeader.WAL_HEADER_SIZE + 50, object.length());
+        assertEquals(WALObjectHeader.WAL_HEADER_SIZE_V0 + 50, object.length());
         ByteBuf result = objectStorage.rangeRead(new ReadOptions().bucket((short) 0), object.path(), 0, object.length()).join();
-        ByteBuf headerBuf = result.readBytes(WALObjectHeader.WAL_HEADER_SIZE);
+        ByteBuf headerBuf = result.readBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
         WALObjectHeader objectHeader = WALObjectHeader.unmarshal(headerBuf);
         headerBuf.release();
-        assertEquals(WALObjectHeader.WAL_HEADER_MAGIC_CODE, objectHeader.magicCode());
+        assertEquals(WALObjectHeader.WAL_HEADER_MAGIC_CODE_V0, objectHeader.magicCode());
         assertEquals(0, objectHeader.startOffset());
         assertEquals(50, objectHeader.length());
         // The last write timestamp is not set currently.
@@ -139,9 +139,9 @@ public class RecordAccumulatorTest {
         assertEquals(2, objectList.size());
 
         object = objectList.get(1);
-        assertEquals(WALObjectHeader.WAL_HEADER_SIZE + 50 + 75, object.length());
+        assertEquals(WALObjectHeader.WAL_HEADER_SIZE_V0 + 50 + 75, object.length());
         result = objectStorage.rangeRead(new ReadOptions().bucket((short) 0), object.path(), 0, object.length()).join();
-        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE);
+        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
         CompositeByteBuf compositeBuffer = Unpooled.compositeBuffer();
         compositeBuffer.addComponents(true, byteBuf2);
         compositeBuffer.addComponents(true, byteBuf3);
@@ -170,14 +170,14 @@ public class RecordAccumulatorTest {
         object = objectList.get(2);
         assertEquals(115, object.length());
         result = objectStorage.rangeRead(new ReadOptions().bucket((short) 0), object.path(), 0, object.length()).join();
-        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE);
+        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
         assertEquals(byteBuf4, result.readBytes(50));
 
         object = objectList.get(3);
         compositeBuffer = Unpooled.compositeBuffer();
         compositeBuffer.addComponents(true, result);
         result = objectStorage.rangeRead(new ReadOptions().bucket((short) 0), object.path(), 0, object.length()).join();
-        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE);
+        result.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
         compositeBuffer.addComponents(true, result);
         assertEquals(compositeBuffer, byteBuf5);
         byteBuf4.release();
@@ -295,7 +295,7 @@ public class RecordAccumulatorTest {
         CompositeByteBuf result = Unpooled.compositeBuffer();
         for (RecordAccumulator.WALObject object : recordAccumulator.objectList()) {
             ByteBuf buf = objectStorage.rangeRead(new ReadOptions().bucket((short) 0), object.path(), 0, object.length()).join();
-            buf.skipBytes(WALObjectHeader.WAL_HEADER_SIZE);
+            buf.skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0);
             result.addComponent(true, buf);
         }
 
@@ -406,9 +406,9 @@ public class RecordAccumulatorTest {
 
         List<RecordAccumulator.WALObject> objectList = recordAccumulator.objectList();
         assertEquals(3, objectList.size());
-        assertEquals(byteBuf1, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(0).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE));
-        assertEquals(byteBuf2, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(1).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE));
-        assertEquals(byteBuf3, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(2).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE));
+        assertEquals(byteBuf1, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(0).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0));
+        assertEquals(byteBuf2, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(1).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0));
+        assertEquals(byteBuf3, objectStorage.read(new ReadOptions().bucket((short) 0), objectList.get(2).path()).join().skipBytes(WALObjectHeader.WAL_HEADER_SIZE_V0));
 
         recordAccumulator.reset().join();
         assertEquals(0, recordAccumulator.objectList().size());

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
@@ -439,21 +439,21 @@ public class RecordAccumulatorTest {
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
-        objectStorage.triggerWrite("1");
+        objectStorage.triggerWrite("1-3");
         Thread.sleep(10);
         assertFalse(future0.isDone());
         assertFalse(future1.isDone());
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
-        objectStorage.triggerWrite("0");
+        objectStorage.triggerWrite("0-1");
         Thread.sleep(10);
         assertTrue(future0.isDone());
         assertTrue(future1.isDone());
         assertTrue(future2.isDone());
         assertFalse(future3.isDone());
 
-        objectStorage.triggerWrite("3");
+        objectStorage.triggerWrite("3-4");
         Thread.sleep(10);
         assertTrue(future0.isDone());
         assertTrue(future1.isDone());

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
@@ -115,6 +115,7 @@ public class RecordAccumulatorTest {
         assertEquals(0L, objectHeader.stickyRecordLength());
         assertEquals(100, objectHeader.nodeId());
         assertEquals(1000, objectHeader.epoch());
+        assertEquals(-1, objectHeader.trimOffset());
 
         assertEquals(byteBuf1, result);
         byteBuf1.release();

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/RecordAccumulatorTest.java
@@ -19,7 +19,6 @@
 
 package com.automq.stream.s3.wal.impl.object;
 
-import com.automq.stream.s3.operator.MemoryObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorage.ReadOptions;
 import com.automq.stream.s3.wal.AppendResult;
@@ -61,7 +60,7 @@ public class RecordAccumulatorTest {
 
     @BeforeEach
     public void setUp() {
-        objectStorage = new MemoryObjectStorage();
+        objectStorage = new MockObjectStorage();
         ObjectWALConfig config = ObjectWALConfig.builder()
             .withMaxBytesInBatch(115)
             .withNodeId(100)

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/WALObjectHeaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/WALObjectHeaderTest.java
@@ -1,0 +1,35 @@
+package com.automq.stream.s3.wal.impl.object;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WALObjectHeaderTest {
+
+    @Test
+    public void testV0() {
+        WALObjectHeader header = new WALObjectHeader(42L, 84L, 126L, 1, 2);
+        assertEquals(-1, header.trimOffset());
+        assertEquals(WALObjectHeader.WAL_HEADER_MAGIC_CODE_V0, header.magicCode());
+
+        ByteBuf buffer = header.marshal();
+        assertEquals(WALObjectHeader.WAL_HEADER_SIZE_V0, buffer.readableBytes());
+
+        WALObjectHeader unmarshal = WALObjectHeader.unmarshal(buffer);
+        assertEquals(header, unmarshal);
+    }
+
+    @Test
+    public void testV1() {
+        WALObjectHeader header = new WALObjectHeader(42L, 84L, 126L, 1, 2, 168L);
+        assertEquals(WALObjectHeader.WAL_HEADER_MAGIC_CODE_V1, header.magicCode());
+
+        ByteBuf buffer = header.marshal();
+        assertEquals(WALObjectHeader.WAL_HEADER_SIZE_V1, buffer.readableBytes());
+
+        WALObjectHeader unmarshal = WALObjectHeader.unmarshal(buffer);
+        assertEquals(header, unmarshal);
+    }
+}


### PR DESCRIPTION
resolve #2432

## Performance Test
- Before
```
2025-04-18 07:42:14 - INFO Summary | Prod rate   1600.46 msg/s /  79.71 MiB/s | Prod total   0.48 M msg /  23.36 GiB /   0.00 K err | Cons rate   1600.44 msg/s /  79.71 MiB/s | Cons total   0.48 M msg /  23.36 GiB | Prod Latency (ms) avg:   267.319 - 50%:   233.070 - 75%:   276.479 - 90%:   416.589 - 95%:   545.547 - 99%:   759.195 - 99.9%:   972.191 - 99.99%:  1230.271 - Max:  1250.511 | E2E Latency (ms) avg:   272.780 - 50%:   237.312 - 75%:   280.909 - 90%:   436.249 - 95%:   547.739 - 99%:   778.615 - 99.9%:   981.371 - 99.99%:  1238.991 - Max:  1381.615
```
- After
```
2025-04-18 08:11:08 - INFO Summary | Prod rate   1601.42 msg/s /  79.76 MiB/s | Prod total   0.48 M msg /  23.40 GiB /   0.00 K err | Cons rate   1600.99 msg/s /  79.74 MiB/s | Cons total   0.48 M msg /  23.40 GiB | Prod Latency (ms) avg:   285.990 - 50%:   243.027 - 75%:   301.301 - 90%:   484.555 - 95%:   598.403 - 99%:   784.067 - 99.9%:   912.219 - 99.99%:  1027.723 - Max:  1064.903 | E2E Latency (ms) avg:   302.057 - 50%:   250.507 - 75%:   324.333 - 90%:   521.625 - 95%:   628.719 - 99%:   831.655 - 99.9%:  1001.287 - 99.99%:  1099.751 - Max:  1202.439
```