### PR TITLE
docs: clarify prerequisites for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@
 - [Asia's GOAT, Poizon uses AutoMQ Kafka to build observability platform for massive data(30 GB/s)](https://www.automq.com/blog/asiax27s-goat-poizon-uses-automq-kafka-to-build-a-new-generation-observability-platform-for-massive-data?utm_source=github_automq)
 - [AutoMQ Helps CaoCao Mobility Address Kafka Scalability During Holidays](https://www.automq.com/blog/automq-helps-caocao-mobility-address-kafka-scalability-issues-during-mid-autumn-and-national-day?utm_source=github_automq)
 
-## 🚀 Get started with AutoMQ
 
 ### Prerequisites
 Before running AutoMQ locally, please ensure:


### PR DESCRIPTION
This PR adds a prerequisites section to the README to help
first-time users successfully run AutoMQ locally using
the Quick Start instructions.
