### PR TITLE
feat(table-topic): Support schema resolution from registry[WIP]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -265,7 +265,7 @@ public class TopicConfig {
     public static final String TABLE_TOPIC_NAMESPACE_CONFIG = "automq.table.topic.namespace";
     public static final String TABLE_TOPIC_NAMESPACE_DOC = "The table topic table namespace";
     public static final String TABLE_TOPIC_SCHEMA_TYPE_CONFIG = "automq.table.topic.schema.type";
-    public static final String TABLE_TOPIC_SCHEMA_TYPE_DOC = "The table topic schema type, support schemaless, schema";
+    public static final String TABLE_TOPIC_SCHEMA_TYPE_DOC = "The table topic schema type, support schemaless, schema, schema_latest";
     public static final String TABLE_TOPIC_ID_COLUMNS_CONFIG = "automq.table.topic.id.columns";
     public static final String TABLE_TOPIC_ID_COLUMNS_DOC = "The primary key, comma-separated list of columns that identify a row in tables."
         + "ex. [region, name]";

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/CustomKafkaProtobufDeserializer.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/CustomKafkaProtobufDeserializer.java
@@ -35,6 +35,10 @@ public class CustomKafkaProtobufDeserializer<T extends Message>
     public CustomKafkaProtobufDeserializer() {
     }
 
+    public CustomKafkaProtobufDeserializer(SchemaResolutionResolver resolver) {
+        super(resolver);
+    }
+
     public CustomKafkaProtobufDeserializer(SchemaRegistryClient schemaRegistry) {
         this.schemaRegistry = schemaRegistry;
     }

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/CustomKafkaProtobufDeserializer.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/CustomKafkaProtobufDeserializer.java
@@ -39,6 +39,11 @@ public class CustomKafkaProtobufDeserializer<T extends Message>
         this.schemaRegistry = schemaRegistry;
     }
 
+    public CustomKafkaProtobufDeserializer(SchemaRegistryClient schemaRegistry, SchemaResolutionResolver schemaResolutionResolver) {
+        super(schemaResolutionResolver);
+        this.schemaRegistry = schemaRegistry;
+    }
+
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         CustomKafkaProtobufDeserializerConfig config = new CustomKafkaProtobufDeserializerConfig(configs);

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.table.deserializer.proto;
+
+import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Default implementation of SchemaResolutionResolver that parses schema information from message headers.
+ * This implementation handles the standard Confluent Kafka protobuf message format with magic byte,
+ * schema ID, message indexes, and message payload.
+ */
+public class HeaderBasedSchemaResolutionResolver implements SchemaResolutionResolver {
+
+    private static final int SCHEMA_ID_SIZE = 4;
+    private static final int HEADER_SIZE = SCHEMA_ID_SIZE + 1; // magic byte + schema id
+    private static final byte MAGIC_BYTE = 0x0;
+
+    @Override
+    public SchemaResolution resolve(String topic, byte[] payload) {
+        if (payload == null) {
+            throw new SerializationException("Payload cannot be null");
+        }
+
+        if (payload.length < HEADER_SIZE) {
+            throw new SerializationException("Invalid payload size: " + payload.length + ", expected at least " + HEADER_SIZE);
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(payload);
+
+        // Extract magic byte
+        byte magicByte = buffer.get();
+        if (magicByte != MAGIC_BYTE) {
+            throw new SerializationException("Unknown magic byte: " + magicByte);
+        }
+
+        // Extract schema ID
+        int schemaId = buffer.getInt();
+
+        // Extract message indexes
+        MessageIndexes indexes = MessageIndexes.readFrom(buffer);
+
+        // Extract message bytes
+        int messageLength = buffer.remaining();
+        byte[] messageBytes = new byte[messageLength];
+        buffer.get(messageBytes);
+
+        return new SchemaResolution(schemaId, indexes, messageBytes);
+    }
+}

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
@@ -20,8 +20,10 @@
 package kafka.automq.table.deserializer.proto;
 
 import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+import kafka.automq.table.transformer.InvalidDataException;
 
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.record.Record;
 
 import java.nio.ByteBuffer;
 
@@ -67,4 +69,15 @@ public class HeaderBasedSchemaResolutionResolver implements SchemaResolutionReso
 
         return new SchemaResolution(schemaId, indexes, messageBytes);
     }
