### PR TITLE
refactor(process): Improve and clarify data processing error handling

### DIFF
--- a/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/HeaderBasedSchemaResolutionResolver.java
@@ -21,6 +21,7 @@ package kafka.automq.table.deserializer.proto;
 
 import kafka.automq.table.deserializer.SchemaResolutionResolver;
 import kafka.automq.table.deserializer.proto.schema.MessageIndexes;
+import kafka.automq.table.process.exception.InvalidDataException;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.record.Record;
@@ -65,13 +66,13 @@ public class HeaderBasedSchemaResolutionResolver implements SchemaResolutionReso
 
     private int readSchemaId(ByteBuffer buffer) {
         if (buffer.remaining() < HEADER_SIZE) {
-            throw new SerializationException("Invalid payload size: " + buffer.remaining() + ", expected at least " + HEADER_SIZE);
+            throw new InvalidDataException("Invalid payload size: " + buffer.remaining() + ", expected at least " + HEADER_SIZE);
         }
 
         // Extract magic byte
         byte magicByte = buffer.get();
         if (magicByte != MAGIC_BYTE) {
-            throw new SerializationException("Unknown magic byte: " + magicByte);
+            throw new InvalidDataException("Unknown magic byte: " + magicByte);
         }
 
         // Extract schema ID

--- a/core/src/main/java/kafka/automq/table/process/Converter.java
+++ b/core/src/main/java/kafka/automq/table/process/Converter.java
@@ -20,6 +20,7 @@
 package kafka.automq.table.process;
 
 import kafka.automq.table.process.exception.ConverterException;
+import kafka.automq.table.process.exception.InvalidDataException;
 
 import org.apache.kafka.common.record.Record;
 
@@ -34,8 +35,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
  *
  * <p>Implementations handle different data formats (e.g., Avro, JSON, Protobuf)
  * and may interact with services like a Schema Registry.</p>
- *
- * <p>Converters are stateful and must be closed to release resources.</p>
  */
 public interface Converter {
 
@@ -53,13 +52,20 @@ public interface Converter {
      *              used for topic-specific schema resolution and routing
      * @param record the Kafka record containing the byte[] payload to convert,
      *               must not be null
-     * @return a ConversionResult containing either the successfully converted
-     *         GenericRecord or detailed error information
+     * @return a {@code ConversionResult} containing the successfully converted data
      * @throws IllegalArgumentException if topic or record is null
+     * @throws InvalidDataException if the input record data is invalid (e.g., null value)
+     * @throws ConverterException if a non-data-related error occurs during conversion (e.g., schema resolution failure)
      */
     ConversionResult convert(String topic, Record record) throws ConverterException;
 
-
+    /**
+     * A convenience wrapper for {@link #buildValueRecord(Object, Schema)}.
+     * Extracts the schema from the given record.
+     *
+     * @param valueRecord the record to wrap.
+     * @return a new GenericRecord wrapping the value record.
+     */
     static GenericRecord buildValueRecord(GenericRecord valueRecord) {
         return buildValueRecord(valueRecord, valueRecord.getSchema());
     }

--- a/core/src/main/java/kafka/automq/table/process/DataError.java
+++ b/core/src/main/java/kafka/automq/table/process/DataError.java
@@ -48,17 +48,6 @@ public final class DataError {
     private final Throwable cause;
 
     /**
-     * Creates a new DataError with the specified type and message.
-     *
-     * @param type the classification of this error
-     * @param message a human-readable description of the error
-     * @throws IllegalArgumentException if type or message is null
-     */
-    public DataError(ErrorType type, String message) {
-        this(type, message, null);
-    }
-
-    /**
      * Creates a new DataError with the specified type, message, and underlying cause.
      *
      * @param type the classification of this error
@@ -155,19 +144,24 @@ public final class DataError {
      * Classification of data processing errors for appropriate error handling.
      */
     public enum ErrorType {
-
         /**
-         * Data-level errors (recoverable, skip record and continue).
-         * Covers format, schema, validation, and general conversion errors.
+         * Indicates that the record's data is malformed or invalid.
+         * This can be due to a null payload, incorrect data size, or a missing or unknown magic byte that prevents further processing.
          */
         DATA_ERROR,
-
         /**
-         * Business logic transformation errors (recoverable, skip record and continue).
-         * Occurs during Transform stage processing.
+         * Indicates a failure during the data deserialization or conversion step.
+         * This can be caused by an inability to fetch a schema from a registry, serialization errors (e.g., Avro, Protobuf), or other schema-related failures.
+         */
+        CONVERT_ERROR,
+        /**
+         * Indicates a failure within a data transformation step.
+         * This can be due to the input data not matching the format expected by a transform (e.g., an invalid Debezium record).
          */
         TRANSFORMATION_ERROR,
-
-        UNKNOW
+        /**
+         * Unknown exception during processing.
+         */
+        UNKNOW_ERROR
     }
 }

--- a/core/src/main/java/kafka/automq/table/process/convert/AvroRegistryConverter.java
+++ b/core/src/main/java/kafka/automq/table/process/convert/AvroRegistryConverter.java
@@ -19,7 +19,8 @@
 
 package kafka.automq.table.process.convert;
 
-import org.apache.kafka.common.errors.SerializationException;
+import kafka.automq.table.process.exception.InvalidDataException;
+
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -85,11 +86,11 @@ public class AvroRegistryConverter extends RegistrySchemaConverter {
     protected int getSchemaId(String topic, Record record) {
         ByteBuffer buffer = record.value();
         if (buffer.remaining() < HEADER_SIZE) {
-            throw new SerializationException("Invalid payload size: " + buffer.remaining() + ", expected at least " + HEADER_SIZE);
+            throw new InvalidDataException("Invalid payload size: " + buffer.remaining() + ", expected at least " + HEADER_SIZE);
         }
         byte magicByte = buffer.get();
         if (magicByte != MAGIC_BYTE) {
-            throw new SerializationException("Unknown magic byte: " + magicByte);
+            throw new InvalidDataException("Unknown magic byte: " + magicByte);
         }
         return buffer.getInt();
     }

--- a/core/src/main/java/kafka/automq/table/process/convert/RawConverter.java
+++ b/core/src/main/java/kafka/automq/table/process/convert/RawConverter.java
@@ -20,7 +20,7 @@ package kafka.automq.table.process.convert;
 
 import kafka.automq.table.process.ConversionResult;
 import kafka.automq.table.process.Converter;
-import kafka.automq.table.process.exception.ConverterException;
+import kafka.automq.table.process.exception.InvalidDataException;
 
 import org.apache.kafka.common.record.Record;
 
@@ -32,9 +32,9 @@ public class RawConverter implements Converter {
     private static final String SCHEMA_IDENTITY = String.valueOf(SCHEMA.hashCode());
 
     @Override
-    public ConversionResult convert(String topic, Record record) throws ConverterException {
+    public ConversionResult convert(String topic, Record record) {
         if (record.value() == null) {
-            throw new ConverterException("Kafka record value cannot be null");
+            throw new InvalidDataException("Kafka record value cannot be null");
         }
         return new ConversionResult(record, Converter.buildValueRecord(record.value(), SCHEMA), SCHEMA_IDENTITY);
     }

--- a/core/src/main/java/kafka/automq/table/process/convert/RegistrySchemaConverter.java
+++ b/core/src/main/java/kafka/automq/table/process/convert/RegistrySchemaConverter.java
@@ -22,6 +22,7 @@ package kafka.automq.table.process.convert;
 import kafka.automq.table.process.ConversionResult;
 import kafka.automq.table.process.Converter;
 import kafka.automq.table.process.exception.ConverterException;
+import kafka.automq.table.process.exception.InvalidDataException;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.record.Record;
@@ -48,6 +49,9 @@ public abstract class RegistrySchemaConverter implements Converter {
     @Override
     public final ConversionResult convert(String topic, Record record) throws ConverterException {
         try {
+            if (record.value() == null) {
+                throw new InvalidDataException("Kafka record value cannot be null");
+            }
             int schemaId = getSchemaId(topic, record);
             GenericRecord convertedRecord = performConversion(topic, record);
 

--- a/core/src/main/java/kafka/automq/table/process/exception/InvalidDataException.java
+++ b/core/src/main/java/kafka/automq/table/process/exception/InvalidDataException.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package kafka.automq.table.transformer;
+package kafka.automq.table.process.exception;
 
 public class InvalidDataException extends RuntimeException {
     private static final long serialVersionUID = 4029025366392702726L;

--- a/core/src/main/java/kafka/automq/table/transformer/ProtoToAvroConverter.java
+++ b/core/src/main/java/kafka/automq/table/transformer/ProtoToAvroConverter.java
@@ -19,6 +19,8 @@
 
 package kafka.automq.table.transformer;
 
+import kafka.automq.table.process.exception.ConverterException;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -43,7 +45,7 @@ public class ProtoToAvroConverter {
             protobufData.addLogicalTypeConversion(new ProtoConversions.TimestampMicrosConversion());
             return convertRecord(protoMessage, schema, protobufData);
         } catch (Exception e) {
-            throw new InvalidDataException("Proto to Avro conversion failed", e);
+            throw new ConverterException("Proto to Avro conversion failed", e);
         }
     }
 
@@ -135,7 +137,7 @@ public class ProtoToAvroConverter {
         } else if (value instanceof Enum) {
             return value.toString(); // protobuf Enum is represented as string
         } else if (value instanceof List) {
-            throw new InvalidDataException("Should be handled in convertValue");
+            throw new ConverterException("Should be handled in convertValue");
         }
 
         // primitive types

--- a/core/src/main/java/kafka/automq/table/transformer/RegistrySchemaAvroConverter.java
+++ b/core/src/main/java/kafka/automq/table/transformer/RegistrySchemaAvroConverter.java
@@ -19,6 +19,7 @@
 
 package kafka.automq.table.transformer;
 
+import kafka.automq.table.process.exception.InvalidDataException;
 import kafka.automq.table.worker.convert.AvroToIcebergVisitor;
 import kafka.automq.table.worker.convert.IcebergRecordConverter;
 

--- a/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
+++ b/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
@@ -21,8 +21,8 @@ package kafka.automq.table.worker;
 
 import kafka.automq.table.events.PartitionMetric;
 import kafka.automq.table.events.TopicMetric;
+import kafka.automq.table.process.exception.InvalidDataException;
 import kafka.automq.table.transformer.Converter;
-import kafka.automq.table.transformer.InvalidDataException;
 
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.utils.FutureUtil;

--- a/core/src/test/java/kafka/automq/table/worker/MemoryWriter.java
+++ b/core/src/test/java/kafka/automq/table/worker/MemoryWriter.java
@@ -19,7 +19,7 @@
 
 package kafka.automq.table.worker;
 
-import kafka.automq.table.transformer.InvalidDataException;
+import kafka.automq.table.process.exception.InvalidDataException;
 import kafka.automq.table.transformer.SchemalessConverter;
 
 import org.apache.kafka.common.record.Record;


### PR DESCRIPTION
1. `DATA_ERROR`:  Indicates that the record's data is malformed or invalid.This can be due to a null payload, incorrect data size, or a missing or unknown magic byte that prevents further processing.
2. `CONVERT_ERROR`: Indicates a failure during the data deserialization or conversion step.This can be caused by an inability to fetch a schema from a registry, serialization errors (e.g., Avro, Protobuf), or other schema-related failures.
3. `TRANSFORMATION_ERROR`: Indicates a failure within a data transformation step.This can be due to the input data not matching the format expected by a transform (e.g., an invalid Debezium record).
4. `UNKNOW_ERROR`:  Unknown exception during processing.
