### PR TITLE
feat(metrics): integrate new metrics for table delay, fields per second, and event loop busy ratio (#2876)

### DIFF
--- a/core/src/main/java/kafka/automq/table/coordinator/TableCoordinator.java
+++ b/core/src/main/java/kafka/automq/table/coordinator/TableCoordinator.java
@@ -36,6 +36,7 @@ import kafka.server.MetadataCache;
 
 import org.apache.kafka.storage.internals.log.LogConfig;
 
+import com.automq.stream.s3.metrics.Metrics;
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.utils.Systems;
 import com.automq.stream.utils.Threads;
@@ -61,13 +62,10 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,23 +80,7 @@ public class TableCoordinator implements Closeable {
     private static final String SNAPSHOT_COMMIT_ID = "automq.commit.id";
     private static final String WATERMARK = "automq.watermark";
     private static final UUID NOOP_UUID = new UUID(0, 0);
-    private static final Map<String, Long> WATERMARK_METRICS = new ConcurrentHashMap<>();
-    private static final Map<String, Double> FIELD_PER_SECONDS_METRICS = new ConcurrentHashMap<>();
     private static final long NOOP_WATERMARK = -1L;
-
-    static {
-        TableTopicMetricsManager.setDelaySupplier(() -> {
-            Map<String, Long> delay = new HashMap<>(WATERMARK_METRICS.size());
-            long now = System.currentTimeMillis();
-            WATERMARK_METRICS.forEach((topic, watermark) -> {
-                if (watermark != NOOP_WATERMARK) {
-                    delay.put(topic, now - watermark);
-                }
-            });
-            return delay;
-        });
-        TableTopicMetricsManager.setFieldsPerSecondSupplier(() -> FIELD_PER_SECONDS_METRICS);
-    }
 
     private final Catalog catalog;
     private final String topic;
@@ -113,9 +95,11 @@ public class TableCoordinator implements Closeable {
     private final long commitTimeout = TimeUnit.SECONDS.toMillis(30);
     private volatile boolean closed = false;
     private final Supplier<LogConfig> config;
+    private final Metrics.LongGaugeBundle.LongGauge delayMetric;
+    private final Metrics.DoubleGaugeBundle.DoubleGauge fieldsPerSecondMetric;
 
     public TableCoordinator(Catalog catalog, String topic, MetaStream metaStream, Channel channel,
-        EventLoop eventLoop, MetadataCache metadataCache, Supplier<LogConfig> config) {
+                            EventLoop eventLoop, MetadataCache metadataCache, Supplier<LogConfig> config) {
         this.catalog = catalog;
         this.topic = topic;
         this.name = topic;
@@ -125,13 +109,15 @@ public class TableCoordinator implements Closeable {
         this.metadataCache = metadataCache;
         this.config = config;
         this.tableIdentifier = TableIdentifierUtil.of(config.get().tableTopicNamespace, topic);
+        this.delayMetric = TableTopicMetricsManager.registerDelay(topic);
+        this.fieldsPerSecondMetric = TableTopicMetricsManager.registerFieldsPerSecond(topic);
     }
 
     private CommitStatusMachine commitStatusMachine;
 
     public void start() {
-        WATERMARK_METRICS.put(topic, -1L);
-        FIELD_PER_SECONDS_METRICS.put(topic, 0.0);
+        delayMetric.clear();
+        fieldsPerSecondMetric.record(0.0);
 
         // await for a while to avoid multi coordinators concurrent commit.
         SCHEDULER.schedule(() -> {
@@ -157,8 +143,8 @@ public class TableCoordinator implements Closeable {
     public void close() {
         // quick close
         closed = true;
-        WATERMARK_METRICS.remove(topic);
-        FIELD_PER_SECONDS_METRICS.remove(topic);
+        delayMetric.close();
+        fieldsPerSecondMetric.close();
         eventLoop.execute(() -> {
             if (commitStatusMachine != null) {
                 commitStatusMachine.close();
@@ -474,9 +460,15 @@ public class TableCoordinator implements Closeable {
         }
 
         private void recordMetrics() {
-            double fps = commitFieldCount * 1000.0 / Math.max(System.currentTimeMillis() - lastCommitTimestamp, 1);
-            FIELD_PER_SECONDS_METRICS.computeIfPresent(topic, (k, v) -> fps);
-            WATERMARK_METRICS.computeIfPresent(topic, (k, v) -> watermark(partitionWatermarks));
+            long now = System.currentTimeMillis();
+            double fps = commitFieldCount * 1000.0 / Math.max(now - lastCommitTimestamp, 1);
+            fieldsPerSecondMetric.record(fps);
+            long watermarkTimestamp = watermark(partitionWatermarks);
+            if (watermarkTimestamp == NOOP_WATERMARK) {
+                delayMetric.clear();
+            } else {
+                delayMetric.record(Math.max(now - watermarkTimestamp, 0));
+            }
         }
 
         private boolean tryEvolvePartition() {

--- a/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
+++ b/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
@@ -19,49 +19,45 @@
 
 package kafka.automq.table.metric;
 
+import com.automq.stream.s3.metrics.Metrics;
+import com.automq.stream.s3.metrics.MetricsLevel;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.ObservableDoubleGauge;
-import io.opentelemetry.api.metrics.ObservableLongGauge;
 
-public class TableTopicMetricsManager {
+public final class TableTopicMetricsManager {
     private static final Cache<String, Attributes> TOPIC_ATTRIBUTE_CACHE = CacheBuilder.newBuilder()
         .expireAfterAccess(Duration.ofMinutes(1)).build();
-    private static Supplier<Map<String, Long>> delaySupplier = Collections::emptyMap;
-    private static Supplier<Map<String, Double>> fieldsPerSecondSupplier = Collections::emptyMap;
-    private static ObservableLongGauge delay;
-    private static ObservableDoubleGauge fieldsPerSecond;
+    private static final Metrics.LongGaugeBundle DELAY_GAUGES = Metrics.instance()
+        .longGauge("kafka_tabletopic_delay", "Table topic commit delay", "ms");
+    private static final Metrics.DoubleGaugeBundle FIELDS_PER_SECOND_GAUGES = Metrics.instance()
+        .doubleGauge("kafka_tabletopic_fps", "Table topic fields per second", "fields/s");
+    private static final Metrics.DoubleGaugeBundle EVENT_LOOP_BUSY_GAUGES = Metrics.instance()
+        .doubleGauge("kafka_tableworker_eventloop_busy_ratio", "Table worker event loop busy ratio", "%");
+
+    private TableTopicMetricsManager() {
+    }
 
     public static void initMetrics(Meter meter) {
-        String prefix = "kafka_tabletopic_";
-        delay = meter.gaugeBuilder(prefix + "delay").ofLongs().setUnit("ms")
-            .buildWithCallback(recorder ->
-                delaySupplier.get().forEach((topic, delay) -> {
-                    if (delay >= 0) {
-                        recorder.record(delay, getTopicAttribute(topic));
-                    }
-                }));
-        fieldsPerSecond = meter.gaugeBuilder(prefix + "fps")
-            .buildWithCallback(recorder ->
-                fieldsPerSecondSupplier.get().forEach((topic, fps) -> recorder.record(fps, getTopicAttribute(topic))));
+        // Metrics instruments are registered via Metrics.instance(); no additional setup required.
     }
 
-    public static void setDelaySupplier(Supplier<Map<String, Long>> supplier) {
-        delaySupplier = supplier;
+    public static Metrics.LongGaugeBundle.LongGauge registerDelay(String topic) {
+        return DELAY_GAUGES.register(MetricsLevel.INFO, getTopicAttribute(topic));
     }
 
-    public static void setFieldsPerSecondSupplier(Supplier<Map<String, Double>> supplier) {
-        fieldsPerSecondSupplier = supplier;
+    public static Metrics.DoubleGaugeBundle.DoubleGauge registerFieldsPerSecond(String topic) {
+        return FIELDS_PER_SECOND_GAUGES.register(MetricsLevel.INFO, getTopicAttribute(topic));
+    }
+
+    public static Metrics.DoubleGaugeBundle.DoubleGauge registerEventLoopBusy(String loop) {
+        return EVENT_LOOP_BUSY_GAUGES.register(MetricsLevel.INFO, getLoopAttribute(loop));
     }
 
     private static Attributes getTopicAttribute(String topic) {
@@ -72,4 +68,7 @@ public class TableTopicMetricsManager {
         }
     }
 
+    private static Attributes getLoopAttribute(String loop) {
+        return Attributes.of(AttributeKey.stringKey("event_loop"), loop);
+    }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/Metrics.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/Metrics.java
@@ -25,13 +25,18 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
 
 public class Metrics {
@@ -56,6 +61,14 @@ public class Metrics {
 
     public LongCounter counter(Function<Meter, LongCounter> newFunc) {
         return new LazyLongCounter(newFunc);
+    }
+
+    public LongGaugeBundle longGauge(String name, String desc, String unit) {
+        return new LongGaugeBundle(name, desc, unit);
+    }
+
+    public DoubleGaugeBundle doubleGauge(String name, String desc, String unit) {
+        return new DoubleGaugeBundle(name, desc, unit);
     }
 
     private synchronized void setup0() {
@@ -185,11 +198,176 @@ public class Metrics {
                     return;
                 }
                 this.finalAttributes = Attributes.builder()
-                        .putAll(globalConfig.getBaseAttributes())
-                        .putAll(histogramAttrs)
-                        .build();
+                    .putAll(globalConfig.getBaseAttributes())
+                    .putAll(histogramAttrs)
+                    .build();
                 this.shouldRecord = level.isWithin(globalConfig.getMetricsLevel());
                 histogram.setSnapshotInterval(globalConfig.getMetricsReportIntervalMs());
+            }
+        }
+    }
+
+    public class LongGaugeBundle implements Setup {
+        private final List<LongGauge> gauges = new CopyOnWriteArrayList<>();
+        private final String name;
+        private final String desc;
+        private final String unit;
+
+        private ObservableLongGauge instrument;
+
+        @SuppressWarnings("this-escape")
+        public LongGaugeBundle(String name, String desc, String unit) {
+            this.name = name;
+            this.desc = desc;
+            this.unit = unit;
+            waitingSetups.add(this);
+            setup0();
+        }
+
+        public LongGauge register(MetricsLevel level, Attributes attributes) {
+            LongGauge gauge = new LongGauge(level, attributes);
+            gauges.add(gauge);
+            gauge.setup();
+            return gauge;
+        }
+
+        public synchronized void setup() {
+            gauges.forEach(LongGauge::setup);
+            this.instrument = meter.gaugeBuilder(name)
+                .setDescription(desc)
+                .setUnit(unit)
+                .ofLongs()
+                .buildWithCallback(measurement -> gauges.forEach(gauge -> gauge.record(measurement)));
+        }
+
+        public final class LongGauge implements AutoCloseable {
+            private final MetricsLevel level;
+            private final Attributes gaugeAttributes;
+            private final AtomicLong value = new AtomicLong();
+            private final AtomicBoolean hasValue = new AtomicBoolean(false);
+            private Attributes finalAttributes = Attributes.empty();
+            private volatile boolean shouldRecord = true;
+
+            private LongGauge(MetricsLevel level, Attributes attributes) {
+                this.level = level;
+                this.gaugeAttributes = attributes;
+                this.finalAttributes = attributes;
+            }
+
+            private void setup() {
+                if (meter != null && globalConfig != null) {
+                    this.finalAttributes = Attributes.builder()
+                        .putAll(globalConfig.getBaseAttributes())
+                        .putAll(gaugeAttributes)
+                        .build();
+                    this.shouldRecord = level.isWithin(globalConfig.getMetricsLevel());
+                } else {
+                    this.finalAttributes = gaugeAttributes;
+                    this.shouldRecord = true;
+                }
+            }
+
+            public void record(long newValue) {
+                value.set(newValue);
+                hasValue.set(true);
+            }
+
+            public void clear() {
+                hasValue.set(false);
+            }
+
+            private void record(ObservableLongMeasurement measurement) {
+                if (shouldRecord && hasValue.get()) {
+                    measurement.record(value.get(), finalAttributes);
+                }
+            }
+
+            @Override
+            public void close() {
+                gauges.remove(this);
+                hasValue.set(false);
+            }
+        }
+    }
+
+    public class DoubleGaugeBundle implements Setup {
+        private final List<DoubleGauge> gauges = new CopyOnWriteArrayList<>();
+        private final String name;
+        private final String desc;
+        private final String unit;
+
+        private ObservableDoubleGauge instrument;
+
+        @SuppressWarnings("this-escape")
+        public DoubleGaugeBundle(String name, String desc, String unit) {
+            this.name = name;
+            this.desc = desc;
+            this.unit = unit;
+            waitingSetups.add(this);
+            setup0();
+        }
+
+        public DoubleGauge register(MetricsLevel level, Attributes attributes) {
+            DoubleGauge gauge = new DoubleGauge(level, attributes);
+            gauges.add(gauge);
+            gauge.setup();
+            return gauge;
+        }
+
+        public synchronized void setup() {
+            gauges.forEach(DoubleGauge::setup);
+            this.instrument = meter.gaugeBuilder(name)
+                .setDescription(desc)
+                .setUnit(unit)
+                .buildWithCallback(measurement -> gauges.forEach(gauge -> gauge.record(measurement)));
+        }
+
+        public final class DoubleGauge implements AutoCloseable {
+            private final MetricsLevel level;
+            private final Attributes gaugeAttributes;
+            private final AtomicReference<Double> value = new AtomicReference<>(0.0);
+            private final AtomicBoolean hasValue = new AtomicBoolean(false);
+            private Attributes finalAttributes = Attributes.empty();
+            private volatile boolean shouldRecord = true;
+
+            private DoubleGauge(MetricsLevel level, Attributes attributes) {
+                this.level = level;
+                this.gaugeAttributes = attributes;
+                this.finalAttributes = attributes;
+            }
+
+            private void setup() {
+                if (meter != null && globalConfig != null) {
+                    this.finalAttributes = Attributes.builder()
+                        .putAll(globalConfig.getBaseAttributes())
+                        .putAll(gaugeAttributes)
+                        .build();
+                    this.shouldRecord = level.isWithin(globalConfig.getMetricsLevel());
+                } else {
+                    this.finalAttributes = gaugeAttributes;
+                    this.shouldRecord = true;
+                }
+            }
+
+            public void record(double newValue) {
+                value.set(newValue);
+                hasValue.set(true);
+            }
+
+            public void clear() {
+                hasValue.set(false);
+            }
+
+            private void record(ObservableDoubleMeasurement measurement) {
+                if (shouldRecord && hasValue.get()) {
+                    measurement.record(value.get(), finalAttributes);
+                }
+            }
+
+            @Override
+            public void close() {
+                gauges.remove(this);
+                hasValue.set(false);
             }
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/network/ThrottleStrategy.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/ThrottleStrategy.java
@@ -23,7 +23,8 @@ public enum ThrottleStrategy {
     BYPASS(0, "bypass"),
     COMPACTION(1, "compaction"),
     TAIL(2, "tail"),
-    CATCH_UP(3, "catchup");
+    CATCH_UP(3, "catchup"),
+    ICEBERG_WRITE(4, "iceberg_write");
 
     private final int priority;
     private final String name;


### PR DESCRIPTION
[feat(metrics): integrate new metrics for table delay, fields per second, and event loop busy ratio](https://github.com/AutoMQ/automq/commit/ae63696aa291cc80d28eecffc034b6ecf2245c5b)

cherry-pick: https://github.com/AutoMQ/automq/pull/2876