### PR TITLE
fix(core): improve resource teardown in S3Client shutdown sequence

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
+++ b/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
@@ -193,6 +193,7 @@ public class DefaultS3Client implements Client {
         this.networkInboundLimiter.shutdown();
         this.networkOutboundLimiter.shutdown();
         this.requestSender.shutdown();
+        S3StreamThreadPoolMonitor.shutdown();
         LOGGER.info("S3Client shutdown successfully");
     }
 


### PR DESCRIPTION
Hi community, we encountered the following problem during verification:
The `DefaultS3Client#shutdown()` method previously missed shutting down the `S3StreamThreadPoolMonitor`, which resulted in residual logging after the client shutdown was declared complete. 