+
+    @Override
+    public int getSchemaId(String topic, Record record) {
+        // io.confluent.kafka.serializers.DeserializationContext#constructor
+        ByteBuffer buffer = record.value().duplicate();
+        if (buffer.get() != MAGIC_BYTE) {
+            throw new InvalidDataException("Unknown magic byte!");
+        }
+        return buffer.getInt();
+    }
+
 }

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/RegistryBasedSchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/RegistryBasedSchemaResolutionResolver.java
@@ -19,18 +19,20 @@
 
 package kafka.automq.table.deserializer.proto;
 
+import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.record.Record;
 
 import com.automq.stream.utils.Time;
-
-import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
+
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 /**
  * Implementation of SchemaResolutionResolver that retrieves the latest schema from Schema Registry by subject name.
@@ -61,6 +63,13 @@ public class RegistryBasedSchemaResolutionResolver implements SchemaResolutionRe
         RegistryBasedSchemaResolutionResolver.CachedSchemaInfo cachedInfo = getCachedSchemaInfo(subject);
 
         return new SchemaResolution(cachedInfo.schemaId, DEFAULT_INDEXES, payload);
+    }
+
+    @Override
+    public int getSchemaId(String topic, Record record) {
+        String subject = getSubjectName(topic);
+        RegistryBasedSchemaResolutionResolver.CachedSchemaInfo cachedInfo = getCachedSchemaInfo(subject);
+        return cachedInfo.schemaId;
     }
 
     private RegistryBasedSchemaResolutionResolver.CachedSchemaInfo getCachedSchemaInfo(String subject) {

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/RegistryBasedSchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/RegistryBasedSchemaResolutionResolver.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.table.deserializer.proto;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+import com.automq.stream.utils.Time;
+
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of SchemaResolutionResolver that retrieves the latest schema from Schema Registry by subject name.
+ * This implementation includes caching mechanism to avoid frequent registry queries.
+ * Cache entries are refreshed every 5 minutes.
+ */
+public class RegistryBasedSchemaResolutionResolver implements SchemaResolutionResolver {
+
+    private static final long CACHE_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+    private static final MessageIndexes DEFAULT_INDEXES = new MessageIndexes(Collections.singletonList(0));
+
+    private final SchemaRegistryClient schemaRegistry;
+    private final ConcurrentHashMap<String, RegistryBasedSchemaResolutionResolver.CachedSchemaInfo> schemaCache = new ConcurrentHashMap<>();
+    private final Time time;
+
+    public RegistryBasedSchemaResolutionResolver(SchemaRegistryClient schemaRegistry) {
+        this.schemaRegistry = schemaRegistry;
+        time = Time.SYSTEM;
+    }
+
+    @Override
+    public SchemaResolution resolve(String topic, byte[] payload) {
+        if (payload == null) {
+            throw new SerializationException("Payload cannot be null");
+        }
+
+        String subject = getSubjectName(topic);
+        RegistryBasedSchemaResolutionResolver.CachedSchemaInfo cachedInfo = getCachedSchemaInfo(subject);
+
+        return new SchemaResolution(cachedInfo.schemaId, DEFAULT_INDEXES, payload);
+    }
+
+    private RegistryBasedSchemaResolutionResolver.CachedSchemaInfo getCachedSchemaInfo(String subject) {
+        long currentTime = time.milliseconds();
+
+        return schemaCache.compute(subject, (key, existing) -> {
+            // If we have existing data and it's still fresh, use it
+            if (existing != null && currentTime - existing.lastUpdated <= CACHE_REFRESH_INTERVAL_MS) {
+                return existing;
+            }
+
+            // Try to get fresh data from registry
+            try {
+                SchemaMetadata latestSchema = schemaRegistry.getLatestSchemaMetadata(subject);
+                return new RegistryBasedSchemaResolutionResolver.CachedSchemaInfo(latestSchema.getId(), currentTime);
+            } catch (IOException | RestClientException e) {
+                // If we have existing cached data (even if expired), use it as fallback
+                if (existing != null) {
+                    // Log warning but continue with stale data
+                    System.err.println("Warning: Failed to refresh schema for subject " + subject +
+                        ", using cached data from " +
+                        new java.util.Date(existing.lastUpdated) + ": " + e.getMessage());
+                    return existing;
+                }
+                // No cached data and fresh fetch failed - this is a hard error
+                throw new SerializationException("Error retrieving schema for subject " + subject +
+                    " and no cached data available", e);
+            }
+        });
+    }
+
+    private String getSubjectName(String topic) {
+        // Follow the Confluent naming convention: <topic>-value or <topic>-key
+        return topic + "-value";
+    }
+
+    private static class CachedSchemaInfo {
+        final int schemaId;
+        final long lastUpdated;
+
+        CachedSchemaInfo(int schemaId, long lastUpdated) {
+            this.schemaId = schemaId;
+            this.lastUpdated = lastUpdated;
+        }
+    }
+}

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/SchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/SchemaResolutionResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.table.deserializer.proto;
+
+import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+
+/**
+ * Interface for resolving schema information for protobuf message deserialization.
+ * This interface supports different strategies for obtaining schema ID and message structure:
+ * - Parse from message header (standard Confluent format)
+ * - Lookup latest schema from registry by subject name
+ */
+public interface SchemaResolutionResolver {
+
+    /**
+     * Resolves schema information for the given message payload and topic.
+     *
+     * @param topic The Kafka topic name
+     * @param payload The serialized protobuf payload
+     * @return SchemaResolution containing schema ID, message indexes, and message bytes
+     * @throws org.apache.kafka.common.errors.SerializationException if resolution fails
+     */
+    SchemaResolution resolve(String topic, byte[] payload);
+
+    /**
+     * Container class for resolved schema information.
+     */
+    class SchemaResolution {
+        private final int schemaId;
+        private final MessageIndexes indexes;
+        private final byte[] messageBytes;
+
+        public SchemaResolution(int schemaId, MessageIndexes indexes, byte[] messageBytes) {
+            this.schemaId = schemaId;
+            this.indexes = indexes;
+            this.messageBytes = messageBytes;
+        }
+
+        public int getSchemaId() {
+            return schemaId;
+        }
+
+        public MessageIndexes getIndexes() {
+            return indexes;
+        }
+
+        public byte[] getMessageBytes() {
+            return messageBytes;
+        }
+    }
+}

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/SchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/SchemaResolutionResolver.java
@@ -21,6 +21,9 @@ package kafka.automq.table.deserializer.proto;
 
 import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
 
