### PR TITLE
fix(schema): streamline schema change handling and enhance test coverage

### DIFF
--- a/core/src/test/java/kafka/automq/table/worker/IcebergSchemaChangeCollectorTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/IcebergSchemaChangeCollectorTest.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.table.worker;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class IcebergSchemaChangeCollectorTest {
+    private InMemoryCatalog catalog;
+
+    @BeforeEach
+    public void setup() {
+        catalog = initializeCatalog();
+        catalog.createNamespace(Namespace.of("default"));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenSchemasMatch() {
+        Schema schema = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(schema, schema);
+        assertTrue(changes.isEmpty());
+    }
+
+    @Test
+    public void shouldDetectTopLevelAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "name", null);
+        assertEquals(Types.StringType.get(), change.getNewType());
+    }
+
+    @Test
+    public void shouldDetectTopLevelOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "id", null);
+    }
+
+    @Test
+    public void shouldDetectTopLevelPromotion() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE, "id", null);
+        assertEquals(Types.LongType.get(), change.getNewType());
+    }
+
+    @Test
+    public void shouldDetectNestedAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()),
+                Types.NestedField.optional(4, "email", Types.StringType.get()))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "email", "user");
+    }
+
+    @Test
+    public void shouldDetectListElementStructAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "street", Types.StringType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(
+                    Types.NestedField.optional(3, "street", Types.StringType.get()),
+                    Types.NestedField.optional(4, "zip", Types.IntegerType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "zip", "addresses.element");
+    }
+
+    @Test
+    public void shouldPromoteListElementStructFieldType() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "zip", Types.IntegerType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "zip", Types.LongType.get())))));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE, "zip", "addresses.element");
+        assertEquals(Types.LongType.get(), change.getNewType());
+    }
+
+    @Test
+    public void shouldPromoteMapValueStructFieldType() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of(Types.NestedField.optional(4, "zip", Types.IntegerType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of(Types.NestedField.optional(4, "zip", Types.LongType.get())))));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE, "zip", "attributes.value");
+        assertEquals(Types.LongType.get(), change.getNewType());
+    }
+
+    @Test
+    public void shouldMakeListElementStructFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.required(3, "zip", Types.IntegerType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "zip", Types.IntegerType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "zip", "addresses.element");
+    }
+
+    @Test
+    public void shouldSoftRemoveMapValueStructField() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of(Types.NestedField.required(4, "zip", Types.IntegerType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of())));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "zip", "attributes.value");
+    }
+
+    @Test
+    public void shouldSkipDuplicateListElementChanges() {
+        Schema schema = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "zip", Types.LongType.get())))));
+
+        List<IcebergTableManager.SchemaChange> changes = List.of(
+            new IcebergTableManager.SchemaChange(IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "zip", null, "addresses.element"),
+            new IcebergTableManager.SchemaChange(IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE, "zip", Types.LongType.get(), "addresses.element"));
+
+        IcebergTableManager manager = new IcebergTableManager(initializeCatalog(), TableIdentifier.of("default", "dummy"), mock(WorkerConfig.class));
+        Table table = manager.getTableOrCreate(schema);
+        manager.applySchemaChange(table, changes);
+    }
+
+    @Test
+    public void ignoresElementTypeReplacementAsIncompatible() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2,
+                Types.StructType.of(Types.NestedField.optional(3, "zip", Types.IntegerType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "addresses", Types.ListType.ofOptional(2, Types.IntegerType.get())));
+
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(initial, current);
+        assertTrue(changes.isEmpty(), "Incompatible list element type change should be ignored");
+    }
+
+    @Test
+    public void ignoresPrimitiveListElementPromotion() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "nums", Types.ListType.ofOptional(2, Types.IntegerType.get())));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "nums", Types.ListType.ofOptional(2, Types.LongType.get())));
+
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(initial, current);
+        assertTrue(changes.isEmpty(), "list<int> -> list<long> promotion is unsupported and should be ignored");
+    }
+
+    @Test
+    public void shouldDetectMapValueStructAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of(Types.NestedField.optional(4, "city", Types.StringType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.optional(1, "attributes", Types.MapType.ofOptional(2, 3,
+                Types.StringType.get(),
+                Types.StructType.of(
+                    Types.NestedField.optional(4, "city", Types.StringType.get()),
+                    Types.NestedField.optional(5, "country", Types.StringType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "country", "attributes.value");
+    }
+
+    @Test
+    public void shouldDetectDeepNestedAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()))))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()),
+                    Types.NestedField.optional(5, "age", Types.IntegerType.get()))))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "age", "user.profile");
+    }
+
+    @Test
+    public void shouldDetectNestedFieldMadeOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()),
+                    Types.NestedField.required(5, "age", Types.IntegerType.get()))))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()),
+                    Types.NestedField.optional(5, "age", Types.IntegerType.get()))))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "age", "user.profile");
+    }
+
+    @Test
+    public void shouldDetectNestedPromotion() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "age", Types.IntegerType.get()))))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "age", Types.LongType.get()))))));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE, "age", "user.profile");
+        assertEquals(Types.LongType.get(), change.getNewType());
+    }
+
+    @Test
+    public void shouldSoftRemoveTopLevelField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "email", Types.StringType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "email", null);
+    }
+
+    @Test
+    public void shouldSoftRemoveNonPrimitiveField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "ids", Types.ListType.ofRequired(2, Types.LongType.get())));
+        Schema current = new Schema();
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "ids", null);
+        // ensure newType is null for non-primitive types so runtime won't call asPrimitiveType
+        assertEquals(null, change.getNewType());
+    }
+
+    @Test
+    public void shouldSoftRemoveNestedField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()),
+                    Types.NestedField.required(5, "age", Types.IntegerType.get()))))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "profile", Types.StructType.of(
+                    Types.NestedField.required(4, "name", Types.StringType.get()))))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "age", "user.profile");
+    }
+
+    @Test
+    public void shouldReportMixedChanges() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "score", Types.FloatType.get()),
+            Types.NestedField.optional(4, "old_field", Types.StringType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "score", Types.DoubleType.get()),
+            Types.NestedField.optional(5, "new_field", Types.StringType.get()));
+
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(initial, current);
+        assertEquals(4, changes.size());
+        assertTrue(changes.stream().anyMatch(c -> c.getType() == IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE
+            && c.getColumnName().equals("id")));
+        assertTrue(changes.stream().anyMatch(c -> c.getType() == IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL
+            && c.getColumnName().equals("name")));
+        assertTrue(changes.stream().anyMatch(c -> c.getType() == IcebergTableManager.SchemaChange.ChangeType.PROMOTE_TYPE
+            && c.getColumnName().equals("score")));
+        assertTrue(changes.stream().anyMatch(c -> c.getType() == IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN
+            && c.getColumnName().equals("new_field")));
+    }
+
+
+    @Test
+    public void shouldDetectOptionalListFieldAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "tags", null);
+        assertEquals(Types.ListType.ofOptional(3, Types.StringType.get()), change.getNewType());
+    }
+
+    @Test
+    public void shouldDetectOptionalMapFieldAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "metadata", Types.MapType.ofOptional(3, 4,
+                Types.StringType.get(), Types.StringType.get())));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "metadata", null);
+        assertEquals(Types.MapType.ofOptional(3, 4, Types.StringType.get(), Types.StringType.get()),
+            change.getNewType());
+    }
+
+    @Test
+    public void shouldDetectRequiredListFieldAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "scores", Types.ListType.ofRequired(3, Types.IntegerType.get())));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "scores", null);
+        assertEquals(Types.ListType.ofRequired(3, Types.IntegerType.get()), change.getNewType());
+    }
+
+    @Test
+    public void shouldDetectRequiredMapFieldAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "attributes", Types.MapType.ofRequired(3, 4,
+                Types.StringType.get(), Types.IntegerType.get())));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "attributes", null);
+        assertEquals(Types.MapType.ofRequired(3, 4, Types.StringType.get(), Types.IntegerType.get()),
+            change.getNewType());
+    }
+
+    @Test
+    public void shouldSoftRemoveRequiredListField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "tags", null);
+        // newType should be null for non-primitive types
+        assertEquals(null, change.getNewType());
+    }
+
+    @Test
+    public void shouldSoftRemoveRequiredMapField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "metadata", Types.MapType.ofOptional(3, 4,
+                Types.StringType.get(), Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+        IcebergTableManager.SchemaChange change = assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "metadata", null);
+        assertEquals(null, change.getNewType());
+    }
+
+    @Test
+    public void shouldSoftRemoveOptionalListField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+        // Optional field removal should still trigger MAKE_OPTIONAL to ensure idempotency
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(initial, current);
+        assertTrue(changes.isEmpty() || changes.stream().allMatch(c ->
+            c.getType() == IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL &&
+            c.getColumnName().equals("tags")));
+    }
+
+    @Test
+    public void shouldSoftRemoveOptionalMapField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "metadata", Types.MapType.ofOptional(3, 4,
+                Types.StringType.get(), Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+        List<IcebergTableManager.SchemaChange> changes = collectChanges(initial, current);
+        assertTrue(changes.isEmpty() || changes.stream().allMatch(c ->
+            c.getType() == IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL &&
+            c.getColumnName().equals("metadata")));
+    }
+
+    @Test
+    public void shouldMakeListFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "tags", null);
+    }
+
+    @Test
+    public void shouldMakeMapFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "metadata", Types.MapType.ofOptional(3, 4,
+                Types.StringType.get(), Types.StringType.get())));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "metadata", Types.MapType.ofOptional(3, 4,
+                Types.StringType.get(), Types.StringType.get())));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "metadata", null);
+    }
+
+    @Test
+    public void shouldDetectNestedListFieldAddition() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()),
+                Types.NestedField.optional(4, "hobbies", Types.ListType.ofOptional(5, Types.StringType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.ADD_COLUMN, "hobbies", "user");
+    }
+
+    @Test
+    public void shouldSoftRemoveNestedListField() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()),
+                Types.NestedField.required(4, "hobbies", Types.ListType.ofOptional(5, Types.StringType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "hobbies", "user");
+    }
+
+    @Test
+    public void shouldMakeNestedMapFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()),
+                Types.NestedField.required(4, "preferences", Types.MapType.ofOptional(5, 6,
+                    Types.StringType.get(), Types.StringType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "user", Types.StructType.of(
+                Types.NestedField.required(3, "name", Types.StringType.get()),
+                Types.NestedField.optional(4, "preferences", Types.MapType.ofOptional(5, 6,
+                    Types.StringType.get(), Types.StringType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "preferences", "user");
+    }
+
+
+    @Test
+    public void shouldMakeStructFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "address", Types.StructType.of(
+                Types.NestedField.required(3, "street", Types.StringType.get()),
+                Types.NestedField.required(4, "city", Types.StringType.get()))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "address", Types.StructType.of(
+                Types.NestedField.required(3, "street", Types.StringType.get()),
+                Types.NestedField.required(4, "city", Types.StringType.get()))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "address", null);
+    }
+
+    @Test
+    public void shouldMakeListNestedStructFieldOptional() {
+        Schema initial = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "contacts", Types.ListType.ofRequired(3,
+                Types.StructType.of(
+                    Types.NestedField.required(4, "type", Types.StringType.get()),
+                    Types.NestedField.required(5, "detail", Types.StringType.get())))));
+        Schema current = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "contacts", Types.ListType.ofRequired(3,
+                Types.StructType.of(
+                    Types.NestedField.optional(4, "type", Types.StringType.get()),
+                    Types.NestedField.required(5, "detail", Types.StringType.get())))));
+
+        assertSingleChange(
+            collectChanges(initial, current), IcebergTableManager.SchemaChange.ChangeType.MAKE_OPTIONAL, "type", "contacts.element");
+    }
+
+    private List<IcebergTableManager.SchemaChange> collectChanges(Schema tableSchema, Schema currentSchema) {
+        TableIdentifier tableId = TableIdentifier.of("default", generateRandomTableName());
+        IcebergTableManager tableManager = new IcebergTableManager(catalog, tableId, mock(WorkerConfig.class));
+        Table table = tableManager.getTableOrCreate(tableSchema);
+        return tableManager.collectSchemaChanges(currentSchema, table);
+    }
+
+    private IcebergTableManager.SchemaChange assertSingleChange(List<IcebergTableManager.SchemaChange> changes,
+                                                                IcebergTableManager.SchemaChange.ChangeType type,
+                                                                String columnName,
+                                                                String parentName) {
+        assertEquals(1, changes.size(), "Expected exactly one schema change");
+        IcebergTableManager.SchemaChange change = changes.get(0);
+        assertEquals(type, change.getType());
+        assertEquals(columnName, change.getColumnName());
+        assertEquals(parentName, change.getParentName());
+        return change;
+    }
+
+    private String generateRandomTableName() {
+        int randomNum = ThreadLocalRandom.current().nextInt(1000, 10000);
+        return "schema_table_" + randomNum;
+    }
+
+    private InMemoryCatalog initializeCatalog() {
+        InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
+        inMemoryCatalog.initialize("test", ImmutableMap.of());
+        return inMemoryCatalog;
+    }
+}

