### PR TITLE
refactor(early returning): remove unnecessary conditional block

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/AutoMQApplication.java
+++ b/automq-shell/src/main/java/com/automq/shell/AutoMQApplication.java
@@ -41,9 +41,8 @@ public class AutoMQApplication {
         if (override) {
             CONTAINER.put(type, singleton);
             return true;
-        } else {
-            return CONTAINER.putIfAbsent(type, singleton) == null;
         }
+        return CONTAINER.putIfAbsent(type, singleton) == null;
     }
 
     public static <T> T getBean(Class<T> type) {


### PR DESCRIPTION
Remove unnecessary `else` block (**shell/AutoMQApplication.java**).
The `if` block is already returning.

This isn't a feature/bug fix. The code have no
crucial changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
