### PR TITLE
fix(log): Prevent potential offset overflow in ElasticLogSegment (#2720)

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
@@ -39,6 +39,7 @@ import org.apache.kafka.storage.internals.log.LogConfig;
 import org.apache.kafka.storage.internals.log.LogFileUtils;
 import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
 import org.apache.kafka.storage.internals.log.LogSegment;
+import org.apache.kafka.storage.internals.log.LogSegmentOffsetOverflowException;
 import org.apache.kafka.storage.internals.log.OffsetIndex;
 import org.apache.kafka.storage.internals.log.OffsetPosition;
 import org.apache.kafka.storage.internals.log.ProducerAppendInfo;
@@ -194,9 +195,26 @@ public class ElasticLogSegment extends LogSegment implements Comparable<ElasticL
         return log.sizeInBytes();
     }
 
+    /**
+     * Checks that the argument offset can be represented as an integer offset relative to the baseOffset.
+     * This method is similar in purpose to {@see org.apache.kafka.storage.internals.log.LogSegment#canConvertToRelativeOffset}.
+     * <p>
+     * The implementation is inspired by {@see org.apache.kafka.storage.internals.log.AbstractIndex#canAppendOffset},
+     * but uses {@code < Integer.MAX_VALUE} instead of {@code <= Integer.MAX_VALUE} to address an offset overflow issue.
+     *
+     * @param offset The offset to check.
+     * @return true if the offset can be converted, false otherwise.
+     * @see <a href="https://github.com/AutoMQ/automq/issues/2718">Issue #2718</a>
+     */
     private boolean canConvertToRelativeOffset(long offset) {
         long relativeOffset = offset - baseOffset;
-        return relativeOffset >= 0 && relativeOffset <= Integer.MAX_VALUE;
+        // Note: The check is `relativeOffset < Integer.MAX_VALUE` instead of `<=` to avoid overflow.
+        // See https://github.com/AutoMQ/automq/issues/2718 for details.
+        return relativeOffset >= 0 && relativeOffset < Integer.MAX_VALUE;
+    }
+    private void ensureOffsetInRange(long offset) throws IOException {
+        if (!canConvertToRelativeOffset(offset))
+            throw new LogSegmentOffsetOverflowException(this, offset);
     }
 
     @Override
@@ -215,6 +233,8 @@ public class ElasticLogSegment extends LogSegment implements Comparable<ElasticL
                 rollingBasedTimestamp = OptionalLong.of(largestTimestampMs);
                 meta.firstBatchTimestamp(largestTimestampMs);
             }
+
+            ensureOffsetInRange(largestOffset);
 
             // append the messages
             long appendedBytes = log.append(records, largestOffset + 1);

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -171,6 +171,9 @@ public class S3Stream implements Stream, StreamMetadataListener {
         if (snapshotRead()) {
             return FutureUtil.failedFuture(new IllegalStateException("Append operation is not support for readonly stream"));
         }
+        if (recordBatch.count() < 0) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("record batch count is negative"));
+        }
         long startTimeNanos = System.nanoTime();
         readLock.lock();
         try {


### PR DESCRIPTION
cherry-pick 201c6eb8320f07e50e19c4a1d5b1a2d319cc8b0d

* fix(log): Prevent potential offset overflow in ElasticLogSegment

This commit addresses an issue where a log segment could accommodate more than Integer.MAX_VALUE records, leading to a potential integer overflow when calculating relative offsets.

The root cause was that the check `offset - baseOffset <= Integer.MAX_VALUE` allowed a relative offset to be exactly `Integer.MAX_VALUE`. Since offsets are 0-based, this allows for `Integer.MAX_VALUE + 1` records, which cannot be represented by a standard Integer.

This fix implements the following changes:
1.  In `ElasticLogSegment`, the offset validation is changed from `<=` to `< Integer.MAX_VALUE` to ensure the relative offset strictly fits within an Integer's bounds.
2.  In `LogCleaner`, a new segment grouping method `groupSegmentsBySizeV2` is introduced for `ElasticUnifiedLog`. This method uses the same stricter offset check to prevent incorrectly grouping segments that would exceed the offset limit.
3.  The corresponding unit tests in `LogCleanerTest` have been updated to reflect these new boundaries and validate the fix.

Fixes: #2718

