### PR TITLE
feat(catalog): avoid static global credentials provider

### DIFF
--- a/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
+++ b/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
@@ -62,6 +62,9 @@ public class CredentialProviderHolder implements AwsCredentialsProvider {
 
     // iceberg will invoke create with reflection.
     public static AwsCredentialsProvider create() {
+        if (bucketURI == null) {
+            throw new IllegalStateException("BucketURI must be set before calling create(). Please invoke setup(BucketURI) first.");
+        }
         return providerSupplier.apply(bucketURI);
     }
 

--- a/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
+++ b/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
@@ -36,14 +36,14 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 public class CredentialProviderHolder implements AwsCredentialsProvider {
     private static Function<BucketURI, AwsCredentialsProvider> providerSupplier = bucketURI -> newCredentialsProviderChain(
         credentialsProviders(bucketURI));
-    private static AwsCredentialsProvider provider;
+    private static BucketURI bucketURI;
 
     public static void setup(Function<BucketURI, AwsCredentialsProvider> providerSupplier) {
         CredentialProviderHolder.providerSupplier = providerSupplier;
     }
 
     public static void setup(BucketURI bucketURI) {
-        CredentialProviderHolder.provider = providerSupplier.apply(bucketURI);
+        CredentialProviderHolder.bucketURI = bucketURI;
     }
 
     private static List<AwsCredentialsProvider> credentialsProviders(BucketURI bucketURI) {
@@ -62,7 +62,7 @@ public class CredentialProviderHolder implements AwsCredentialsProvider {
 
     // iceberg will invoke create with reflection.
     public static AwsCredentialsProvider create() {
-        return provider;
+        return providerSupplier.apply(bucketURI);
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
+++ b/core/src/main/java/kafka/automq/table/CredentialProviderHolder.java
@@ -47,7 +47,7 @@ public class CredentialProviderHolder implements AwsCredentialsProvider {
     }
 
     private static List<AwsCredentialsProvider> credentialsProviders(BucketURI bucketURI) {
-        return List.of(new AutoMQStaticCredentialsProvider(bucketURI), DefaultCredentialsProvider.create());
+        return List.of(new AutoMQStaticCredentialsProvider(bucketURI), DefaultCredentialsProvider.builder().build());
     }
 
     private static AwsCredentialsProvider newCredentialsProviderChain(


### PR DESCRIPTION
Refactors CredentialProviderHolder to prevent "Connection Pool Shutdown" errors by creating a new provider instance upon each invocation of create().

Previously, a single static `AwsCredentialsProvider` was shared globally. If this provider was closed, it would affect all subsequent operations. By creating a new provider on each `create()` call from Iceberg, this change removes the global singleton and isolates provider instances.

Fixes #2680

https://github.com/apache/iceberg/pull/8677

> **How do I fix "java.lang.IllegalStateException: Connection pool shut down" error?**
> 
> You attempted to use the credentials provider returned from DefaultCredentialsProvider#create() after it was closed. [DefaultCredentialsProvider#create](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html#create()) returns a singleton instance, so if it's closed and your code calls the resolveCredentials method, the exception is thrown after cached credentials (or token) expire.
> 
> https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/troubleshooting.html#faq-connection-pool-shutdown-exception
