### PR TITLE
fix(s3wal): improve next() logic to handle pre-fetched records

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecoverIterator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecoverIterator.java
@@ -194,13 +194,12 @@ public class RecoverIterator implements Iterator<RecoverResult> {
 
     @Override
     public RecoverResult next() {
-        if (nextRecord != null) {
+        if (nextRecord != null || hasNext()) {
+            // - If the nextRecord is already read ahead.
+            // - Or #hasNext() is true, it means the nextRecord is already ready.
             RecoverResult rst = nextRecord;
             nextRecord = null;
             return rst;
-        }
-        if (hasNext()) {
-            return nextRecord;
         } else {
             return null;
         }


### PR DESCRIPTION
- [Bug] the nextRecord is not cleaned up when directly calling #next without calling #hasNext
- The bug won't happen in production because each #next is called after #hasNext