### PR TITLE
Add JMX-based Prometheus Metrics Exporter for JVM Observability in AutoMQ

### DIFF
--- a/automq-shell/pom.xml
+++ b/automq-shell/pom.xml
@@ -1,0 +1,5 @@
+<dependency>
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_hotspot</artifactId>
+    <version>0.16.0</version>
+</dependency>

--- a/automq-shell/src/main/java/com/automq/shell/monitoring/JmxMetricExporter.java
+++ b/automq-shell/src/main/java/com/automq/shell/monitoring/JmxMetricExporter.java
@@ -1,0 +1,28 @@
+package io.automq.monitoring;
+
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+
+import java.io.IOException;
+
+public class JmxMetricsExporter {
+
+    private static HTTPServer server;
+
+    public static void start(int port) {
+        try {
+            DefaultExports.initialize(); // Collect JVM metrics
+            server = new HTTPServer(port);
+            System.out.println("Prometheus metrics exporter started at http://localhost:" + port + "/metrics");
+        } catch (IOException e) {
+            System.err.println("Failed to start Prometheus exporter: " + e.getMessage());
+        }
+    }
+
+    public static void stop() {
+        if (server != null) {
+            server.stop();
+            System.out.println("Prometheus exporter stopped.");
+        }
+    }
+}

--- a/automq-shell/src/main/java/com/automq/shell/server/ServerMain.java
+++ b/automq-shell/src/main/java/com/automq/shell/server/ServerMain.java
@@ -1,0 +1,7 @@
+import io.automq.monitoring.JmxMetricsExporter;
+
+public class ServerMain {
+    public static void main(String[] args) {
+        JmxMetricsExporter.start(8080);  // Start the /metrics endpoint
+    }
+}


### PR DESCRIPTION
This PR adds a JMX-based Prometheus metrics exporter to AutoMQ, exposing JVM metrics like memory usage, thread counts, and GC stats. A new JmxMetricsExporter.java class is introduced to start a Prometheus server on port 8080. ServerMain.java is updated to call JmxMetricsExporter.start(8080) at startup, and the pom.xml includes the simpleclient_hotspot dependency for Prometheus integration. This enables seamless monitoring with Prometheus and Grafana without affecting existing functionality.