--- a/core/src/test/java/kafka/automq/table/worker/IcebergWriterSchemaEvolutionTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/IcebergWriterSchemaEvolutionTest.java
@@ -46,18 +46,14 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -93,348 +89,1283 @@ class IcebergWriterSchemaEvolutionTest {
         writer.setOffset(0, 0);
     }
 
-    private String generateRandomTableName() {
-        int randomNum = ThreadLocalRandom.current().nextInt(1000, 10000);
-        return "test_table_" + randomNum;
-    }
-
     @Test
-    void testSchemaEvolutionAddColumn() throws IOException {
-        // Given: Initial Avro schema (v1)
-        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV1.setFields(fieldsV1);
+    void testAddRequiredFieldsInNestedStruct() throws IOException {
+        // v1: {id, user{name}}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Collections.singletonList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
 
-        // Create v1 record
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
         GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
         avroRecordV1.put("id", 1L);
-        avroRecordV1.put("name", "test");
+        avroRecordV1.put("user", userRecordV1);
 
-        // Given: Updated Avro schema (v2) with new email field
+        // v2: Add required primitive field in nested struct (age)
+        // Add required nested struct field (profile)
+        // Add required list field in nested struct (hobbies)
+        Schema profileV2 = Schema.createRecord("Profile", null, null, false);
+        profileV2.setFields(Arrays.asList(
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("level", Schema.create(Schema.Type.INT), null, null)));
+
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        Schema hobbiesSchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("age", Schema.create(Schema.Type.INT), null, null),
+            new Schema.Field("profile", profileV2, null, null),
+            new Schema.Field("hobbies", hobbiesSchema, null, null)));
+
         Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        Schema emailSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
