### PR TITLE
fix(zerozone2): fix epoch missing update when there isn't new record

### DIFF
--- a/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
@@ -313,6 +313,11 @@ public class PartitionSnapshotsManager {
             @Override
             public void onDeleted(TopicPartition partition) {
             }
+
+            @Override
+            public void onNewLeaderEpoch(long oldEpoch, long newEpoch) {
+                version.version.incrementRecordsVersion();
+            }
         };
     }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -79,6 +79,14 @@ trait PartitionListener {
    * that the partition was deleted but only that this broker does not host a replica of it any more.
    */
   def onDeleted(partition: TopicPartition): Unit = {}
+
+  // AutoMQ inject start
+  /**
+   * Called when the partition leader epoch is changed.
+   */
+  def onNewLeaderEpoch(oldEpoch: Long, newEpoch: Long): Unit = {}
+  // AutoMQ inject end
+
 }
 
 trait AlterPartitionListener {
@@ -350,6 +358,16 @@ class Partition(val topicPartition: TopicPartition,
       }
     }
   }
+
+  // AutoMQ inject start
+  private val newLeaderEpochListener = new PartitionListener {
+    override def onNewLeaderEpoch(oldEpoch: Long, newEpoch: Long): Unit = {
+      listeners.forEach { listener =>
+        listener.onNewLeaderEpoch(oldEpoch, newEpoch)
+      }
+    }
+  }
+  // AutoMQ inject end
 
   /* Epoch of the controller that last changed the leader. This needs to be initialized correctly upon broker startup.
    * One way of doing that is through the controller's start replica state change command. When a new broker starts up
@@ -911,8 +929,12 @@ class Partition(val topicPartition: TopicPartition,
 
         // We update the leader epoch and the leader epoch start offset iff the
         // leader epoch changed.
+        val oldLeaderEpoch = leaderEpoch
         leaderEpoch = partitionState.leaderEpoch
         leaderEpochStartOffsetOpt = Some(leaderEpochStartOffset)
+        // AutoMQ inject start
+        newLeaderEpochListener.onNewLeaderEpoch(oldLeaderEpoch, partitionState.leaderEpoch)
+        // AutoMQ inject end
       } else {
         stateChangeLogger.info(s"Skipped the become-leader state change for $topicPartition with topic id $topicId " +
           s"and partition state $partitionState since it is already the leader with leader epoch $leaderEpoch. " +


### PR DESCRIPTION
When there isn't any new record and the partition is reassigned, the snapshot-read partition only applies the leader epoch that trigger the partition reassignment (not the final leader epoch). This will cause OFFSET_FOR_LEADER_EPOCH request return UNKNOWN_LEADER_EPOCH.