### PR TITLE
feat(metrics): optimzie to support dynamic metrics config

### DIFF
--- a/automq-metrics/src/main/java/com/automq/opentelemetry/AutoMQTelemetryManager.java
+++ b/automq-metrics/src/main/java/com/automq/opentelemetry/AutoMQTelemetryManager.java
@@ -19,6 +19,10 @@
 
 package com.automq.opentelemetry;
 
+import org.apache.kafka.common.Reconfigurable;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+
 import com.automq.opentelemetry.exporter.DelegatingMetricReader;
 import com.automq.opentelemetry.exporter.MetricsExportConfig;
 import com.automq.opentelemetry.exporter.MetricsExporter;
@@ -42,10 +46,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.apache.kafka.common.Reconfigurable;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.types.Password;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;

--- a/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/DelegatingMetricReader.java
+++ b/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/DelegatingMetricReader.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.opentelemetry.exporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+
+public class DelegatingMetricReader implements MetricReader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatingMetricReader.class);
+    private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
+
+    private volatile List<MetricReader> delegates;
+    private volatile CollectionRegistration collectionRegistration;
+    private final Object lock = new Object();
+
+    public DelegatingMetricReader(List<MetricReader> initialDelegates) {
+        this.delegates = new ArrayList<>(initialDelegates);
+    }
+
+    public void setDelegates(List<MetricReader> newDelegates) {
+        synchronized (lock) {
+            List<MetricReader> oldDelegates = this.delegates;
+            if (collectionRegistration != null && newDelegates != null) {
+                for (MetricReader reader : newDelegates) {
+                    reader.register(collectionRegistration);
+                }
+            }
+            this.delegates = new ArrayList<>(newDelegates);
+            if (oldDelegates != null && !oldDelegates.isEmpty()) {
+                List<CompletableResultCode> shutdownResults = new ArrayList<>();
+                for (MetricReader oldDelegate : oldDelegates) {
+                    try {
+                        shutdownResults.add(oldDelegate.shutdown());
+                    } catch (Exception e) {
+                        LOGGER.warn("Error shutting down old delegate", e);
+                    }
+                }
+                CompletableResultCode.ofAll(shutdownResults)
+                        .join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    public List<MetricReader> getDelegates() {
+        return Collections.unmodifiableList(delegates);
+    }
+
+    @Override
+    public void register(CollectionRegistration registration) {
+        synchronized (lock) {
+            this.collectionRegistration = registration;
+            for (MetricReader delegate : delegates) {
+                delegate.register(registration);
+            }
+        }
+    }
+
+    @Override
+    public CompletableResultCode forceFlush() {
+        List<MetricReader> current = delegates;
+        if (current.isEmpty()) {
+            return CompletableResultCode.ofSuccess();
+        }
+        List<CompletableResultCode> codes = new ArrayList<>();
+        for (MetricReader reader : current) {
+            codes.add(reader.forceFlush());
+        }
+        return CompletableResultCode.ofAll(codes);
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        synchronized (lock) {
+            List<MetricReader> current = delegates;
+            if (current.isEmpty()) {
+                return CompletableResultCode.ofSuccess();
+            }
+            List<CompletableResultCode> codes = new ArrayList<>();
+            for (MetricReader reader : current) {
+                codes.add(reader.shutdown());
+            }
+            return CompletableResultCode.ofAll(codes);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        shutdown().join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+        List<MetricReader> current = delegates;
+        if (!current.isEmpty()) {
+            // should be consistent for all the MetricReader
+            return current.get(0).getAggregationTemporality(instrumentType);
+        }
+        return AggregationTemporality.CUMULATIVE;
+    }
+}

--- a/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/DelegatingMetricReader.java
+++ b/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/DelegatingMetricReader.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.MemoryMode;
-import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
@@ -51,7 +49,7 @@ public class DelegatingMetricReader implements MetricReader {
     public void setDelegates(List<MetricReader> newDelegates) {
         synchronized (lock) {
             List<MetricReader> oldDelegates = this.delegates;
-            if (collectionRegistration != null && newDelegates != null) {
+            if (collectionRegistration != null) {
                 for (MetricReader reader : newDelegates) {
                     reader.register(collectionRegistration);
                 }

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import kafka.autobalancer.config.{AutoBalancerControllerConfig, AutoBalancerMetricsReporterConfig}
 import kafka.automq.backpressure.BackPressureConfig
+import com.automq.opentelemetry.AutoMQTelemetryManager
 
 import java.util
 import java.util.{Collections, Properties}
@@ -103,7 +104,8 @@ object DynamicBrokerConfig {
     DynamicRemoteLogConfig.ReconfigurableConfigs ++
     AutoBalancerControllerConfig.RECONFIGURABLE_CONFIGS.asScala ++
     AutoBalancerMetricsReporterConfig.RECONFIGURABLE_CONFIGS.asScala ++
-    BackPressureConfig.RECONFIGURABLE_CONFIGS.asScala
+    BackPressureConfig.RECONFIGURABLE_CONFIGS.asScala ++
+    AutoMQTelemetryManager.RECONFIGURABLE_CONFIGS.asScala
 
   private val ClusterLevelListenerConfigs = Set(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG, SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG)
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
@@ -275,6 +277,9 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
     kafkaServer match {
       case brokerServer: BrokerServer =>
         addReconfigurable(brokerServer.backPressureManager)
+        if (brokerServer.sharedServer.telemetryManager != null) {
+          addReconfigurable(brokerServer.sharedServer.telemetryManager)
+        }
       case _ =>
     }
     // AutoMQ inject end


### PR DESCRIPTION
The e2e test results are shown as below
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2026-01-08--009
run time:         5 minutes 38.223 seconds
tests run:        4
passed:           4
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.core.automq_telemetry_test.AutoMQBrokerTelemetryTest.test_dynamic_prometheus_exporter_reconfiguration
status:     PASS
run time:   1 minute 3.004 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.automq_telemetry_test.AutoMQBrokerTelemetryTest.test_prometheus_metrics_exporter
status:     PASS
run time:   1 minute 6.223 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.automq_telemetry_test.AutoMQBrokerTelemetryTest.test_s3_log_uploader
status:     PASS
run time:   1 minute 11.146 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.automq_telemetry_test.AutoMQBrokerTelemetryTest.test_s3_metrics_exporter
status:     PASS
run time:   2 minutes 17.602 seconds
--------------------------------------------------------------------------------
```