-        fieldsV2.add(new Schema.Field("email", emailSchema, null, null));
-        avroSchemaV2.setFields(fieldsV2);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
 
-        // Create v2 record
+        GenericRecord profileRecordV2 = new GenericData.Record(profileV2);
+        profileRecordV2.put("city", "Shanghai");
+        profileRecordV2.put("level", 5);
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("age", 30);
+        userRecordV2.put("profile", profileRecordV2);
+        userRecordV2.put("hobbies", Arrays.asList("reading", "coding"));
+
         GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
         avroRecordV2.put("id", 2L);
-        avroRecordV2.put("name", "test2");
-        avroRecordV2.put("email", "test@example.com");
+        avroRecordV2.put("user", userRecordV2);
 
-        // Mock deserializer behavior
         when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
             .thenReturn(avroRecordV1)
             .thenReturn(avroRecordV2);
 
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
 
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        // Verify schema evolution
         Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertEquals(4, table.schema().columns().size());
-        assertNotNull(table.schema().findField("_kafka_value.email"));
+        // Verify nested primitive field
+        assertNotNull(table.schema().findField("_kafka_value.user.age"));
+        // Verify nested struct field
+        assertNotNull(table.schema().findField("_kafka_value.user.profile"));
+        assertNotNull(table.schema().findField("_kafka_value.user.profile.city"));
+        // Verify nested list field
+        assertNotNull(table.schema().findField("_kafka_value.user.hobbies"));
     }
 
     @Test
-    void testSchemaEvolutionMakeColumnOptional() throws IOException {
-        // Given: Initial Avro schema with required fields
-        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV1.setFields(fieldsV1);
+    void testAddRequiredFieldsInCollectionElement() throws IOException {
+        // v1: {id, addresses: list<{street}>}
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Collections.singletonList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null)));
 
-        // Create v1 record
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(addressV1);
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("street", "Main St");
         GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
         avroRecordV1.put("id", 1L);
-        avroRecordV1.put("name", "test");
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
 
-        // Given: Updated schema with optional name field
+        // v2: Add required primitive field in list element (zipCode, floor)
+        // Add required nested struct field in list element (location)
+        Schema locationV2 = Schema.createRecord("Location", null, null, false);
+        locationV2.setFields(Arrays.asList(
+            new Schema.Field("lat", Schema.create(Schema.Type.DOUBLE), null, null),
+            new Schema.Field("lng", Schema.create(Schema.Type.DOUBLE), null, null)));
+
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        addressV2.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("zipCode", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("floor", Schema.create(Schema.Type.INT), null, null),
+            new Schema.Field("location", locationV2, null, null)));
+
         Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        Schema optionalName = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
-        fieldsV2.add(new Schema.Field("name", optionalName, null, null));
-        avroSchemaV2.setFields(fieldsV2);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
 
