### PR TITLE
refactor(core): support dynamic splicing factory class name

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/client/ClientFactoryProxy.java
+++ b/core/src/main/scala/kafka/log/streamaspect/client/ClientFactoryProxy.java
@@ -25,12 +25,12 @@ import java.lang.reflect.Method;
 
 public class ClientFactoryProxy {
     private static final String PROTOCOL_SEPARATOR = ":";
-    private static final String FACTORY_CLASS_FORMAT = "kafka.log.streamaspect.client.%s.ClientFactory";
 
     public static Client get(Context context) {
         String endpoint = context.config.elasticStreamEndpoint();
         String protocol = endpoint.split(PROTOCOL_SEPARATOR)[0];
-        String className = String.format(FACTORY_CLASS_FORMAT, protocol);
+        String proxyPackage = ClientFactoryProxy.class.getPackage().getName();
+        String className = String.format("%s.%s.ClientFactory", proxyPackage, protocol);
         try {
             Class<?> clazz = Class.forName(className);
             Method method = clazz.getDeclaredMethod("get", Context.class);


### PR DESCRIPTION
Decouple package name hard coding and support dynamic splicing factory class name.

The current ClientFactoryProxy factory classpath concatenation uses a hard-coded package name, which can be prone to omissions or errors if the package structure changes. This change will now dynamically concatenate the factory class name based on the proxy class's package prefix. Simply ensure that the protocol implementation is located in the expected parent package.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
