### PR TITLE
docs: clarify recommended onboarding path in contributing guide

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -9,6 +9,14 @@ or [Slack](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL
 Before getting started, please review AutoMQ's Code of Conduct. Everyone interacting in Slack or WeChat
 follow [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Suggested Onboarding Path for New Contributors
+
+If you are new to AutoMQ, it is recommended to first deploy and run AutoMQ using Docker as described in the README.
+This helps you quickly understand AutoMQ’s core concepts and behavior without local environment complexity.
+
+After gaining familiarity, contributors who want to work on code can follow the steps in this guide to build and run AutoMQ locally.
+
+
 ## Code Contributions
 
 ### Finding or Reporting Issues


### PR DESCRIPTION
Adds a short onboarding note to clarify the recommended setup path for new contributors.

### What
Adds a short onboarding note to CONTRIBUTING_GUIDE.md to clarify the recommended learning and setup path for new contributors.

### Why
From a beginner’s perspective, it was unclear when to use Docker versus a local build. This change reflects the recommended flow already described by maintainers and in the README.

### Related
- Related to #3116

### Testing
Documentation-only change. No code or behavior changes.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation
- [x] Verify documentation (including upgrade notes)
