### PR TITLE
fix(docker): update minio policy commands to use 'anonymous' instead of 'policy' (#2640)

### DIFF
--- a/docker/docker-compose-cluster.yaml
+++ b/docker/docker-compose-cluster.yaml
@@ -58,8 +58,8 @@ services:
       /usr/bin/mc rm -r --force minio/automq-ops;
       /usr/bin/mc mb minio/automq-data;
       /usr/bin/mc mb minio/automq-ops;
-      /usr/bin/mc policy set public minio/automq-data;
-      /usr/bin/mc policy set public minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
       tail -f /dev/null
       "
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -51,8 +51,8 @@ services:
       /usr/bin/mc rm -r --force minio/automq-ops;
       /usr/bin/mc mb minio/automq-data;
       /usr/bin/mc mb minio/automq-ops;
-      /usr/bin/mc policy set public minio/automq-data;
-      /usr/bin/mc policy set public minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
       tail -f /dev/null
       "
     networks:

--- a/docker/table_topic/docker-compose.yml
+++ b/docker/table_topic/docker-compose.yml
@@ -64,16 +64,16 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: |
       /bin/sh -c "
-      until (/usr/bin/mc alias set add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
-      /usr/bin/mc policy set public minio/warehouse;
+      /usr/bin/mc anonymous set public minio/warehouse;
       /usr/bin/mc rm -r --force minio/automq-data;
       /usr/bin/mc mb minio/automq-data;
-      /usr/bin/mc policy set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-data;
       /usr/bin/mc rm -r --force minio/automq-ops;
       /usr/bin/mc mb minio/automq-ops;
-      /usr/bin/mc policy set public minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-ops;
       tail -f /dev/null
       "
   automq:


### PR DESCRIPTION

fix(docker): update minio policy commands to use 'anonymous' instead of 'public'