-        // Create v2 record
+        GenericRecord locationRecordV2 = new GenericData.Record(locationV2);
+        locationRecordV2.put("lat", 39.9042);
+        locationRecordV2.put("lng", 116.4074);
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Second St");
+        addressRecordV2.put("zipCode", "100000");
+        addressRecordV2.put("floor", 5);
+        addressRecordV2.put("location", locationRecordV2);
+
         GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
         avroRecordV2.put("id", 2L);
-        avroRecordV2.put("name", null);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
 
-        // Mock deserializer behavior
         when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
             .thenReturn(avroRecordV1)
             .thenReturn(avroRecordV2);
 
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
 
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        // Verify schema evolution
         Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertEquals(false, table.schema().findField("_kafka_value.name").isRequired());
+        // Verify primitive fields in list element
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.zipCode"));
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.floor"));
+        // Verify struct field in list element
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.location"));
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.location.lat"));
     }
 
     @Test
-    void testSchemaEvolutionChangeColumnType() throws IOException {
-        // Given: Initial Avro schema with integer type
+    void testAddOptionalCollection() throws IOException {
+        // v1: {id, name}
         Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("count", Schema.create(Schema.Type.INT), null, null));
-        avroSchemaV1.setFields(fieldsV1);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
 
-        // Create v1 record
         GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
         avroRecordV1.put("id", 1L);
-        avroRecordV1.put("count", 100);
+        avroRecordV1.put("name", "alice");
 
-        // Given: Updated schema with long type
+        // v2: {id, name, tags: list<string>}
         Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("count", Schema.create(Schema.Type.LONG), null, null));
-        avroSchemaV2.setFields(fieldsV2);
+        Schema listSchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+        Schema optionalList = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listSchema));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("tags", optionalList, null, null)));
 
-        // Create v2 record
         GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
         avroRecordV2.put("id", 2L);
-        avroRecordV2.put("count", 1000L);
+        avroRecordV2.put("name", "bob");
+        avroRecordV2.put("tags", Arrays.asList("tag1", "tag2"));
 
-        // Mock deserializer behavior
         when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
             .thenReturn(avroRecordV1)
             .thenReturn(avroRecordV2);
 
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
 
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        // Verify schema evolution
         Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertEquals(Types.LongType.get(), table.schema().findField("_kafka_value.count").type());
+        assertNotNull(table.schema().findField("_kafka_value.tags"));
+        assertEquals(true, table.schema().findField("_kafka_value.tags").type().isListType());
     }
 
-    @Test
-    void testSchemaEvolutionDropColumn() throws IOException {
-        // Given: Initial Avro schema (v1)
-        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        fieldsV1.add(new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV1.setFields(fieldsV1);
 
-        // Create v1 record
+    @Test
+    void testAddRequiredCollections() throws IOException {
+        // v1: {id, name}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
         GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
         avroRecordV1.put("id", 1L);
-        avroRecordV1.put("name", "test");
-        avroRecordV1.put("email", "test@example.com");
+        avroRecordV1.put("name", "alice");
 
-        // Given: Updated Avro schema (v2) with dropped email field
+        // v2: Add list<primitive> (tags)
+        // Add list<struct> (addresses)
+        // Add map<K,primitive> (scores)
+        // Add map<K,struct> (locations)
+        Schema addressSchema = Schema.createRecord("Address", null, null, false);
+        addressSchema.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema locationSchema = Schema.createRecord("Location", null, null, false);
+        locationSchema.setFields(Arrays.asList(
+            new Schema.Field("lat", Schema.create(Schema.Type.DOUBLE), null, null),
+            new Schema.Field("lng", Schema.create(Schema.Type.DOUBLE), null, null)));
+
         Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV2.setFields(fieldsV2);
+        Schema tagsList = Schema.createArray(Schema.create(Schema.Type.STRING));
+        Schema addressesList = Schema.createArray(addressSchema);
+        Schema scoresMap = Schema.createMap(Schema.create(Schema.Type.INT));
+        Schema locationsMap = Schema.createMap(locationSchema);
 
-        // Create v2 record
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("tags", tagsList, null, null),
+            new Schema.Field("addresses", addressesList, null, null),
+            new Schema.Field("scores", scoresMap, null, null),
+            new Schema.Field("locations", locationsMap, null, null)));
+
+        GenericRecord addressRecord = new GenericData.Record(addressSchema);
+        addressRecord.put("street", "Main St");
+        addressRecord.put("city", "Beijing");
+
+        GenericRecord locationRecord = new GenericData.Record(locationSchema);
+        locationRecord.put("lat", 39.9042);
+        locationRecord.put("lng", 116.4074);
+
         GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
         avroRecordV2.put("id", 2L);
-        avroRecordV2.put("name", "test2");
+        avroRecordV2.put("name", "bob");
+        avroRecordV2.put("tags", Arrays.asList("tag1", "tag2"));
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecord));
+        java.util.Map<String, Integer> scoresMapData = new java.util.HashMap<>();
+        scoresMapData.put("math", 95);
+        avroRecordV2.put("scores", scoresMapData);
+        java.util.Map<String, GenericRecord> locationsMapData = new java.util.HashMap<>();
+        locationsMapData.put("home", locationRecord);
+        avroRecordV2.put("locations", locationsMapData);
 
-        // Mock deserializer behavior
         when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
             .thenReturn(avroRecordV1)
             .thenReturn(avroRecordV2);
 
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
 
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        // Verify schema evolution
         Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertEquals(4, table.schema().columns().size());
