### PR TITLE
Add support for reusing topics in catch-up read testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,125 +1,54 @@
-# AutoMQ: A stateless Kafka® on S3, offering 10x cost savings and scaling in seconds.
+# Contributing to AutoMQ
 
-<div align="center">
-<p align="center">
-  📑&nbsp <a
-    href="https://docs.automq.com/docs/automq-opensource/HSiEwHVfdiO7rWk34vKcVvcvn2Z?utm_source=github"
-    target="_blank"
-  ><b>Documentation</b></a>&nbsp&nbsp&nbsp
-  🔥&nbsp <a
-    href="https://www.automq.com/docs/automq-cloud/getting-started/install-byoc-environment/aws/install-env-from-marketplace"
-    target="_blank"
-  ><b>Free trial of AutoMQ on AWS</b></a>&nbsp&nbsp&nbsp
-</p>
+Thank you for your interest in contributing! We welcome and appreciate community contributions.  
+Read on to learn how to get started with AutoMQ. If you have any questions, feel free to reach out via our [WeChat group](https://www.automq.com/img/----------------------------1.png) or [Slack workspace](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL9oXuRdACnOIA).
 
-[![Linkedin Badge](https://img.shields.io/badge/-LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white&link=https://www.linkedin.com/company/automq)](https://www.linkedin.com/company/automq)
-[![Twitter URL](https://img.shields.io/twitter/follow/AutoMQ)](https://twitter.com/intent/follow?screen_name=AutoMQ_Lab)
-[![](https://badgen.net/badge/Slack/Join%20AutoMQ/0abd59?icon=slack)](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL9oXuRdACnOIA)
-[![](https://img.shields.io/badge/AutoMQ%20vs.%20Kafka(Cost)-yellow)](https://www.automq.com/blog/automq-vs-apache-kafka-a-real-aws-cloud-bill-comparison)
-[![](https://img.shields.io/badge/AutoMQ%20vs.%20Kafka(Performance)-orange)](https://docs.automq.com/docs/automq-opensource/IJLQwnVROiS5cUkXfF0cuHnWnNd)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20AutoMQ%20Guru-006BFF)](https://gurubase.io/g/automq)
-[![DeepWiki](https://img.shields.io/badge/DeepWiki-AutoMQ%2Fautomq-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/AutoMQ/automq)
+Before you begin, please review AutoMQ’s [Code of Conduct](CODE_OF_CONDUCT.md). Everyone who interacts on Slack or WeChat must follow the Code of Conduct.
 
-<a href="https://trendshift.io/repositories/9782" target="_blank"><img src="https://trendshift.io/api/badge/repositories/9782" alt="AutoMQ%2Fautomq | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</div>
+---
 
-## 👥 Big Companies Worldwide are Using AutoMQ
-> Here are some of our major customers worldwide using AutoMQ.
+## Code Contributions
 
-<img width="1151" alt="image" src="https://github.com/user-attachments/assets/a2668e5e-eebf-479a-b85a-9611de1b60c8" />
+Most open issues are labeled **good first issue**. To claim one, simply comment **“pick up”** on the issue, and an AutoMQ maintainer will assign it to you. If you have any questions about a **good first issue**, feel free to ask—we’re here to help!
 
-- [Grab: Driving Efficiency with AutoMQ in DataStreaming Platform](https://www.youtube.com/watch?v=IB8sh639Rsg)
-- [JD.com x AutoMQ x CubeFS: A Cost-Effective Journey](https://www.automq.com/blog/jdcom-automq-cubefs-trillion-scale-kafka-messaging)
-- [Palmpay Uses AutoMQ to Replace Kafka, Optimizing Costs by 50%+](https://www.automq.com/blog/palmpay-uses-automq-to-replace-kafka)
-- [AutoMQ help Geely Auto(Fortune Global 500) solve the pain points of Kafka elasticity in the V2X scenario](https://www.automq.com/blog/automq-help-geely-auto-solve-the-pain-points-of-kafka-elasticity-in-the-v2x-scenario)
-- [How Asia’s Quora Zhihu uses AutoMQ to reduce Kafka cost and maintenance complexity](https://www.automq.com/blog/how-asias-quora-zhihu-use-automq-to-reduce-kafka-cost-and-maintenance-complexity)
-- [XPENG Motors Reduces Costs by 50%+ by Replacing Kafka with AutoMQ](https://www.automq.com/blog/xpeng-motors-reduces-costs-by-50-by-replacing-kafka-with-automq)
-- [Asia's GOAT, Poizon uses AutoMQ Kafka to build observability platform for massive data(30 GB/s)](https://www.automq.com/blog/asiax27s-goat-poizon-uses-automq-kafka-to-build-a-new-generation-observability-platform-for-massive-data)
-- [AutoMQ Helps CaoCao Mobility Address Kafka Scalability During Holidays](https://www.automq.com/blog/automq-helps-caocao-mobility-address-kafka-scalability-issues-during-mid-autumn-and-national-day)
+Start here:  
+[Issues tagged “good first issue”](https://github.com/AutoMQ/automq-for-kafka/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
-## ⛄ Get started with AutoMQ
+### Typical Workflow
 
-> [!Tip]
-> Deploying a production-ready AutoMQ cluster is challenging. This Quick Start is only for evaluating AutoMQ features and is not suitable for production use. For production deployment best practices, please [contact](https://www.automq.com/contact) our community for support.
+1. **Fork** the AutoMQ repository.
+2. **Clone** your fork locally.
+3. **Create** a branch named `{your_username}/{feature_or_bug}` (e.g., `jdoe/source-stock-api-stream-fix`).
+4. **Implement** your changes and commit them.
+5. **Push** your branch to your fork.
+6. **Open** a Pull Request (PR) against the main AutoMQ repository.
+7. **Link** an existing issue (without the `needs triage` label) to your PR. PRs without a linked issue will be closed.
+8. **Use** the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) for your PR title and description.
+9. An AutoMQ maintainer will trigger CI tests and review your code.
+10. **Address** any feedback or questions from maintainers.
+11. **Merge** your contribution once approved.
 
-The `docker/docker-compose.yaml` file provides a simple single-node setup for quick evaluation and development:
-```shell
-docker compose -f docker/docker-compose.yaml up -d
+> **Note:** Please respond promptly to feedback and sign our Contributor License Agreement (CLA). PRs left inactive will be closed.
+
+---
+
+## Requirements
+
+| Requirement          | Version |
+| -------------------- | ------- |
+| Java Development Kit | 17      |
+| Scala                | 2.13    |
+
+> **Tip:** See the [Scala 2.13.12 download page](https://www.scala-lang.org/download/2.13.12.html) for installation instructions.
+
+---
+
+## Local Development with IntelliJ IDEA
+
+### Using Gradle
+
+AutoMQ uses Gradle (via the `gradlew` wrapper) just like Apache Kafka:
+
+```bash
+./gradlew jar -x test
 ```
-This setup features a single AutoMQ node serving as both controller and broker, alongside MinIO for S3 storage. All services operate within a Docker bridge network called `automq_net`, allowing you to start a Kafka producer in this network to test AutoMQ:
-```shell
-docker run --network automq_net automqinc/automq:latest /bin/bash -c \
-"/opt/automq/kafka/bin/kafka-producer-perf-test.sh --topic test-topic --num-records=1024000 --throughput 5120 --record-size 1024 \
---producer-props bootstrap.servers=server1:9092 linger.ms=100 batch.size=524288 buffer.memory=134217728 max.request.size=67108864"
-```
-After testing, you can destroy the setup with:
-```shell
-docker compose -f docker/docker-compose.yaml down
-```
-The `docker/docker-compose-cluster.yaml` file offers a more complex setup with three AutoMQ nodes, ideal for testing AutoMQ's cluster features, and can be run in the same way.
-
-There are more deployment options available:
-- [Deploy on Linux with 5 Nodes](https://www.automq.com/docs/automq/getting-started/cluster-deployment-on-linux)
-- [Deploy on Kubernetes (Enterprise only now, open source soon)](https://www.automq.com/docs/automq/getting-started/cluster-deployment-on-kubernetes)
-- [Run on Ceph / MinIO / CubeFS / HDFS](https://www.automq.com/docs/automq/deployment/overview)
-- [Try AutoMQ on AWS Marketplace (Two Weeks Free Trial)](https://docs.automq.com/automq-cloud/getting-started/install-byoc-environment/aws/install-env-from-marketplace)
-- [Try AutoMQ on Alibaba Cloud Marketplace (Two Weeks Free Trial)](https://market.aliyun.com/products/55530001/cmgj00065841.html)
-
-## 🗞️ Newest Feature - Table Topic
-Table Topic is a new feature in AutoMQ that combines stream and table functionalities to unify streaming and data analysis. Currently, it supports Apache Iceberg and integrates with catalog services such as AWS Glue, HMS, and the Rest catalog. Additionally, it natively supports S3 tables, a new AWS product announced at the 2024 re:Invent. [Learn more](https://www.automq.com/blog/automq-table-topic-seamless-integration-with-s3-tables-and-iceberg).
-
-![image](https://github.com/user-attachments/assets/6b2a514a-cc3e-442e-84f6-d953206865e0)
-
-## 🔶 Why AutoMQ
-AutoMQ is a stateless Kafka alternative that runs on S3 or any S3-compatible storage, such as MinIO. It is designed to address two major issues of Apache Kafka. First, Kafka clusters are difficult to scale out or in due to the stateful nature of its brokers. Data movement is required, and even reassigning partitions between brokers is a complex process. Second, hosting Kafka in the cloud can be prohibitively expensive. You face high costs for EBS storage, cross-AZ traffic, and significant over-provisioning due to Kafka's limited scalability.
-
-Here are some key highlights of AutoMQ that make it an ideal choice to replace your Apache Kafka cluster, whether in the cloud or on-premise, as long as you have S3-compatible storage:
-- **Cost effective**: The first true cloud-native streaming storage system, designed for optimal cost and efficiency on the cloud. Refer to [this report](https://www.automq.com/docs/automq/benchmarks/cost-effective-automq-vs-apache-kafka) to see how we cut Apache Kafka billing by 90% on the cloud.
-- **High Reliability**: Leverage object storage service to achieve zero RPO, RTO in seconds and 99.999999999% durability.
-- **Zero Cross-AZ Traffic**: By using cloud object storage as the priority storage solution, AutoMQ eliminates cross-AZ traffic costs on AWS and GCP. In traditional Kafka setups, over 80% of costs arise from cross-AZ traffic, including producer, consumer, and replication sides.
-- **Serverless**:
-    - Auto Scaling: Monitor cluster metrics and automatically scale in/out to align with your workload, enabling a pay-as-you-go model.
-    - Scaling in seconds: The computing layer (broker) is stateless and can scale in/out within seconds, making AutoMQ a truly serverless solution.
-    - Infinite scalable: Utilize cloud object storage as the primary storage solution, eliminating concerns about storage capacity.
-- **Manage-less**: The built-in auto-balancer component automatically schedules partitions and network traffic between brokers, eliminating manual partition reassignment.
-- **High performance**:
-    - High throughput: Leverage pre-fetching, batch processing, and parallel technologies to maximize the capabilities of cloud object storage. Refer to the [AutoMQ Performance White Paper](https://www.automq.com/docs/automq/benchmarks/benchmark-automq-vs-apache-kafka) to see how we achieve this.
-    - Low Latency: AutoMQ defaults to running on S3 directly, resulting in hundreds of milliseconds of latency. The enterprise version offers single-digit millisecond latency. [Contact us](https://www.automq.com/contact) for more details.
-- **Built-in Metrics Export**: Natively export Prometheus and OpenTelemetry metrics, supporting both push and pull. Ditch inefficient JMX and monitor your cluster with modern tools. Refer to [full metrics list](https://www.automq.com/docs/automq/observability/metrics) provided by AutoMQ.
-- **100% Kafka Compatible**: Fully compatible with Apache Kafka, offering all features with greater cost-effectiveness and operational efficiency.
-
-## ✨Architecture
-AutoMQ is a fork of the open-source [Apache Kafka](https://github.com/apache/kafka). We've introduced a new storage engine based on object storage, transforming the classic shared-nothing architecture into a shared storage architecture.
-
-![image](./docs/images/automq_simple_arch.png)
-
-Regarding the architecture of AutoMQ, it is fundamentally different from Kafka. The core difference lies in the storage layer of Apache Kafka and how we leverage object storage to achieve a stateless broker architecture. AutoMQ consists of below key components:
-- S3 Storage Adapter: an adapter layer that reimplements the UnifiedLog, LocalLog, and LogSegment classes to create logs on S3 instead of a local disk. Traditional local disk storage is still supported if desired.
-- S3Stream: a shared streaming storage library that encapsulates various storage modules, including WAL and object storage. WAL is a write-ahead log optimized for frequent writes and low IOPS to reduce S3 API costs. To boost read performance, we use LogCache and BlockCache for improved efficiency.
-- Auto Balancer: a component that automatically balances traffic and partitions between brokers, eliminating the need for manual reassignment. Unlike Kafka, this built-in feature removes the need for cruise control.
-- Rack-aware Router: Kafka has long faced cross-AZ traffic fees on AWS and GCP. Our shared storage architecture addresses this by using a rack-aware router to provide clients in different AZs with specific partition metadata, avoiding cross-AZ fees while exchanging data through object storage.
-
-For more on AutoMQ's architecture, visit [AutoMQ Architecture](https://docs.automq.com/automq/architecture/overview) or explore the source code directly.
-
-## 💬 Community
-You can join the following groups or channels to discuss or ask questions about AutoMQ:
-- Ask questions or report a bug by [GitHub Issues](https://github.com/AutoMQ/automq/issues)
-- Discuss about AutoMQ or Kafka by [Slack](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL9oXuRdACnOIA) or [Wechat Group](docs/images/automq-wechat.png)
-
-
-## 👥 How to contribute
-If you've found a problem with AutoMQ, please open a [GitHub Issues](https://github.com/AutoMQ/automq/issues).
-To contribute to AutoMQ please see [Code of Conduct](CODE_OF_CONDUCT.md) and [Contributing Guide](CONTRIBUTING_GUIDE.md).
-We have a list of [good first issues](https://github.com/AutoMQ/automq/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) that help you to get started, gain experience, and get familiar with our contribution process.
-
-## 👍 AutoMQ Enterprise Edition
-The enterprise edition of AutoMQ offers a robust, user-friendly control plane for seamless cluster management, with enhanced availability and observability over the open-source version. Additionally, we offer [Kafka Linking](https://www.automq.com/solutions/kafka-linking) for zero-downtime migration from any Kafka-compatible cluster to AutoMQ.
-
-[Contact us](https://www.automq.com/contact) for more information about the AutoMQ enterprise edition, and we'll gladly assist with your free trial.
-
-## 📜 License
-AutoMQ is under the Apache 2.0 license. See the [LICENSE](https://github.com/AutoMQ/automq/blob/main/LICENSE) file for details.
-
-## 📝 Trademarks
-Apache®, Apache Kafka®, Kafka®, Apache Iceberg®, Iceberg® and associated open source project names are trademarks of the Apache Software Foundation
-

--- a/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
@@ -57,6 +57,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import java.util.stream.Collectors;
+
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -69,6 +71,10 @@ public class PerfCommand implements AutoCloseable {
 
     private static final ObjectWriter JSON = new ObjectMapper().writerWithDefaultPrettyPrinter();
     private static final Logger LOGGER = LoggerFactory.getLogger(PerfCommand.class);
+    
+    private static final String CATCHUP_TOPIC_PREFIX = "catchup-topic-prefix";
+
+    
 
     private final PerfConfig config;
     private final TopicService topicService;

--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
@@ -359,6 +359,11 @@ public class ConsumerService implements AutoCloseable {
             }
         }
 
+        boolean isCatchup = !Strings.isNullOrEmpty(config.catchupTopicPrefix());
+if (isCatchup) {
+    LOGGER.info("Catch‑up mode enabled for prefix '{}'", config.catchupTopicPrefix());
+}
+
         /**
          * Signal the consumer to close.
          */

--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/ConsumerService.java
@@ -82,6 +82,17 @@ public class ConsumerService implements AutoCloseable {
         this.groupSuffix = new SimpleDateFormat("HHmmss").format(System.currentTimeMillis());
     }
 
+    public void resetToBeginning() {
+        for (Consumer<?, ?> consumer : consumers) {
+            try {
+                consumer.seekToBeginning(consumer.assignment());
+                LOGGER.info("Reset consumer to beginning: {}", consumer);
+            } catch (Exception e) {
+                LOGGER.error("Failed to reset consumer to beginning", e);
+            }
+        }
+    }
+
     /**
      * Create consumers for the given topics.
      * Note: the created consumers will start polling immediately.

--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
@@ -75,6 +75,10 @@ public class PerfConfig {
     public final String valueSchema;
     public final String valuesFile;
 
+    public final String catchupTopicPrefix;
+
+    
+
     public PerfConfig(String[] args) {
         ArgumentParser parser = parser();
 
@@ -120,6 +124,18 @@ public class PerfConfig {
             throw new IllegalArgumentException(String.format("BACKLOG_DURATION_SECONDS(%d) should not be less than GROUPS_PER_TOPIC(%d) * GROUP_START_DELAY_SECONDS(%d)",
                 backlogDurationSeconds, groupsPerTopic, groupStartDelaySeconds));
         }
+
+        options.addOption(Option.builder()
+                .longOpt(PerfCommand.CATCHUP_TOPIC_PREFIX)
+                .hasArg()
+                .desc("Topic prefix to reuse for catch-up read testing")
+                .build());
+
+        CommandLine cmd = parser.parse(options, args);
+
+      
+        this.catchupTopicPrefix = cmd.hasOption(PerfCommand.CATCHUP_TOPIC_PREFIX) ? 
+                cmd.getOptionValue(PerfCommand.CATCHUP_TOPIC_PREFIX) : null;
     }
 
     public static ArgumentParser parser() {

--- a/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/perf/PerfConfig.java
@@ -76,6 +76,7 @@ public class PerfConfig {
     public final String valuesFile;
 
     public final String catchupTopicPrefix;
+    public final boolean reuseTopics;
 
     
 
@@ -119,6 +120,9 @@ public class PerfConfig {
         reportingIntervalSeconds = ns.getInt("reportingIntervalSeconds");
         valueSchema = ns.getString("valueSchema");
         valuesFile = ns.get("valuesFile");
+
+        reuseTopics = ns.getBoolean("reuseTopics");
+        catchupTopicPrefix=ns.getString("catchupTopicPrefix");
 
         if (backlogDurationSeconds < groupsPerTopic * groupStartDelaySeconds) {
             throw new IllegalArgumentException(String.format("BACKLOG_DURATION_SECONDS(%d) should not be less than GROUPS_PER_TOPIC(%d) * GROUP_START_DELAY_SECONDS(%d)",
@@ -292,6 +296,17 @@ public class PerfConfig {
             .dest("valuesFile")
             .metavar("VALUES_FILE")
             .help("The avro value file. Example file content {\"f1\": \"value1\"}");
+
+        parser.addArgument("--reuse-topics")
+            .action(storeTrue())
+            .dest("reuseTopics")
+            .help("If set, do not delete existing topics ; only create the missing ones.")
+
+        parser.addArgument("--catchup-topic-prefix")
+            .type(String.class)
+            .dest("catchupTopicPrefix")
+            .meatavar("PREFIX")
+            .help("When set, reuse the existing topics with this prefix for catchup-read test")
         return parser;
     }
 
@@ -303,6 +318,10 @@ public class PerfConfig {
         Properties properties = new Properties();
         properties.putAll(commonConfigs);
         return properties;
+    }
+
+    public boolean reuseTopics(){
+        return reuseTopics;
     }
 
     public TopicsConfig topicsConfig() {


### PR DESCRIPTION


This PR addresses the issue of time-consuming performance tests when testing "catch-up read" scenarios. Currently, each test run requires spending significant time to accumulate messages, which slows down testing. This PR adds the ability to reuse existing topics with accumulated messages, eliminating the wait time.

Issue: #2373 

Added a new command-line parameter `--catchup-topic-prefix` that allows users to specify topics to reuse for catch-up read testing. When this parameter is provided and topics matching the prefix exist:

1. The script reuses these topics instead of creating new ones
2. The message accumulation phase is skipped
3. Consumers are reset to read from the beginning of the topics

This significantly speeds up testing by eliminating the wait time for message accumulation.
