### PR TITLE
feat(clients): NetworkReceive memory optimization

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -25,49 +25,38 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * A size delimited Receive that consists of a 4 byte network-ordered size N followed by N bytes of content
+ * A size delimited Receive that consists of a 4 byte network-ordered size N
+ * followed by N bytes of content.
  */
 public class NetworkReceive implements Receive {
 
     public static final String UNKNOWN_SOURCE = "";
     public static final int UNLIMITED = -1;
+
     private static final Logger log = LoggerFactory.getLogger(NetworkReceive.class);
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
-    // Thread-safe pool for reusing 4-byte size buffers
-    private static final Queue<ByteBuffer> SIZE_BUFFER_POOL = new ConcurrentLinkedQueue<>();
-    private static final int SIZE_BUFFER_POOL_CAPACITY = 512;
-
-    // Tiered memory pool buckets for common payload sizes
-    private static final int[] BUCKET_SIZES = {1024, 4096, 16384, 65536, 262144, 1048576};
-    private static final Queue<?>[] BUCKET_POOLS = new Queue[BUCKET_SIZES.length];
-
-    static {
-        // Initialize bucket pools
-        for (int i = 0; i < BUCKET_SIZES.length; i++) {
-            BUCKET_POOLS[i] = new ConcurrentLinkedQueue<>();
-        }
-    }
-
     private final String source;
-    private ByteBuffer size;
     private final int maxSize;
     private final MemoryPool memoryPool;
+
+    private final ByteBuffer size;
     private int requestedBufferSize = -1;
     private ByteBuffer buffer;
-    private int bufferBucketIndex = -1;
 
-    public NetworkReceive(String source, ByteBuffer buffer) {
-        this(UNLIMITED, source);
-        this.buffer = buffer;
+    public NetworkReceive() {
+        this(UNKNOWN_SOURCE);
     }
 
     public NetworkReceive(String source) {
-        this(UNLIMITED, source);
+        this(UNLIMITED, source, MemoryPool.NONE);
+    }
+
+    public NetworkReceive(String source, ByteBuffer buffer) {
+        this(UNLIMITED, source, MemoryPool.NONE);
+        this.buffer = buffer;
     }
 
     public NetworkReceive(int maxSize, String source) {
@@ -76,98 +65,9 @@ public class NetworkReceive implements Receive {
 
     public NetworkReceive(int maxSize, String source, MemoryPool memoryPool) {
         this.source = source;
-        this.size = acquireSizeBuffer();
-        this.buffer = null;
         this.maxSize = maxSize;
         this.memoryPool = memoryPool;
-    }
-
-    public NetworkReceive() {
-        this(UNKNOWN_SOURCE);
-    }
-
-    /**
-     * Acquires a 4-byte buffer from the pool or creates a new one
-     */
-    private static ByteBuffer acquireSizeBuffer() {
-        ByteBuffer pooled = SIZE_BUFFER_POOL.poll();
-        if (pooled != null) {
-            pooled.clear();
-            return pooled;
-        }
-        return ByteBuffer.allocate(4);
-    }
-
-    /**
-     * Returns a 4-byte buffer to the pool
-     */
-    private static void releaseSizeBuffer(ByteBuffer buffer) {
-        if (SIZE_BUFFER_POOL.size() < SIZE_BUFFER_POOL_CAPACITY) {
-            buffer.clear();
-            SIZE_BUFFER_POOL.offer(buffer);
-        }
-    }
-
-    /**
-     * Finds the appropriate bucket index for a given size
-     */
-    private static int findBucketIndex(int size) {
-        for (int i = 0; i < BUCKET_SIZES.length; i++) {
-            if (size <= BUCKET_SIZES[i]) {
-                return i;
-            }
-        }
-
-        // Size exceeds all buckets, use memoryPool directly
-        return -1; 
-    }
-
-    /**
-     * Acquires a buffer from the tiered pool or memoryPool
-     */
-    @SuppressWarnings("unchecked")
-    private ByteBuffer acquirePayloadBuffer(int size) {
-        int bucketIndex = findBucketIndex(size);
-
-        if (bucketIndex >= 0) {
-            Queue<ByteBuffer> bucketPool = (Queue<ByteBuffer>) BUCKET_POOLS[bucketIndex];
-            ByteBuffer pooled = bucketPool.poll();
-            if (pooled != null) {
-                pooled.clear();
-                this.bufferBucketIndex = bucketIndex;
-                return pooled;
-            }
-        }
-
-        // Fall back to memoryPool for large sizes or if bucket pool is empty
-        ByteBuffer allocated = memoryPool.tryAllocate(size);
-        if (allocated != null) {
-            this.bufferBucketIndex = bucketIndex;
-        }
-        return allocated;
-    }
-
-    /**
-     * Releases a buffer back to the tiered pool
-     */
-    @SuppressWarnings("unchecked")
-    private void releasePayloadBuffer(ByteBuffer buffer) {
-        if (buffer == null || buffer == EMPTY_BUFFER) {
-            return;
-        }
-
-        if (bufferBucketIndex >= 0 && bufferBucketIndex < BUCKET_POOLS.length) {
-            Queue<ByteBuffer> bucketPool = (Queue<ByteBuffer>) BUCKET_POOLS[bufferBucketIndex];
-            int maxPoolSize = 128; // Limit pool size to prevent memory buildup
-            if (bucketPool.size() < maxPoolSize) {
-                buffer.clear();
-                bucketPool.offer(buffer);
-                return;
-            }
-        }
-
-        // Fall back to memoryPool release
-        memoryPool.release(buffer);
+        this.size = ByteBuffer.allocate(4);
     }
 
     @Override
@@ -180,35 +80,60 @@ public class NetworkReceive implements Receive {
         return !size.hasRemaining() && buffer != null && !buffer.hasRemaining();
     }
 
+    @Override
     public long readFrom(ScatteringByteChannel channel) throws IOException {
         int read = 0;
+
+        // Step 1: Read the 4-byte size prefix
         if (size.hasRemaining()) {
             int bytesRead = channel.read(size);
             if (bytesRead < 0)
                 throw new EOFException();
+
             read += bytesRead;
+
             if (!size.hasRemaining()) {
                 size.rewind();
                 int receiveSize = size.getInt();
+
                 if (receiveSize < 0)
-                    throw new InvalidReceiveException("Invalid receive (size = " + receiveSize + ")");
+                    throw new InvalidReceiveException(
+                        "Invalid receive (size = " + receiveSize + ")"
+                    );
+
                 if (maxSize != UNLIMITED && receiveSize > maxSize)
-                    throw new InvalidReceiveException("Invalid receive (size = " + receiveSize + " larger than " + maxSize + ")");
-                requestedBufferSize = receiveSize; // may be 0 for some payloads (SASL)
+                    throw new InvalidReceiveException(
+                        "Invalid receive (size = " + receiveSize +
+                        " larger than " + maxSize + ")"
+                    );
+
+                requestedBufferSize = receiveSize;
+
                 if (receiveSize == 0) {
                     buffer = EMPTY_BUFFER;
                 }
             }
         }
-        if (buffer == null && requestedBufferSize != -1) { // we know the size we want but haven't been able to allocate it yet
-            buffer = acquirePayloadBuffer(requestedBufferSize);
-            if (buffer == null)
-                log.trace("Broker low on memory - could not allocate buffer of size {} for source {}", requestedBufferSize, source);
+
+        // Step 2: Allocate payload buffer via MemoryPool
+        if (buffer == null && requestedBufferSize != -1) {
+            buffer = memoryPool.tryAllocate(requestedBufferSize);
+            if (buffer == null) {
+                log.trace(
+                    "Broker low on memory - could not allocate buffer of size {} for source {}",
+                    requestedBufferSize,
+                    source
+                );
+                return read;
+            }
         }
+
+        // Step 3: Read payload
         if (buffer != null) {
             int bytesRead = channel.read(buffer);
             if (bytesRead < 0)
                 throw new EOFException();
+
             read += bytesRead;
         }
 
@@ -227,33 +152,25 @@ public class NetworkReceive implements Receive {
 
     @Override
     public void close() throws IOException {
-        // Release payload buffer to tiered pool
         if (buffer != null) {
-            releasePayloadBuffer(buffer);
+            memoryPool.release(buffer);
             buffer = null;
-            bufferBucketIndex = -1;
-        }
-
-        // Release size buffer to pool
-        if (size != null) {
-            releaseSizeBuffer(size);
-            size = null;
         }
     }
 
     public ByteBuffer payload() {
-        return this.buffer;
+        return buffer;
     }
 
     public int bytesRead() {
         if (buffer == null)
             return size.position();
-        return buffer.position() + size.position();
+        return size.position() + buffer.position();
     }
 
     /**
      * Returns the total size of the receive including payload and size buffer
-     * for use in metrics. This is consistent with {@link NetworkSend#size()}
+     * for use in metrics. This is consistent with {@link NetworkSend#size()}.
      */
     public int size() {
         return payload().limit() + size.limit();

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -18,8 +18,8 @@ package org.apache.kafka.common.network;
 
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -29,7 +29,10 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
 import java.util.Queue;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetworkReceiveTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -19,18 +19,24 @@ package org.apache.kafka.common.network;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
+import java.util.Queue;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NetworkReceiveTest {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        clearSizeBufferPool();
+    }
 
     @Test
     public void testBytesRead() throws IOException {
@@ -68,6 +74,72 @@ public class NetworkReceiveTest {
         assertEquals(64, receive.readFrom(channel));
         assertEquals(132, receive.bytesRead());
         assertTrue(receive.complete());
+        
+        receive.close();
     }
 
+    /**
+     * Test that size buffers are reused from the pool after close
+     * @throws Exception 
+     */
+    @Test
+    public void testSizeBufferPoolReuse() throws Exception {
+        int initialPoolSize = getSizeBufferPoolSize();
+        assertEquals(0, initialPoolSize);
+
+        NetworkReceive receive1 = new NetworkReceive("test-1");
+        receive1.close();
+
+        int poolSizeAfterClose = getSizeBufferPoolSize();
+        assertEquals(1, poolSizeAfterClose, "Size buffer should be returned to pool");
+
+        NetworkReceive receive2 = new NetworkReceive("test-2");
+        int poolSizeAfterReuse = getSizeBufferPoolSize();
+        assertEquals(0, poolSizeAfterReuse, "Buffer should be reused from pool");
+        
+        receive2.close();
+    }
+
+    /**
+     * Test that close() properly releases resources
+     * @throws Exception 
+     */
+    @Test
+    public void testCloseReleasesBuffers() throws Exception {
+        ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            ByteBuffer buf = bufferCaptor.getValue();
+            if (buf.capacity() == 4) {
+                buf.putInt(1024);
+                return 4;
+            }
+            return 0;
+        });
+
+        NetworkReceive receive = new NetworkReceive(1024, "test-close");
+        receive.readFrom(channel);
+        assertNotNull(receive.payload());
+
+        receive.close();
+        assertEquals(1, getSizeBufferPoolSize(), "Size buffer should be released to pool");
+    }
+
+    // Helper method
+    private int getSizeBufferPoolSize() throws Exception {
+        Field field = NetworkReceive.class.getDeclaredField("SIZE_BUFFER_POOL");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Queue<ByteBuffer> pool = (Queue<ByteBuffer>) field.get(null);
+        return pool.size();
+    }
+
+    private void clearSizeBufferPool() throws Exception {
+        Field field = NetworkReceive.class.getDeclaredField("SIZE_BUFFER_POOL");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Queue<ByteBuffer> pool = (Queue<ByteBuffer>) field.get(null);
+        pool.clear();
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -16,133 +16,102 @@
  */
 package org.apache.kafka.common.network;
 
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
-import java.util.Queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetworkReceiveTest {
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        clearSizeBufferPool();
-    }
-
     @Test
     public void testBytesRead() throws IOException {
         NetworkReceive receive = new NetworkReceive(128, "0");
-        assertEquals(0, receive.bytesRead());
 
         ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
+        ArgumentCaptor<ByteBuffer> captor = ArgumentCaptor.forClass(ByteBuffer.class);
 
-        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
-        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().putInt(128);
-            return 4;
-        }).thenReturn(0);
+        Mockito.when(channel.read(captor.capture()))
+            .thenAnswer(invocation -> {
+                ByteBuffer buf = captor.getValue();
+                if (buf.remaining() == 4) {
+                    buf.putInt(128);
+                    return 4;
+                }
+                int toWrite = Math.min(buf.remaining(), 64);
+                buf.put(TestUtils.randomBytes(toWrite));
+                return toWrite;
+            });
 
-        assertEquals(4, receive.readFrom(channel));
-        assertEquals(4, receive.bytesRead());
-        assertFalse(receive.complete());
+        int totalRead = 0;
+        while (!receive.complete()) {
+            totalRead += receive.readFrom(channel);
+        }
 
-        Mockito.reset(channel);
-        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
-            return 64;
-        });
-
-        assertEquals(64, receive.readFrom(channel));
-        assertEquals(68, receive.bytesRead());
-        assertFalse(receive.complete());
-
-        Mockito.reset(channel);
-        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
-            return 64;
-        });
-
-        assertEquals(64, receive.readFrom(channel));
         assertEquals(132, receive.bytesRead());
+        assertEquals(132, totalRead);
         assertTrue(receive.complete());
-        
+
         receive.close();
     }
 
-    /**
-     * Test that size buffers are reused from the pool after close
-     * @throws Exception 
-     */
     @Test
-    public void testSizeBufferPoolReuse() throws Exception {
-        int initialPoolSize = getSizeBufferPoolSize();
-        assertEquals(0, initialPoolSize);
+    public void testZeroSizePayload() throws IOException {
+        NetworkReceive receive = new NetworkReceive("zero");
 
-        NetworkReceive receive1 = new NetworkReceive("test-1");
-        receive1.close();
-
-        int poolSizeAfterClose = getSizeBufferPoolSize();
-        assertEquals(1, poolSizeAfterClose, "Size buffer should be returned to pool");
-
-        NetworkReceive receive2 = new NetworkReceive("test-2");
-        int poolSizeAfterReuse = getSizeBufferPoolSize();
-        assertEquals(0, poolSizeAfterReuse, "Buffer should be reused from pool");
-        
-        receive2.close();
-    }
-
-    /**
-     * Test that close() properly releases resources
-     * @throws Exception 
-     */
-    @Test
-    public void testCloseReleasesBuffers() throws Exception {
         ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
-        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        ArgumentCaptor<ByteBuffer> captor = ArgumentCaptor.forClass(ByteBuffer.class);
 
-        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            ByteBuffer buf = bufferCaptor.getValue();
-            if (buf.capacity() == 4) {
-                buf.putInt(1024);
-                return 4;
-            }
-            return 0;
-        });
+        Mockito.when(channel.read(captor.capture()))
+            .thenAnswer(invocation -> {
+                ByteBuffer buf = captor.getValue();
+                if (buf.remaining() == 4) {
+                    buf.putInt(0);
+                    return 4;
+                }
+                return 0;
+            });
 
-        NetworkReceive receive = new NetworkReceive(1024, "test-close");
         receive.readFrom(channel);
-        assertNotNull(receive.payload());
+
+        assertTrue(receive.complete());
+        assertEquals(0, receive.payload().remaining());
 
         receive.close();
-        assertEquals(1, getSizeBufferPoolSize(), "Size buffer should be released to pool");
     }
 
-    // Helper method
-    private int getSizeBufferPoolSize() throws Exception {
-        Field field = NetworkReceive.class.getDeclaredField("SIZE_BUFFER_POOL");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Queue<ByteBuffer> pool = (Queue<ByteBuffer>) field.get(null);
-        return pool.size();
-    }
+    @Test
+    public void testWithMemoryPoolNone() throws IOException {
+        NetworkReceive receive =
+            new NetworkReceive(1024, "none", MemoryPool.NONE);
 
-    private void clearSizeBufferPool() throws Exception {
-        Field field = NetworkReceive.class.getDeclaredField("SIZE_BUFFER_POOL");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Queue<ByteBuffer> pool = (Queue<ByteBuffer>) field.get(null);
-        pool.clear();
+        ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
+        ArgumentCaptor<ByteBuffer> captor = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        Mockito.when(channel.read(captor.capture()))
+            .thenAnswer(invocation -> {
+                ByteBuffer buf = captor.getValue();
+                if (buf.remaining() == 4) {
+                    buf.putInt(256);
+                    return 4;
+                }
+                buf.put(TestUtils.randomBytes(buf.remaining()));
+                return buf.remaining();
+            });
+
+        while (!receive.complete()) {
+            receive.readFrom(channel);
+        }
+
+        assertTrue(receive.complete());
+        receive.close();
     }
 }


### PR DESCRIPTION
Fixes #2962 [ Enhancement/Optimization ]

Clean MemoryPool implementation at NetworkReceive:

- Lazy creation of buffer via MemoryPool
- readFrom() - Allocation Failure - return head (prevent attempt to a payload without memory)
- readFrom() - Readable execution flow
- close() - Buffer ownership optimization - removed buffer != EMPTY_BUFFER (before buffer was not allocated through the MemoryPool, now being allocated through MemoryPool, MemoryPool now becomes single owner for all payload buffers)