### PR TITLE
feat(s3stream): S3 API timeout can be configured via the path parameter

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/BucketURI.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/BucketURI.java
@@ -40,6 +40,8 @@ public class BucketURI {
     private static final String REGION_KEY = "region";
     public static final String ACCESS_KEY_KEY = "accessKey";
     public static final String SECRET_KEY_KEY = "secretKey";
+    public static final String API_CALL_TIMEOUT_KEY = "apiCallTimeoutMs";
+    public static final String API_CALL_ATTEMPT_TIMEOUT_KEY = "apiCallAttemptTimeoutMs";
     private static final String EMPTY_STRING = "";
     private final short bucketId;
     private final String protocol;


### PR DESCRIPTION
S3 API timeout can be configured via the path parameter.
The `apiCallTimeoutMs` and `apiCallAttemptTimeoutMs` parameters can be specified in the path. If not specified, the default values ​​are `apiCallTimeoutMs=30s` and `apiCallAttemptTimeoutMs=10s`.