+        // Verify list<primitive>
+        assertNotNull(table.schema().findField("_kafka_value.tags"));
+        assertEquals(true, table.schema().findField("_kafka_value.tags").type().isListType());
+        // Verify list<struct>
+        assertNotNull(table.schema().findField("_kafka_value.addresses"));
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.street"));
+        // Verify map<K,primitive>
+        assertNotNull(table.schema().findField("_kafka_value.scores"));
+        assertEquals(true, table.schema().findField("_kafka_value.scores").type().isMapType());
+        // Verify map<K,struct>
+        assertNotNull(table.schema().findField("_kafka_value.locations"));
+        assertNotNull(table.schema().findField("_kafka_value.locations.value.lat"));
+    }
+
+
+    @Test
+    void testAddRequiredFieldInCollectionElement() throws IOException {
+        // v1: addresses: list<{street}>
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Collections.singletonList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(addressV1);
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("street", "Main St");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
+
+        // v2: addresses: list<{street, required city}>
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        addressV2.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Second St");
+        addressRecordV2.put("city", "Beijing");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.city"));
+        assertEquals(Types.StringType.get(), table.schema().findField("_kafka_value.addresses.element.city").type());
+    }
+
+    @Test
+    void testAddRequiredFieldInMapValueStruct() throws IOException {
+        // v1: locations: map<string, {city}>
+        Schema locationV1 = Schema.createRecord("Location", null, null, false);
+        locationV1.setFields(Collections.singletonList(
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV1 = Schema.createMap(locationV1);
+        Schema optionalMapV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("locations", optionalMapV1, null, null)));
+
+        GenericRecord locationRecordV1 = new GenericData.Record(locationV1);
+        locationRecordV1.put("city", "Shanghai");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        java.util.Map<String, GenericRecord> mapData1 = new java.util.HashMap<>();
+        mapData1.put("home", locationRecordV1);
+        avroRecordV1.put("locations", mapData1);
+
+        // v2: locations: map<string, {city, required country}>
+        Schema locationV2 = Schema.createRecord("Location", null, null, false);
+        locationV2.setFields(Arrays.asList(
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("country", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV2 = Schema.createMap(locationV2);
+        Schema optionalMapV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("locations", optionalMapV2, null, null)));
+
+        GenericRecord locationRecordV2 = new GenericData.Record(locationV2);
+        locationRecordV2.put("city", "Beijing");
+        locationRecordV2.put("country", "China");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        java.util.Map<String, GenericRecord> mapData2 = new java.util.HashMap<>();
+        mapData2.put("work", locationRecordV2);
+        avroRecordV2.put("locations", mapData2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.locations.value.country"));
+        assertEquals(Types.StringType.get(), table.schema().findField("_kafka_value.locations.value.country").type());
+    }
+
+
+    // ========== Add Optional Field Tests ==========
+
+    @Test
+    void testAddOptionalFieldInNestedStruct() throws IOException {
+        // v1: user{name}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Collections.singletonList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: user{name, email}
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        Schema optionalEmail = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("email", optionalEmail, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("email", "bob@example.com");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.user.email"));
+    }
+
+
+    @Test
+    void testDropRequiredCollection() throws IOException {
+        // v1: {id, tags: list<string>}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listSchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("tags", listSchema, null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("tags", Arrays.asList("tag1", "tag2"));
+
+        // v2: {id} - dropped tags
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Collections.singletonList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.tags"));
+        assertEquals(false, table.schema().findField("_kafka_value.tags").isRequired());
+    }
+
+    @Test
+    void testDropRequiredFieldInNestedStruct() throws IOException {
+        // v1: user{name, email, age}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("age", Schema.create(Schema.Type.INT), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
+        userRecordV1.put("email", "alice@example.com");
+        userRecordV1.put("age", 25);
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: user{name, email} - dropped age
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("email", "bob@example.com");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.user.age"));
+        assertEquals(false, table.schema().findField("_kafka_value.user.age").isRequired());
+    }
+
+    @Test
+    void testMakeRequiredFieldOptionalInNestedStruct() throws IOException {
+        // v1: user{required name, required age}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("age", Schema.create(Schema.Type.INT), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
+        userRecordV1.put("age", 25);
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: user{required name, optional age}
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        Schema optionalAge = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("age", optionalAge, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("age", null);
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertEquals(false, table.schema().findField("_kafka_value.user.age").isRequired());
+    }
+
+    @Test
+    void testPromoteFieldTypeInNestedStruct() throws IOException {
+        // v1: user{age: int}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Collections.singletonList(
+            new Schema.Field("age", Schema.create(Schema.Type.INT), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("age", 25);
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: user{age: long}
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        userV2.setFields(Collections.singletonList(
+            new Schema.Field("age", Schema.create(Schema.Type.LONG), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("age", 30L);
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertEquals(Types.LongType.get(), table.schema().findField("_kafka_value.user.age").type());
+    }
+
+    // ========== Collection Field Tests ==========
+
+
+
+    @Test
+    void testAddOptionalMapCollection() throws IOException {
+        // v1: {id, name}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("name", "alice");
+
+        // v2: {id, name, metadata: map<string,string>}
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+        Schema optionalMap = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapSchema));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("metadata", optionalMap, null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("name", "bob");
+        java.util.Map<String, String> metadataMap = new java.util.HashMap<>();
+        metadataMap.put("key1", "value1");
+        metadataMap.put("key2", "value2");
+        avroRecordV2.put("metadata", metadataMap);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.metadata"));
+        assertEquals(true, table.schema().findField("_kafka_value.metadata").type().isMapType());
+    }
+
+
+    @Test
+    void testAddOptionalFieldInCollectionElement() throws IOException {
+        // v1: addresses: list<{street}>
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Collections.singletonList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(addressV1);
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("street", "Main St");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
+
+        // v2: addresses: list<{street, zipCode}>
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        Schema optionalZip = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        addressV2.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("zipCode", optionalZip, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Second St");
+        addressRecordV2.put("zipCode", "12345");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.zipCode"));
+    }
+
+    @Test
+    void testDropRequiredFieldInMapValueStruct() throws IOException {
+        // v1: attributes: map<string, {city, country}>
+        Schema locationV1 = Schema.createRecord("Location", null, null, false);
+        locationV1.setFields(Arrays.asList(
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("country", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV1 = Schema.createMap(locationV1);
+        Schema optionalMapV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("attributes", optionalMapV1, null, null)));
+
+        GenericRecord locationRecordV1 = new GenericData.Record(locationV1);
+        locationRecordV1.put("city", "Beijing");
+        locationRecordV1.put("country", "China");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        java.util.Map<String, GenericRecord> mapData1 = new java.util.HashMap<>();
+        mapData1.put("home", locationRecordV1);
+        avroRecordV1.put("attributes", mapData1);
+
+        // v2: attributes: map<string, {city}> - dropped country
+        Schema locationV2 = Schema.createRecord("Location", null, null, false);
+        locationV2.setFields(Collections.singletonList(
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV2 = Schema.createMap(locationV2);
+        Schema optionalMapV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("attributes", optionalMapV2, null, null)));
+
+        GenericRecord locationRecordV2 = new GenericData.Record(locationV2);
+        locationRecordV2.put("city", "Shanghai");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        java.util.Map<String, GenericRecord> mapData2 = new java.util.HashMap<>();
+        mapData2.put("work", locationRecordV2);
+        avroRecordV2.put("attributes", mapData2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.attributes.value.country"));
+        assertEquals(false, table.schema().findField("_kafka_value.attributes.value.country").isRequired());
+    }
+
+    @Test
+    void testPromoteFieldTypeInCollectionElement() throws IOException {
+        // v1: addresses: list<{zip: int}>
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Collections.singletonList(
+            new Schema.Field("zip", Schema.create(Schema.Type.INT), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(addressV1);
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("zip", 12345);
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
+
+        // v2: addresses: list<{zip: long}>
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        addressV2.setFields(Collections.singletonList(
+            new Schema.Field("zip", Schema.create(Schema.Type.LONG), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("zip", 67890L);
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertEquals(Types.LongType.get(), table.schema().findField("_kafka_value.addresses.element.zip").type());
+    }
+
+    // ========== Drop Required Field Tests ==========
+
+    @Test
+    void testDropRequiredFieldInCollectionElement() throws IOException {
+        // v1: addresses: list<{street, city, zipCode}>
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("zipCode", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(addressV1);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", listV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("street", "Main St");
+        addressRecordV1.put("city", "Beijing");
+        addressRecordV1.put("zipCode", "100000");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
+
+        // v2: addresses: list<{street, city}> - dropped required zipCode
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        addressV2.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", listV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Second St");
+        addressRecordV2.put("city", "Shanghai");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that the dropped required field is now optional
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.zipCode"));
+        assertEquals(false, table.schema().findField("_kafka_value.addresses.element.zipCode").isRequired());
+    }
+
+    // ========== Drop Optional Field Tests ==========
+
+    @Test
+    void testDropOptionalFieldInNestedStruct() throws IOException {
+        // v1: user{name, email, phone}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        Schema optionalEmail = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        Schema optionalPhone = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        userV1.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("email", optionalEmail, null, null),
+            new Schema.Field("phone", optionalPhone, null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
+        userRecordV1.put("email", "alice@example.com");
+        userRecordV1.put("phone", "123-456-7890");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: user{name, email} - dropped optional phone
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("email", optionalEmail, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("email", "bob@example.com");
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that the dropped optional field still exists and remains optional
+        assertNotNull(table.schema().findField("_kafka_value.user.phone"));
+        assertEquals(false, table.schema().findField("_kafka_value.user.phone").isRequired());
+    }
+
+    @Test
+    void testDropOptionalCollections() throws IOException {
+        // v1: {id, tags: optional list<string>, metadata: optional map<string,string>}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listSchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+        Schema optionalList = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listSchema));
+        Schema mapSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+        Schema optionalMap = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapSchema));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("tags", optionalList, null, null),
+            new Schema.Field("metadata", optionalMap, null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("tags", Arrays.asList("tag1", "tag2"));
+        java.util.Map<String, String> metadataMap = new java.util.HashMap<>();
+        metadataMap.put("key1", "value1");
+        avroRecordV1.put("metadata", metadataMap);
+
+        // v2: {id} - dropped both optional collections
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Collections.singletonList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that dropped optional collections still exist and remain optional
+        assertNotNull(table.schema().findField("_kafka_value.tags"));
+        assertEquals(false, table.schema().findField("_kafka_value.tags").isRequired());
+        assertNotNull(table.schema().findField("_kafka_value.metadata"));
+        assertEquals(false, table.schema().findField("_kafka_value.metadata").isRequired());
+    }
+
+    // ========== Make Field Optional Tests ==========
+
+    @Test
+    void testMakeRequiredFieldOptional() throws IOException {
+        // v1: {id, required email}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("email", "alice@example.com");
+
+        // v2: {id, optional email}
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema optionalEmail = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("email", optionalEmail, null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("email", null);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
         assertNotNull(table.schema().findField("_kafka_value.email"));
         assertEquals(false, table.schema().findField("_kafka_value.email").isRequired());
     }
 
     @Test
-    void testSchemaEvolutionSwitchOptionalField() throws IOException {
-        // Base schema without optional fields
+    void testMakeRequiredFieldOptionalInCollectionElement() throws IOException {
+        // v1: addresses: list<{street, required city}>
+        Schema addressV1 = Schema.createRecord("Address", null, null, false);
+        addressV1.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", Schema.create(Schema.Type.STRING), null, null)));
+
         Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV1.setFields(fieldsV1);
+        Schema listV1 = Schema.createArray(addressV1);
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV1, null, null)));
+
+        GenericRecord addressRecordV1 = new GenericData.Record(addressV1);
+        addressRecordV1.put("street", "Main St");
+        addressRecordV1.put("city", "Beijing");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("addresses", Collections.singletonList(addressRecordV1));
+
+        // v2: addresses: list<{street, optional city}>
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        Schema optionalCity = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        addressV2.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("city", optionalCity, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Second St");
+        addressRecordV2.put("city", null);
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that the field in collection element is now optional
+        assertNotNull(table.schema().findField("_kafka_value.addresses.element.city"));
+        assertEquals(false, table.schema().findField("_kafka_value.addresses.element.city").isRequired());
+    }
+
+    @Test
+    void testMakeRequiredCollectionOptional() throws IOException {
+        // v1: {id, required tags: list<string>}
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(Schema.create(Schema.Type.STRING));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("tags", listV1, null, null)));
 
         GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
         avroRecordV1.put("id", 1L);
-        avroRecordV1.put("name", "base");
+        avroRecordV1.put("tags", Arrays.asList("tag1", "tag2"));
 
-        // Schema with optional field1 added on top of base schema
+        // v2: {id, optional tags: list<string>}
         Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        Schema optionalField1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
-        fieldsV2.add(new Schema.Field("field1", optionalField1, null, null));
-        avroSchemaV2.setFields(fieldsV2);
+        Schema listV2 = Schema.createArray(Schema.create(Schema.Type.STRING));
+        Schema optionalList = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("tags", optionalList, null, null)));
 
         GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
         avroRecordV2.put("id", 2L);
-        avroRecordV2.put("name", "with-field1");
-        avroRecordV2.put("field1", "value1");
+        avroRecordV2.put("tags", null);
 
-        // Schema removes field1 and introduces optional field2 instead
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        assertNotNull(table.schema().findField("_kafka_value.tags"));
+        assertEquals(false, table.schema().findField("_kafka_value.tags").isRequired());
+    }
+
+    // ========== Promote Field Type Tests ==========
+
+    @Test
+    void testPromoteCollectionElementType() throws IOException {
+        // v1: scores: list<int>
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV1 = Schema.createArray(Schema.create(Schema.Type.INT));
+        Schema optionalListV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("scores", optionalListV1, null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("scores", Arrays.asList(90, 85, 95));
+
+        // v2: scores: list<long>
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema listV2 = Schema.createArray(Schema.create(Schema.Type.LONG));
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("scores", optionalListV2, null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("scores", Arrays.asList(100L, 95L, 98L));
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that the collection element type cannot be promoted from int to long
+        assertNotNull(table.schema().findField("_kafka_value.scores"));
+        assertEquals(true, table.schema().findField("_kafka_value.scores").type().isListType());
+        assertEquals(Types.IntegerType.get(),
+            table.schema().findField("_kafka_value.scores").type().asListType().elementType());
+    }
+
+    @Test
+    void testPromoteMapValueType() throws IOException {
+        // v1: metadata: map<string, int>
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV1 = Schema.createMap(Schema.create(Schema.Type.INT));
+        Schema optionalMapV1 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV1));
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("metadata", optionalMapV1, null, null)));
+
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        java.util.Map<String, Integer> mapData1 = new java.util.HashMap<>();
+        mapData1.put("score", 90);
+        mapData1.put("rank", 5);
+        avroRecordV1.put("metadata", mapData1);
+
+        // v2: metadata: map<string, long>
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        Schema mapV2 = Schema.createMap(Schema.create(Schema.Type.LONG));
+        Schema optionalMapV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), mapV2));
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("metadata", optionalMapV2, null, null)));
+
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        java.util.Map<String, Long> mapData2 = new java.util.HashMap<>();
+        mapData2.put("score", 100L);
+        mapData2.put("rank", 1L);
+        avroRecordV2.put("metadata", mapData2);
+
+        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
+            .thenReturn(avroRecordV1)
+            .thenReturn(avroRecordV2);
+
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+
+        Table table = catalog.loadTable(tableId);
+        // Verify that the map value type cannot be promoted from int to long
+        assertNotNull(table.schema().findField("_kafka_value.metadata"));
+        assertEquals(true, table.schema().findField("_kafka_value.metadata").type().isMapType());
+        assertEquals(Types.IntegerType.get(),
+            table.schema().findField("_kafka_value.metadata").type().asMapType().valueType());
+    }
+
+    // ========== Complex Mixed Scenarios ==========
+
+    @Test
+    void testComplexNestedAndCollectionEvolution() throws IOException {
+        // v1: {id, user{name}}
+        Schema userV1 = Schema.createRecord("User", null, null, false);
+        userV1.setFields(Collections.singletonList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV1.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV1, null, null)));
+
+        GenericRecord userRecordV1 = new GenericData.Record(userV1);
+        userRecordV1.put("name", "alice");
+        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
+        avroRecordV1.put("id", 1L);
+        avroRecordV1.put("user", userRecordV1);
+
+        // v2: {id, user{name, addresses: list<{street}>}}
+        Schema addressV2 = Schema.createRecord("Address", null, null, false);
+        addressV2.setFields(Collections.singletonList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null)));
+
+        Schema userV2 = Schema.createRecord("User", null, null, false);
+        Schema listV2 = Schema.createArray(addressV2);
+        Schema optionalListV2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV2));
+        userV2.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("addresses", optionalListV2, null, null)));
+
+        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
+        avroSchemaV2.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV2, null, null)));
+
+        GenericRecord addressRecordV2 = new GenericData.Record(addressV2);
+        addressRecordV2.put("street", "Main St");
+        GenericRecord userRecordV2 = new GenericData.Record(userV2);
+        userRecordV2.put("name", "bob");
+        userRecordV2.put("addresses", Collections.singletonList(addressRecordV2));
+        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
+        avroRecordV2.put("id", 2L);
+        avroRecordV2.put("user", userRecordV2);
+
+        // v3: {id, user{name, addresses: list<{street, zipCode}>}}
+        Schema addressV3 = Schema.createRecord("Address", null, null, false);
+        Schema optionalZip = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
+        addressV3.setFields(Arrays.asList(
+            new Schema.Field("street", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("zipCode", optionalZip, null, null)));
+
+        Schema userV3 = Schema.createRecord("User", null, null, false);
+        Schema listV3 = Schema.createArray(addressV3);
+        Schema optionalListV3 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), listV3));
+        userV3.setFields(Arrays.asList(
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("addresses", optionalListV3, null, null)));
+
         Schema avroSchemaV3 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV3 = new ArrayList<>();
