### PR TITLE
fix: correctly use bytebuffer slice in decodecontexts method (#2925)

### DIFF
--- a/core/src/main/java/kafka/automq/failover/FailoverListener.java
+++ b/core/src/main/java/kafka/automq/failover/FailoverListener.java
@@ -80,11 +80,11 @@ public class FailoverListener implements MetadataPublisher, AutoCloseable {
             .map(kv -> kv.get(FailoverConstants.FAILOVER_KEY))
             .map(this::decodeContexts);
     }
-
+    
     private FailoverContext[] decodeContexts(ByteBuffer byteBuffer) {
-        byteBuffer.slice();
-        byte[] data = new byte[byteBuffer.remaining()];
-        byteBuffer.get(data);
+        ByteBuffer slice = byteBuffer.slice();
+        byte[] data = new byte[slice.remaining()];
+        slice.get(data);
         return JsonUtils.decode(new String(data, StandardCharsets.UTF_8), FailoverContext[].class);
     }
 


### PR DESCRIPTION
cherry-pick: #2925 (https://github.com/AutoMQ/automq/commit/6ed19409488d1addcb5ea21132e56a8fe4794339)