### PR TITLE
fix(s3stream): fix array bounds check in ByteBufAlloc

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
@@ -147,7 +147,7 @@ public class ByteBufAlloc {
             if (MEMORY_USAGE_DETECT) {
                 LongAdder counter;
 
-                if (type > MAX_TYPE_NUMBER) {
+                if (type >= MAX_TYPE_NUMBER || type < 0) {
                     counter = UNKNOWN_USAGE_STATS;
                 } else {
                     counter = USAGE_STATS[type];


### PR DESCRIPTION
Fix array index out of bounds bug (V6025) reported by PVS-Studio static analyzer.

**Problem:** In `ByteBufAlloc.java` line 150, the condition `type > MAX_TYPE_NUMBER` 
allows `type = 20` to pass validation, but `USAGE_STATS` array has size 20 
(valid indices 0-19), causing potential `ArrayIndexOutOfBoundsException`.

**Fix:** Changed condition from `type > MAX_TYPE_NUMBER` to 
`type >= MAX_TYPE_NUMBER || type < 0` to properly validate bounds.

Fixes #2777

**Testing:**
- Compiled with `./gradlew :s3stream:compileJava` 
- Ran `./gradlew :s3stream:test` - all related tests pass 