-        fieldsV3.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV3.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        Schema optionalField2 = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)));
-        fieldsV3.add(new Schema.Field("field2", optionalField2, null, null));
-        avroSchemaV3.setFields(fieldsV3);
+        avroSchemaV3.setFields(Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user", userV3, null, null)));
 
+        GenericRecord addressRecordV3 = new GenericData.Record(addressV3);
+        addressRecordV3.put("street", "Second St");
+        addressRecordV3.put("zipCode", "12345");
+        GenericRecord userRecordV3 = new GenericData.Record(userV3);
+        userRecordV3.put("name", "charlie");
+        userRecordV3.put("addresses", Collections.singletonList(addressRecordV3));
         GenericRecord avroRecordV3 = new GenericData.Record(avroSchemaV3);
         avroRecordV3.put("id", 3L);
-        avroRecordV3.put("name", "with-field2");
-        avroRecordV3.put("field2", "value2");
+        avroRecordV3.put("user", userRecordV3);
 
         when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
             .thenReturn(avroRecordV1)
             .thenReturn(avroRecordV2)
             .thenReturn(avroRecordV3);
 
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
-
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        Record kafkaRecordV3 = createMockKafkaRecord(3, 2);
-        writer.write(0, kafkaRecordV3);
+        writer.write(0, createMockKafkaRecord(1, 0));
+        writer.write(0, createMockKafkaRecord(2, 1));
+        writer.write(0, createMockKafkaRecord(3, 2));
 
         Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertNotNull(table.schema().findField("_kafka_value.field1"));
-        assertEquals(false, table.schema().findField("_kafka_value.field1").isRequired());
-        assertNotNull(table.schema().findField("_kafka_value.field2"));
-        assertEquals(false, table.schema().findField("_kafka_value.field2").isRequired());
+        assertNotNull(table.schema().findField("_kafka_value.user.addresses"));
+        assertNotNull(table.schema().findField("_kafka_value.user.addresses.element.street"));
+        assertNotNull(table.schema().findField("_kafka_value.user.addresses.element.zipCode"));
     }
 
