### PR TITLE
perf(metadata): optimize SortedStreamSetObjectsList using binary search

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/stream/SortedStreamSetObjectsListTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/stream/SortedStreamSetObjectsListTest.java
@@ -21,11 +21,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(60)
 @Tag("S3Unit")
@@ -68,6 +71,163 @@ public class SortedStreamSetObjectsListTest {
             .stream()
             .map(S3StreamSetObject::objectId)
             .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testBinarySearchAdd() {
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList();
+        
+        // Test adding to empty list
+        objects.add(new S3StreamSetObject(100, -1, Collections.emptyList(), 50));
+        assertEquals(1, objects.size());
+        assertEquals(50L, objects.get(0).orderId());
+        
+        // Test adding at the beginning
+        objects.add(new S3StreamSetObject(101, -1, Collections.emptyList(), 10));
+        assertEquals(2, objects.size());
+        assertEquals(10L, objects.get(0).orderId());
+        assertEquals(50L, objects.get(1).orderId());
+        
+        // Test adding at the end
+        objects.add(new S3StreamSetObject(102, -1, Collections.emptyList(), 100));
+        assertEquals(3, objects.size());
+        assertEquals(100L, objects.get(2).orderId());
+        
+        // Test adding in the middle
+        objects.add(new S3StreamSetObject(103, -1, Collections.emptyList(), 30));
+        assertEquals(4, objects.size());
+        List<Long> expectedOrderIds = List.of(10L, 30L, 50L, 100L);
+        assertEquals(expectedOrderIds, objects.list()
+            .stream()
+            .map(S3StreamSetObject::orderId)
+            .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testBinarySearchAddDuplicateOrderId() {
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList();
+        
+        // Add objects with the same orderId but different objectIds
+        objects.add(new S3StreamSetObject(1, -1, Collections.emptyList(), 50));
+        objects.add(new S3StreamSetObject(2, -1, Collections.emptyList(), 50));
+        objects.add(new S3StreamSetObject(3, -1, Collections.emptyList(), 50));
+        
+        assertEquals(3, objects.size());
+        // All should have orderId 50
+        for (S3StreamSetObject obj : objects) {
+            assertEquals(50L, obj.orderId());
+        }
+    }
+
+    @Test
+    public void testBinarySearchRemove() {
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList();
+        objects.add(new S3StreamSetObject(1, -1, Collections.emptyList(), 10));
+        objects.add(new S3StreamSetObject(2, -1, Collections.emptyList(), 20));
+        objects.add(new S3StreamSetObject(3, -1, Collections.emptyList(), 30));
+        objects.add(new S3StreamSetObject(4, -1, Collections.emptyList(), 40));
+        objects.add(new S3StreamSetObject(5, -1, Collections.emptyList(), 50));
+        
+        assertEquals(5, objects.size());
+        
+        // Remove from middle
+        S3StreamSetObject toRemove = new S3StreamSetObject(3, -1, Collections.emptyList(), 30);
+        assertTrue(objects.remove(toRemove));
+        assertEquals(4, objects.size());
+        
+        // Verify the element was removed
+        List<Long> expectedObjectIds = List.of(1L, 2L, 4L, 5L);
+        assertEquals(expectedObjectIds, objects.list()
+            .stream()
+            .map(S3StreamSetObject::objectId)
+            .collect(Collectors.toList()));
+        
+        // Remove from beginning
+        toRemove = new S3StreamSetObject(1, -1, Collections.emptyList(), 10);
+        assertTrue(objects.remove(toRemove));
+        assertEquals(3, objects.size());
+        
+        // Remove from end
+        toRemove = new S3StreamSetObject(5, -1, Collections.emptyList(), 50);
+        assertTrue(objects.remove(toRemove));
+        assertEquals(2, objects.size());
+        
+        // Try to remove non-existent element
+        toRemove = new S3StreamSetObject(99, -1, Collections.emptyList(), 999);
+        assertFalse(objects.remove(toRemove));
+        assertEquals(2, objects.size());
+    }
+
+    @Test
+    public void testBinarySearchRemoveWithDuplicateOrderIds() {
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList();
+        
+        // Add objects with the same orderId but different objectIds
+        objects.add(new S3StreamSetObject(1, -1, Collections.emptyList(), 50));
+        objects.add(new S3StreamSetObject(2, -1, Collections.emptyList(), 50));
+        objects.add(new S3StreamSetObject(3, -1, Collections.emptyList(), 50));
+        
+        assertEquals(3, objects.size());
+        
+        // Remove the one with objectId=2
+        S3StreamSetObject toRemove = new S3StreamSetObject(2, -1, Collections.emptyList(), 50);
+        assertTrue(objects.remove(toRemove));
+        assertEquals(2, objects.size());
+        
+        // Verify remaining elements have objectIds 1 and 3
+        List<Long> remainingObjectIds = objects.list()
+            .stream()
+            .map(S3StreamSetObject::objectId)
+            .sorted()
+            .collect(Collectors.toList());
+        assertEquals(List.of(1L, 3L), remainingObjectIds);
+    }
+
+    @Test
+    public void testConstructorWithLinkedList() {
+        // Verify that constructor properly converts non-ArrayList to ArrayList
+        List<S3StreamSetObject> linkedList = new java.util.LinkedList<>();
+        linkedList.add(new S3StreamSetObject(1, -1, Collections.emptyList(), 10));
+        linkedList.add(new S3StreamSetObject(2, -1, Collections.emptyList(), 20));
+        
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList(linkedList);
+        assertEquals(2, objects.size());
+        
+        // Should still work with binary search operations
+        objects.add(new S3StreamSetObject(3, -1, Collections.emptyList(), 15));
+        assertEquals(3, objects.size());
+        
+        List<Long> expectedOrderIds = List.of(10L, 15L, 20L);
+        assertEquals(expectedOrderIds, objects.list()
+            .stream()
+            .map(S3StreamSetObject::orderId)
+            .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testLargeListPerformance() {
+        SortedStreamSetObjects objects = new SortedStreamSetObjectsList();
+        
+        // Add 1000 elements in random order
+        List<Long> orderIds = new ArrayList<>();
+        for (long i = 0; i < 1000; i++) {
+            orderIds.add(i);
+        }
+        Collections.shuffle(orderIds);
+        
+        for (int i = 0; i < orderIds.size(); i++) {
+            objects.add(new S3StreamSetObject(i, -1, Collections.emptyList(), orderIds.get(i)));
+        }
+        
+        assertEquals(1000, objects.size());
+        
+        // Verify the list is sorted
+        long prevOrderId = -1;
+        for (S3StreamSetObject obj : objects) {
+            assertTrue(obj.orderId() > prevOrderId, 
+                "List should be sorted by orderId, but found " + obj.orderId() + " after " + prevOrderId);
+            prevOrderId = obj.orderId();
+        }
     }
 
 


### PR DESCRIPTION
Closes #3137

### Problem

`SortedStreamSetObjectsList` maintains a sorted list but currently:
- Uses `LinkedList`, which has O(n) random access
- Uses linear scans for insertion and removal
- Contains explicit TODOs requesting binary search optimization

### Solution

- Replace `LinkedList` with `ArrayList` for O(1) random access
- Use `Collections.binarySearch()` to find insertion/removal positions in O(log n)
- Handle duplicate `orderId` cases correctly
- Add tests covering edge cases

### Testing

Added unit tests for:
- Binary search insertion at beginning, middle, end
- Removal from various positions
- Duplicate `orderId` handling
- Large list correctness (1000 elements)

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)