### PR TITLE
fix(core): fix outbound bandwidth limiter token refill and metrics baseline

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
+++ b/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
@@ -140,11 +140,12 @@ public class DefaultS3Client implements Client {
             config.networkBaselineBandwidth() - (long) networkInboundRate.derive(
                 TimeUnit.NANOSECONDS.toSeconds(System.nanoTime()), NetworkStats.getInstance().networkInboundUsageTotal().get()));
         // Use a larger token pool for outbound traffic to avoid spikes caused by Upload WAL affecting tail-reading performance.
+        long outboundBaselineBandwidth = config.networkBaselineBandwidth() * 5;
         GlobalNetworkBandwidthLimiters.instance().setup(AsyncNetworkBandwidthLimiter.Type.OUTBOUND,
-            refillToken, config.refillPeriodMs(), config.networkBaselineBandwidth() * 5);
+            refillToken * 5, config.refillPeriodMs(), outboundBaselineBandwidth);
         networkOutboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND);
         S3StreamMetricsManager.registerNetworkAvailableBandwidthSupplier(AsyncNetworkBandwidthLimiter.Type.OUTBOUND, () ->
-            config.networkBaselineBandwidth() - (long) networkOutboundRate.derive(
+            outboundBaselineBandwidth - (long) networkOutboundRate.derive(
                 TimeUnit.NANOSECONDS.toSeconds(System.nanoTime()), NetworkStats.getInstance().networkOutboundUsageTotal().get()));
 
         this.localIndexCache = LocalStreamRangeIndexCache.create();


### PR DESCRIPTION
Outbound baseline bandwidth is configured as networkBaselineBandwidth * 5, but refillToken and metrics calculation were still using inbound baseline.
This caused dashboard outbound available bandwidth to always show negative values.
<img width="1146" height="263" alt="image" src="https://github.com/user-attachments/assets/c47a8fd9-6868-4d87-8705-85b9cecefe88" />
