### PR TITLE
fix(core): fix e2e

### DIFF
--- a/tests/kafkatest/tests/core/automq_remote_write_test.py
+++ b/tests/kafkatest/tests/core/automq_remote_write_test.py
@@ -203,8 +203,8 @@ PY"""
         script_path = f"/tmp/automq_remote_write_server_{int(time.time())}.py"
 
         server_overrides = [
-            ["automq.telemetry.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=1000000"],
-            ["automq.telemetry.exporter.interval.ms", "15000"],
+            ["s3.telemetry.metrics.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=1000000"],
+            ["s3.telemetry.exporter.report.interval.ms", "15000"],
             ["service.name", cluster_id],
             ["service.instance.id", "broker-remote-write"],
         ]
@@ -251,8 +251,8 @@ PY"""
         script_path = f"/tmp/automq_remote_write_gzip_server_{int(time.time())}.py"
 
         server_overrides = [
-            ["automq.telemetry.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=500000&compression=gzip"],
-            ["automq.telemetry.exporter.interval.ms", "10000"],
+            ["s3.telemetry.metrics.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=500000&compression=gzip"],
+            ["s3.telemetry.exporter.report.interval.ms", "10000"],
             ["service.name", cluster_id],
             ["service.instance.id", "broker-remote-write-gzip"],
         ]
@@ -305,8 +305,8 @@ PY"""
 
         # Test with smaller batch size to ensure multiple requests
         server_overrides = [
-            ["automq.telemetry.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=10000"],
-            ["automq.telemetry.exporter.interval.ms", "5000"],
+            ["s3.telemetry.metrics.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=10000"],
+            ["s3.telemetry.exporter.report.interval.ms", "5000"],
             ["service.name", cluster_id],
             ["service.instance.id", "broker-remote-write-batch"],
         ]
@@ -356,8 +356,8 @@ PY"""
         remote_write_port = 19093
 
         server_overrides = [
-            ["automq.telemetry.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=1000000"],
-            ["automq.telemetry.exporter.interval.ms", "10000"],
+            ["s3.telemetry.metrics.exporter.uri", f"rw://?endpoint=http://localhost:{remote_write_port}/api/v1/write&auth=no_auth&maxBatchSize=1000000"],
+            ["s3.telemetry.exporter.report.interval.ms", "10000"],
             ["service.name", cluster_id],
             ["service.instance.id", "broker-remote-write-unavail"],
         ]


### PR DESCRIPTION
This pull request updates the configuration keys used for remote write telemetry metrics in several test cases to align with the new naming convention. The keys have been changed from the old `automq.telemetry.exporter.*` format to the new `s3.telemetry.metrics.exporter.*` and `s3.telemetry.exporter.report.interval.ms` format.

Configuration key updates in telemetry tests:

* Updated the exporter URI and interval configuration keys in the `test_remote_write_metrics_exporter`, `test_remote_write_with_compression`, `test_remote_write_batch_size_limits`, and `test_remote_write_server_unavailable` test functions to use `s3.telemetry.metrics.exporter.uri` and `s3.telemetry.exporter.report.interval.ms` instead of the previous `automq.telemetry.exporter.uri` and `automq.telemetry.exporter.interval.ms` keys. [[1]](diffhunk://#diff-e4105f671e83496662280d87f10ce7efc389606d8a8092a8583776447ae4f945L206-R207) [[2]](diffhunk://#diff-e4105f671e83496662280d87f10ce7efc389606d8a8092a8583776447ae4f945L254-R255) [[3]](diffhunk://#diff-e4105f671e83496662280d87f10ce7efc389606d8a8092a8583776447ae4f945L308-R309) [[4]](diffhunk://#diff-e4105f671e83496662280d87f10ce7efc389606d8a8092a8583776447ae4f945L359-R360)