### PR TITLE
refactor: use `KAFKA_S3_*` env vars instead of AWS-specific names in Helm chart

### DIFF
--- a/chart/bitnami/demo-values.yaml
+++ b/chart/bitnami/demo-values.yaml
@@ -7,9 +7,9 @@ image:
   tag: 1.5.0-bitnami
   pullPolicy: Always
 extraEnvVars:
-  - name: AWS_ACCESS_KEY_ID
+  - name: KAFKA_S3_ACCESS_KEY
     value: "${access-key}"
-  - name: AWS_SECRET_ACCESS_KEY
+  - name: KAFKA_S3_SECRET_KEY
     value: "${secret-key}"
 controller:
   replicaCount: 3


### PR DESCRIPTION
### What this PR does

This PR updates the AutoMQ Helm chart to use the more semantically accurate environment variable names:
- `KAFKA_S3_ACCESS_KEY`
- `KAFKA_S3_SECRET_KEY`

instead of the AWS-specific:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

This change aligns better with AutoMQ’s multi-cloud and generic object storage positioning, avoiding confusion that these variables are AWS-only.


### Why this is needed

the Helm chart currently defaults to the AWS-specific ones. This may mislead users to believe that only AWS S3 is supported, whereas in reality, AutoMQ works with any S3-compatible storage.

Using KAFKA_S3_* as default improves clarity and neutrality, especially for users deploying on Tencent Cloud, MinIO, or other providers.
