### PR TITLE
fix(proto): enhance map field type resolution

### DIFF
--- a/core/src/main/java/kafka/automq/table/binder/AbstractTypeAdapter.java
+++ b/core/src/main/java/kafka/automq/table/binder/AbstractTypeAdapter.java
@@ -200,14 +200,25 @@ public abstract class AbstractTypeAdapter<S> implements TypeAdapter<S> {
         if (sourceValue instanceof Temporal) return sourceValue;
         if (sourceValue instanceof Date) {
             Instant instant = ((Date) sourceValue).toInstant();
-            return DateTimeUtil.timestamptzFromMicros(DateTimeUtil.microsFromInstant(instant));
+            long micros = DateTimeUtil.microsFromInstant(instant);
+            return targetType.shouldAdjustToUTC()
+                    ? DateTimeUtil.timestamptzFromMicros(micros)
+                    : DateTimeUtil.timestampFromMicros(micros);
         }
         if (sourceValue instanceof String) {
             Instant instant = Instant.parse(sourceValue.toString());
-            return DateTimeUtil.timestamptzFromMicros(DateTimeUtil.microsFromInstant(instant));
+            long micros = DateTimeUtil.microsFromInstant(instant);
+            return targetType.shouldAdjustToUTC()
+                    ? DateTimeUtil.timestamptzFromMicros(micros)
+                    : DateTimeUtil.timestampFromMicros(micros);
         }
         if (sourceValue instanceof Number) {
-            return DateTimeUtil.timestamptzFromMicros(((Number) sourceValue).longValue());
+            // Assume the number represents microseconds since epoch
+            // Subclasses should override to handle milliseconds or other units based on logical type
+            long micros = ((Number) sourceValue).longValue();
+            return targetType.shouldAdjustToUTC()
+                    ? DateTimeUtil.timestamptzFromMicros(micros)
+                    : DateTimeUtil.timestampFromMicros(micros);
         }
         throw new IllegalArgumentException("Cannot convert " + sourceValue.getClass().getSimpleName() + " to " + targetType.typeId());
     }

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/ProtoElementSchemaConvert.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/ProtoElementSchemaConvert.java
@@ -127,8 +127,8 @@ public class ProtoElementSchemaConvert implements ProtoElementConvert {
         MessageDefinition.Builder mapMessage = MessageDefinition.newBuilder(mapEntryName);
         mapMessage.setMapEntry(true);
 
-        mapMessage.addField(null, keyType.getSimpleName(), ProtoConstants.KEY_FIELD, 1, null, null, null);
-        mapMessage.addField(null, valueType.getSimpleName(), ProtoConstants.VALUE_FIELD, 2, null, null, null);
+        mapMessage.addField(null, resolveFieldTypeName(keyType), ProtoConstants.KEY_FIELD, 1, null, null, null);
+        mapMessage.addField(null, resolveFieldTypeName(valueType), ProtoConstants.VALUE_FIELD, 2, null, null, null);
 
         message.addMessageDefinition(mapMessage.build());
         message.addField("repeated", mapEntryName, field.getName(), field.getTag(),
@@ -179,5 +179,9 @@ public class ProtoElementSchemaConvert implements ProtoElementConvert {
         return Character.toUpperCase(fieldName.charAt(0)) +
             fieldName.substring(1) +
             ProtoConstants.MAP_ENTRY_SUFFIX;
+    }
+
+    private static String resolveFieldTypeName(ProtoType type) {
+        return type.toString();
     }
 }


### PR DESCRIPTION
* Changed map field processing in `ProtoElementSchemaConvert.java` to use a new `resolveFieldTypeName` helper, ensuring correct type names for map keys and values.
* Added the `resolveFieldTypeName` helper method to centralize type name resolution for map fields.
* Updated `convertTimestamp` in `AbstractTypeAdapter.java` to conditionally convert timestamps to UTC or local time based on the target type, and clarified handling of numeric values as microseconds.