### PR TITLE
fix(s3stream): correct the comment about the maximum range of merged read tasks

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -730,7 +730,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
     }
 
     /**
-     * Get adjacent read tasks and merge them into one read task which read range is not exceed 16MB.
+     * Get adjacent read tasks and merge them into one read task which read range is not exceed {@link MergedReadTask#MAX_MERGE_READ_SIZE} (4MB).
      */
     private void tryMergeRead0() {
         List<AbstractObjectStorage.MergedReadTask> mergedReadTasks = new ArrayList<>();


### PR DESCRIPTION

The comments do not match the actual values ​​in the code.
<img width="833" height="126" alt="image" src="https://github.com/user-attachments/assets/cc4576f1-759a-405e-9ca8-072df3724ab6" />
<img width="878" height="461" alt="image" src="https://github.com/user-attachments/assets/ad54cb91-39b2-41e4-af05-bc1773e1692e" />


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
