### PR TITLE
fix: adjust minJavaVersion to 17 and fix compile warnings (#2717)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ plugins {
 
 ext {
   gradleVersion = versions.gradle
-  minJavaVersion = 11
+  minJavaVersion = 17
   buildVersionFileName = "kafka-version.properties"
 
   defaultMaxHeapSize = "2g"


### PR DESCRIPTION
Fixes https://github.com/AutoMQ/automq/issues/2717
Changes
* Updated minJavaVersion from 11 to 17.

Reason
* The code uses APIs introduced in Java 13 and above, which caused errors with the previous version setting.
* Java 17 is an LTS release that ensures better long-term support and aligns with Kafka ecosystem recommendations.


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
