### PR TITLE
fix(config): remove exception for invalid list string in TableTopicConfigValidator

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/automq/TableTopicConfigValidator.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/automq/TableTopicConfigValidator.java
@@ -137,8 +137,6 @@ public class TableTopicConfigValidator {
         Matcher matcher = LIST_STRING_REGEX.matcher(value);
         if (matcher.matches()) {
             value = matcher.group(1);
-        } else {
-            throw new ConfigException("", value, String.format("Invalid list string %s", value));
         }
         return Arrays.stream(value.split(regex)).map(String::trim).collect(toList());
     }

--- a/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
@@ -63,6 +63,7 @@ public class TableTopicConfigValidatorTest {
 
     @Test
     public void testStringToList() {
+        Assertions.assertEquals(List.of("a", "b", "c"), TableTopicConfigValidator.stringToList("a, b, c", COMMA_NO_PARENS_REGEX));
         Assertions.assertEquals(List.of("a", "b", "c"), TableTopicConfigValidator.stringToList("[a, b, c]", COMMA_NO_PARENS_REGEX));
     }
 }


### PR DESCRIPTION
- The error indicates the configuration value `month(ts)` is invalid because it is not recognized as a valid list string.
```
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidConfigurationException: Invalid value month(ts) for configuration : Invalid list string month(ts)
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:180)
	at kafka.admin.ConfigCommand$.alterConfig(ConfigCommand.scala:382)
	at kafka.admin.ConfigCommand$.processCommand(ConfigCommand.scala:349)
	at kafka.admin.ConfigCommand$.main(ConfigCommand.scala:98)
	at kafka.admin.ConfigCommand.main(ConfigCommand.scala)
Caused by: org.apache.kafka.common.errors.InvalidConfigurationException: Invalid value month(ts) for configuration : Invalid list string month(ts)
```

- The method `ConfigCommand#parseConfigsToBeAdded` parses user-supplied configurations from the command line into a `Properties` object.
- It processes a comma-separated string of `key=value` pairs.
- To handle values containing commas, the method treats commas inside square brackets `[]` as part of the value, not as separators.
- It trims spaces around keys and values, removes the surrounding brackets from values, then stores the cleaned pairs in `props`.
- Example: `"k2=[v2_a,v2_b]"` is stored as key `k2` and value `v2_a,v2_b` without brackets.

https://github.com/AutoMQ/automq/blob/21caf6b123dd70a68d258fd925785a529f3a48d9/core/src/main/scala/kafka/admin/ConfigCommand.scala#L292-L303

The error likely arises because `month(ts)` was not enclosed in brackets, so the parser misinterprets it as an invalid list.