-    @Test
-    void testSchemaEvolutionReorderColumn() throws IOException {
-        // Given: Initial Avro schema (v1)
-        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        fieldsV1.add(new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV1.setFields(fieldsV1);
+    // ========== Helper Methods ==========
 
-        // Create v1 record
-        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
-        avroRecordV1.put("id", 1L);
-        avroRecordV1.put("name", "test");
-        avroRecordV1.put("email", "test@example.com");
-
-        // Given: Updated Avro schema (v2) with reordered fields
-        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null));
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("email", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV2.setFields(fieldsV2);
-
-        // Create v2 record
-        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
-        avroRecordV2.put("name", "test2");
-        avroRecordV2.put("id", 2L);
-        avroRecordV2.put("email", "test2@example.com");
-
-        // Mock deserializer behavior
-        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
-            .thenReturn(avroRecordV1)
-            .thenReturn(avroRecordV2);
-
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        writer.write(0, kafkaRecordV1);
-
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        writer.write(0, kafkaRecordV2);
-
-        // Verify schema evolution
-        Table table = catalog.loadTable(tableId);
-        assertNotNull(table);
-        assertEquals(4, table.schema().columns().size());
-        assertNotNull(table.schema().findField("_kafka_value.id"));
-        assertNotNull(table.schema().findField("_kafka_value.name"));
-        assertNotNull(table.schema().findField("_kafka_value.email"));
-    }
-
-    @Test
-    void testSchemaEvolutionIncompatibleTypeChange() throws IOException {
-        // Given: Initial Avro schema with string type
-        Schema avroSchemaV1 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV1 = new ArrayList<>();
-        fieldsV1.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV1.add(new Schema.Field("age", Schema.create(Schema.Type.INT), null, null));
-        avroSchemaV1.setFields(fieldsV1);
-
-        // Create v1 record
-        GenericRecord avroRecordV1 = new GenericData.Record(avroSchemaV1);
-        avroRecordV1.put("id", 2L);
-        avroRecordV1.put("age", 30);
-
-        // Given: Updated schema with incompatible string type for age
-        Schema avroSchemaV2 = Schema.createRecord("TestRecord", null, null, false);
-        List<Schema.Field> fieldsV2 = new ArrayList<>();
-        fieldsV2.add(new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null));
-        fieldsV2.add(new Schema.Field("age", Schema.create(Schema.Type.STRING), null, null));
-        avroSchemaV2.setFields(fieldsV2);
-
-        // Create v2 record
-        GenericRecord avroRecordV2 = new GenericData.Record(avroSchemaV2);
-        avroRecordV2.put("id", 1L);
-        avroRecordV2.put("age", "twenty");
-
-        // Mock deserializer behavior
-        when(kafkaAvroDeserializer.deserialize(anyString(), any(), any(ByteBuffer.class)))
-            .thenReturn(avroRecordV1)
-            .thenReturn(avroRecordV2);
-
-        // Write records
-        Record kafkaRecordV1 = createMockKafkaRecord(1, 0);
-        assertDoesNotThrow(() -> writer.write(0, kafkaRecordV1));
-
-        // Verify that writing the second record with an incompatible schema throws an exception
-        Record kafkaRecordV2 = createMockKafkaRecord(2, 1);
-        assertThrows(IOException.class, () -> writer.write(0, kafkaRecordV2));
+    private String generateRandomTableName() {
+        return "test_table_" + ThreadLocalRandom.current().nextInt(100000, 999999);
     }
 
     private Record createMockKafkaRecord(int schemaId, int offset) {


### PR DESCRIPTION
* Enhanced handling of nested fields: Added logic to recursively process removed and changed fields within structs, struct lists, and struct maps, ensuring schema changes are detected for all nested structures. [[1]](diffhunk://#diff-53fae29a74f3af862064f6abca476e0f1684a3951e653f2abae8f051b37643eeL224-R235) [[2]](diffhunk://#diff-53fae29a74f3af862064f6abca476e0f1684a3951e653f2abae8f051b37643eeL244-R296)

* Corrected construction of `MAKE_OPTIONAL` schema changes: Now passes `null` for the type when marking a field as optional during soft removal, ensuring correct change representation.

* Refactored field change detection: Streamlined logic for adding columns, making fields optional, and promoting types.