### PR TITLE
docs: update Slack community link in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,3 +37,4 @@ This Code of Conduct is to be understood to apply in addition to any institution
 ## Attribution
 This Code of Conduct is adapted from that of [Airbyte](https://github.com/airbytehq/airbyte), which is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
+


### PR DESCRIPTION
This pull request updates the Slack community link in the README.  
The previous link was no longer functional, so it has been replaced with the new working link:

**https://go.automq.com/slack**