### PR TITLE
fix(s3stream): correct mismatch between configuration class defaults and profile property defaults

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -45,17 +45,17 @@ public class Config {
     private int controllerRequestRetryMaxCount = Integer.MAX_VALUE;
     private long controllerRequestRetryBaseDelayMs = 500;
     private long nodeEpoch = 0L;
-    private int streamSetObjectCompactionInterval = 10;
+    private int streamSetObjectCompactionInterval = 5;
     private long streamSetObjectCompactionCacheSize = 200 * 1024 * 1024;
     private int streamSetObjectCompactionUploadConcurrency = 8;
-    private long streamSetObjectCompactionStreamSplitSize = 16 * 1024 * 1024;
+    private long streamSetObjectCompactionStreamSplitSize = 8 * 1024 * 1024;
     private int streamSetObjectCompactionForceSplitPeriod = 120;
     private int streamSetObjectCompactionMaxObjectNum = 500;
-    private int maxStreamNumPerStreamSetObject = 100000;
+    private int maxStreamNumPerStreamSetObject = 20000;
     private int maxStreamObjectNumPerCommit = 10000;
     private boolean mockEnable = false;
-    // 100MB/s
-    private long networkBaselineBandwidth = 100 * 1024 * 1024;
+    // 1GBps/s
+    private long networkBaselineBandwidth = 1024 * 1024 * 1024;
     private int refillPeriodMs = 10;
     private long objectRetentionTimeInSecond = 10 * 60; // 10min
     private boolean failoverEnable = false;


### PR DESCRIPTION

Correct mismatch between configuration class defaults and profile property defaults.
<img width="539" height="100" alt="企业微信截图_1e30f1b8-9161-4e43-8818-6e97f0c8fa81" src="https://github.com/user-attachments/assets/6c6cda1a-e7ad-478a-a2bb-7b92c7ad98e4" />
<img width="536" height="91" alt="企业微信截图_f708f750-e8dc-44f7-85c5-5a9227d828ff" src="https://github.com/user-attachments/assets/f349a400-a956-4196-b515-9f9c171351f7" />
<img width="669" height="103" alt="企业微信截图_25b7ef8e-179c-44fb-be36-a970528d3c7b" src="https://github.com/user-attachments/assets/5dba1aaf-0320-40a1-9a2c-11ec4b34d6d9" />
<img width="522" height="100" alt="企业微信截图_63bc0de1-45fe-4268-9705-97f1e1d1413c" src="https://github.com/user-attachments/assets/75fdd184-22d7-4452-a16a-14e6a8811f2d" />




### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
