### PR TITLE
fix: adjust build config and fix compile warnings (#2717)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ plugins {
 
 ext {
   gradleVersion = versions.gradle
-  minJavaVersion = 11
+  minJavaVersion = 13
   buildVersionFileName = "kafka-version.properties"
 
   defaultMaxHeapSize = "2g"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -128,7 +128,7 @@ public interface AdminApiHandler<K, V> {
         }
 
         public static <K, V> ApiResult<K, V> unmapped(List<K> keys) {
-            return new ApiResult<>(
+            return new ApiResult<K, V>(
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 keys

--- a/core/src/main/scala/kafka/log/streamaspect/cache/FileCache.java
+++ b/core/src/main/scala/kafka/log/streamaspect/cache/FileCache.java
@@ -219,7 +219,11 @@ public class FileCache {
                 }
                 long cacheBlockStartPosition = cacheBlockEndPosition - blockSize;
                 int readSize = (int) Math.min(remaining, cacheBlockEndPosition - nextPosition);
-                buf.writeBytes(cacheByteBuffer.slice(blocks.indexes[i] * blockSize + (int) (nextPosition - cacheBlockStartPosition), readSize));
+                // Use Java 11 compatible approach instead of Java 13+ slice(int, int) method
+                int slicePosition = blocks.indexes[i] * blockSize + (int) (nextPosition - cacheBlockStartPosition);
+                MappedByteBuffer slicedBuffer = cacheByteBuffer.duplicate();
+                slicedBuffer.position(slicePosition).limit(slicePosition + readSize);
+                buf.writeBytes(slicedBuffer.slice());
                 remaining -= readSize;
                 nextPosition += readSize;
                 if (remaining <= 0) {


### PR DESCRIPTION
- Bump minJavaVersion from 11 to 13 to align with Java 13+ API usage
- Fix generic type warning in AdminApiHandler.java
- Replace Java 13+ slice(int, int) method with Java 11+ compatible approach in FileCache.java
- Resolves IDE configuration issues where IntelliJ flagged API calls as errors

Fixes #2717

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