+import org.apache.kafka.common.record.Record;
+
+
 /**
  * Interface for resolving schema information for protobuf message deserialization.
  * This interface supports different strategies for obtaining schema ID and message structure:
@@ -38,6 +41,9 @@ public interface SchemaResolutionResolver {
      * @throws org.apache.kafka.common.errors.SerializationException if resolution fails
      */
     SchemaResolution resolve(String topic, byte[] payload);
+
+
+    int getSchemaId(String topic, Record record);
 
     /**
      * Container class for resolved schema information.

--- a/core/src/main/java/kafka/automq/table/transformer/ConverterFactory.java
+++ b/core/src/main/java/kafka/automq/table/transformer/ConverterFactory.java
@@ -19,25 +19,29 @@
 
 package kafka.automq.table.transformer;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import kafka.automq.table.deserializer.proto.ProtobufSchemaProvider;
 import kafka.automq.table.deserializer.proto.RegistryBasedSchemaResolutionResolver;
 import kafka.automq.table.deserializer.proto.SchemaResolutionResolver;
-import org.apache.avro.generic.GenericRecord;
+
 import org.apache.kafka.server.record.TableTopicSchemaType;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import org.apache.avro.generic.GenericRecord;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 
 public class ConverterFactory {
     private final String registryUrl;

--- a/core/src/main/java/kafka/automq/table/transformer/KafkaRecordConvert.java
+++ b/core/src/main/java/kafka/automq/table/transformer/KafkaRecordConvert.java
@@ -25,6 +25,10 @@ public interface KafkaRecordConvert<T> {
 
     T convert(String topic, org.apache.kafka.common.record.Record record, int schemaId);
 
+
+    // io.confluent.kafka.serializers.DeserializationContext#constructor
+    int getSchemaId(String topic, org.apache.kafka.common.record.Record record);
+
     /**
      * Configure this class.
      * @param configs configs in key/value pairs

--- a/core/src/main/java/kafka/automq/table/transformer/ProtobufKafkaRecordConvert.java
+++ b/core/src/main/java/kafka/automq/table/transformer/ProtobufKafkaRecordConvert.java
@@ -21,6 +21,7 @@ package kafka.automq.table.transformer;
 
 import kafka.automq.table.deserializer.proto.CustomKafkaProtobufDeserializer;
 
+import kafka.automq.table.deserializer.proto.SchemaResolutionResolver;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -53,6 +54,10 @@ public class ProtobufKafkaRecordConvert implements KafkaRecordConvert<GenericRec
 
     public ProtobufKafkaRecordConvert(SchemaRegistryClient schemaRegistry) {
         this.deserializer = new CustomKafkaProtobufDeserializer<>(schemaRegistry);
+    }
+
+    public ProtobufKafkaRecordConvert(SchemaRegistryClient schemaRegistry, SchemaResolutionResolver resolver) {
+        this.deserializer = new CustomKafkaProtobufDeserializer<>(schemaRegistry, resolver);
     }
 
     @VisibleForTesting

--- a/core/src/main/java/kafka/automq/table/transformer/ProtobufKafkaRecordConvert.java
+++ b/core/src/main/java/kafka/automq/table/transformer/ProtobufKafkaRecordConvert.java
@@ -20,8 +20,9 @@
 package kafka.automq.table.transformer;
 
 import kafka.automq.table.deserializer.proto.CustomKafkaProtobufDeserializer;
-
+import kafka.automq.table.deserializer.proto.HeaderBasedSchemaResolutionResolver;
 import kafka.automq.table.deserializer.proto.SchemaResolutionResolver;
+
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -30,12 +31,10 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.Message;
 
-import kafka.automq.table.deserializer.proto.HeaderBasedSchemaResolutionResolver;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.protobuf.ProtoConversions;
 import org.apache.avro.protobuf.ProtobufData;
-import org.apache.kafka.common.utils.Utils;
 
 import java.time.Duration;
 import java.util.Map;
@@ -88,7 +87,7 @@ public class ProtobufKafkaRecordConvert implements KafkaRecordConvert<GenericRec
 
     @Override
     public int getSchemaId(String topic, Record record) {
-        return resolver.resolve(topic, Utils.toNullableArray(record.value())).getSchemaId();
+        return resolver.getSchemaId(topic, record);
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/table/transformer/RegistrySchemaAvroConverter.java
+++ b/core/src/main/java/kafka/automq/table/transformer/RegistrySchemaAvroConverter.java
@@ -55,7 +55,7 @@ public class RegistrySchemaAvroConverter implements Converter {
 
     @Override
     public Record convert(org.apache.kafka.common.record.Record record) {
-        int schemaId = getSchemaId(record);
+        int schemaId = recordConvert.getSchemaId(topic, record);
         GenericRecord value;
         try {
             value = recordConvert.convert(topic, record, schemaId);

--- a/server-common/src/main/java/org/apache/kafka/server/record/TableTopicSchemaType.java
+++ b/server-common/src/main/java/org/apache/kafka/server/record/TableTopicSchemaType.java
@@ -27,7 +27,8 @@ import static java.util.Arrays.asList;
 
 public enum TableTopicSchemaType {
     SCHEMALESS("schemaless"),
-    SCHEMA("schema");
+    SCHEMA("schema"),
+    SCHEMA_LATEST("schema_latest");
 
     public final String name;
     private static final List<TableTopicSchemaType> VALUES = asList(values());


### PR DESCRIPTION
This PR enables Table Topics to support Protobuf messages that lack an embedded schema ID, allowing users to adopt this feature without modifying their existing data producers.

A new `schema_latest` option for the `automq.table.topic.schema.type` topic config activates this behavior. When set, the broker fetches the latest schema directly from the Schema Registry.

The implementation uses a `SchemaResolutionResolver` strategy pattern to handle both the new registry-based resolution and the existing header-based resolution.

Fixes #2739