### PR TITLE
fix: Reset partCount in StreamObjectCompactor to prevent inefficient grouping

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -7,7 +7,7 @@ reach out to us via [Wechat Group](https://www.automq.com/img/------------------
 or [Slack](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL9oXuRdACnOIA)!
 
 Before getting started, please review AutoMQ's Code of Conduct. Everyone interacting in Slack or WeChat
-follow [Code of Conduct](CODE_OF_CONDUCT.md).
+must follow [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Suggested Onboarding Path for New Contributors
 

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -516,6 +516,7 @@ public class StreamObjectCompactor {
                 objectGroups.add(group);
                 group = new LinkedList<>();
                 groupSize = 0;
+                partCount = 0;
             }
             group.add(object);
             groupSize += object.objectSize();


### PR DESCRIPTION
1. What does this PR do?
This PR fixes a logic bug in [StreamObjectCompactor.java](cci:7://file:///C:/Users/HP/.gemini/antigravity/scratch/automq_contribution/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java:0:0-0:0) where the `partCount` accumulator was not being reset when creating a new object group.

2. Why is it needed?
Currently, `partCount` keeps increasing indefinitely because it isn't cleared when [group](cci:1://file:///C:/Users/HP/.gemini/antigravity/scratch/automq_contribution/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java:486:4-529:5) and `groupSize` are reset. 

This causes the condition `partCount + objectPartCount > Writer.MAX_PART_COUNT` to fail prematurely for all subsequent groups after the first one. As a result, valid large groups are split unnecessarily into smaller chunks, leading to **inefficient compaction**.

3. How was it fixed?
- Added `partCount = 0;` inside the group initialization block in `StreamObjectCompactor#group0`.
- This ensures that every new group starts with a fresh part count, just like it starts with a fresh size.

4. Other Changes
- Fixed a small grammar error in [CONTRIBUTING_GUIDE.md](cci:7://file:///C:/Users/HP/.gemini/antigravity/scratch/automq_contribution/CONTRIBUTING_GUIDE.md:0:0-0:0) ("follow" -> "must follow").