### PR TITLE
perf(s3stream): compute compaction delay using min timestamp instead of sorting

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
@@ -55,7 +55,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -160,6 +159,10 @@ public class CompactionManager {
                     if (ts < minCommittedTimestamp) {
                         minCommittedTimestamp = ts;
                     }
+                }
+                if (minCommittedTimestamp == Long.MAX_VALUE) {
+                    this.compactionDelayTime = 0;
+                    return;
                 }
                 this.compactionDelayTime = System.currentTimeMillis() - minCommittedTimestamp;
             }).join(), (long) this.compactionInterval * 2, 1, TimeUnit.MINUTES);


### PR DESCRIPTION



          
**Issue Title**
Performance: avoid sorting when computing `compactionDelayTime`; use min timestamp

**Description**
In `CompactionManager.start()`’s periodic monitor task, `compactionDelayTime` is computed by sorting server objects by `committedTimestamp` and then taking the first element. This sorting is unnecessary because we only need the minimum timestamp. Sorting costs O(n log n) time; finding the minimum is O(n). With large object lists, the sort introduces avoidable CPU overhead and potential GC pressure.

**Affected Code**
- Path: `s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java`
- Method: `start()`
- Current logic:
```
data.sort(Comparator.comparingLong(S3ObjectMetadata::committedTimestamp));
this.compactionDelayTime = System.currentTimeMillis() - data.get(0).committedTimestamp();
```

**Benefits**
- Reduce time complexity from O(n log n) to O(n).
- Lower CPU usage and reduce GC pressure from sorting.
- Improve efficiency of the periodic monitoring task in high-object-count scenarios.

**Behavior**
- Semantics unchanged: the delay is still based on the earliest `committedTimestamp`.
- Edge cases unchanged: when `data` is null/empty or an exception occurs, delay is set to `0`.

**Validation**
- Build `s3stream` module: `./gradlew :s3stream:compileJava -x test` should pass.
- Run regular builds/integration tests to confirm no functional regressions.
- Optional: profile CPU/time of the monitor task with large object lists to confirm reduction.
        

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
