### PR TITLE
fix(RecordAssembler): optimize field creation using Accessor

### DIFF
--- a/core/src/main/java/kafka/automq/table/process/RecordAssembler.java
+++ b/core/src/main/java/kafka/automq/table/process/RecordAssembler.java
@@ -27,6 +27,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.internal.Accessor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -145,7 +146,9 @@ public final class RecordAssembler {
         List<Schema.Field> finalFields = new ArrayList<>(baseRecord.getSchema().getFields().size() + 3);
         Schema baseSchema = baseRecord.getSchema();
         for (Schema.Field field : baseSchema.getFields()) {
-            finalFields.add(new Schema.Field(field, field.schema()));
+            // Accessor keeps the original Schema instance (preserving logical types) while skipping default-value revalidation.
+            Schema.Field f = Accessor.createField(field.name(), field.schema(), field.doc(), Accessor.defaultValue(field), false, field.order());
+            finalFields.add(f);
         }
 
         int baseFieldCount = baseSchema.getFields().size();


### PR DESCRIPTION
Confluent Schema Registry currently suppresses Avro’s default-value validation (see (https://github.com/confluentinc/schema-registry/issues/1687)), which means even schemas such as `{"name":"f_v2","type":"string","default":null}` slip through unchecked (https://github.com/confluentinc/schema-registry/issues/2213). If we rebuilt those fields via new Schema.Field(...), Avro would revalidate and reject them, diverging from what the registry already accepted. (https://github.com/AutoMQ/automq-labs/pull/100#issuecomment-3552925429 & https://github.com/AutoMQ/automq/issues/3006)

By constructing fields with Accessor.createField(...), we reuse the existing schema object (so logical types stay intact) while bypassing the costly validation step; this keeps the hot path efficient and, more importantly, aligns our behavior with the registry’s current tolerance. If we ever need the original field’s custom props or aliases, we can still copy them after the accessor call.