### PR TITLE
fix: Added support for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY 

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/commands/cluster/Deploy.java
+++ b/automq-shell/src/main/java/com/automq/shell/commands/cluster/Deploy.java
@@ -110,9 +110,11 @@ public class Deploy implements Callable<Integer> {
             String globalAccessKey = null;
             String globalSecretKey = null;
             for (Env env : topo.getGlobal().getEnvs()) {
-                if ("KAFKA_S3_ACCESS_KEY".equals(env.getName())) {
+                if ("KAFKA_S3_ACCESS_KEY".equals(env.getName()) ||
+                    "AWS_ACCESS_KEY_ID".equals(env.getName())) {
                     globalAccessKey = env.getValue();
-                } else if ("KAFKA_S3_SECRET_KEY".equals(env.getName())) {
+                } else if ("KAFKA_S3_SECRET_KEY".equals(env.getName()) ||
+                            "AWS_SECRET_ACCESS_KEY".equals(env.getName())) {
                     globalSecretKey = env.getValue();
                 }
             }


### PR DESCRIPTION
This PR attempts to resolve Issue #2746. The main goal was to add support for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to the list of supported environment variables.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
