### PR TITLE
fix(connect): do not print stack when s3 error

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.automq.az.AzMetadataProviderHolder;
 import org.apache.kafka.connect.automq.log.ConnectLogUploader;
+import org.apache.kafka.connect.automq.metrics.MetricsConfigConstants;
 import org.apache.kafka.connect.automq.metrics.OpenTelemetryMetricsReporter;
 import org.apache.kafka.connect.automq.s3.S3PermissionProbe;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
@@ -37,8 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -109,14 +112,7 @@ public abstract class AbstractConnectCli<H extends Herder, T extends WorkerConfi
             }
             AzMetadataProviderHolder.initialize(workerProps);
 
-            S3PermissionProbe.ProbeResult metricsProbe = S3PermissionProbe.probeMetrics(workerProps);
-            if (metricsProbe.shouldInitialize()) {
-                Properties telemetryProps = new Properties();
-                telemetryProps.putAll(workerProps);
-                OpenTelemetryMetricsReporter.initializeTelemetry(telemetryProps);
-            } else if (metricsProbe.isRequired()) {
-                getLogger().warn("Skip starting AutoMQ telemetry exporter: {}", metricsProbe.reason());
-            }
+            initializeTelemetry(workerProps);
             // AutoMQ inject end
 
             Connect<H> connect = startConnect(workerProps);
@@ -175,5 +171,84 @@ public abstract class AbstractConnectCli<H extends Herder, T extends WorkerConfi
         }
 
         return connect;
+    }
+
+    private void initializeTelemetry(Map<String, String> workerProps) {
+        List<String> exporterUris = parseTelemetryExporterUris(workerProps.get(MetricsConfigConstants.EXPORTER_URI_KEY));
+        if (exporterUris.isEmpty()) {
+            getLogger().info("AutoMQ telemetry exporter URI is not configured; skipping telemetry initialization.");
+            return;
+        }
+
+        S3PermissionProbe.ProbeResult metricsProbe = S3PermissionProbe.probeMetrics(workerProps);
+        if (!metricsProbe.isRequired()) {
+            startTelemetry(workerProps, exporterUris, false);
+            return;
+        }
+
+        if (metricsProbe.shouldInitialize()) {
+            startTelemetry(workerProps, exporterUris, false);
+            return;
+        }
+
+        List<String> filteredExporters = filterOutOpsExporters(exporterUris);
+        if (filteredExporters.isEmpty()) {
+            getLogger().warn("Skip starting AutoMQ telemetry exporter: {}. S3 exporter unavailable and no alternative exporters configured.", metricsProbe.reason());
+            return;
+        }
+
+        getLogger().warn("AutoMQ S3 telemetry exporter disabled ({}). Continuing with exporters: {}",
+            metricsProbe.reason(), joinExporterUris(filteredExporters));
+        startTelemetry(workerProps, filteredExporters, true);
+    }
+
+    private static List<String> parseTelemetryExporterUris(String exporterConfig) {
+        List<String> exporters = new ArrayList<>();
+        if (exporterConfig == null) {
+            return exporters;
+        }
+        String[] entries = exporterConfig.split(",");
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                exporters.add(trimmed);
+            }
+        }
+        return exporters;
+    }
+
+    private static List<String> filterOutOpsExporters(List<String> exporters) {
+        List<String> filtered = new ArrayList<>(exporters.size());
+        for (String exporter : exporters) {
+            if (!isOpsExporter(exporter)) {
+                filtered.add(exporter);
+            }
+        }
+        return filtered;
+    }
+
+    private static boolean isOpsExporter(String exporter) {
+        try {
+            URI uri = URI.create(exporter);
+            String scheme = uri.getScheme();
+            return scheme != null && scheme.equalsIgnoreCase("ops");
+        } catch (Exception e) {
+            getLogger().warn("Invalid AutoMQ telemetry exporter URI '{}', ignoring for S3 readiness gating", exporter, e);
+            return false;
+        }
+    }
+
+    private static String joinExporterUris(List<String> exporters) {
+        return String.join(",", exporters);
+    }
+
+    private void startTelemetry(Map<String, String> workerProps, List<String> exporters, boolean removeS3TelemetryConfig) {
+        Properties telemetryProps = new Properties();
+        telemetryProps.putAll(workerProps);
+        telemetryProps.put(MetricsConfigConstants.EXPORTER_URI_KEY, joinExporterUris(exporters));
+        if (removeS3TelemetryConfig) {
+            telemetryProps.remove(MetricsConfigConstants.S3_BUCKET);
+        }
+        OpenTelemetryMetricsReporter.initializeTelemetry(telemetryProps);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/automq/s3/S3PermissionProbeTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/automq/s3/S3PermissionProbeTest.java
@@ -93,6 +93,26 @@ public class S3PermissionProbeTest {
     }
 
     @Test
+    public void metricsProbeDetectsOpsExporterWhenNotFirst() {
+        Map<String, String> props = new HashMap<>();
+        props.put(MetricsConfigConstants.EXPORTER_URI_KEY, "prometheus://0.0.0.0:9090,ops://bucket");
+        props.put(MetricsConfigConstants.S3_BUCKET, "0@mem://metrics-bucket");
+        S3PermissionProbe.ProbeResult result = S3PermissionProbe.probeMetrics(props);
+        assertTrue(result.isRequired());
+        assertTrue(result.shouldInitialize());
+    }
+
+    @Test
+    public void metricsProbeFailsWhenOpsBucketMissingEvenIfOtherExportersConfigured() {
+        Map<String, String> props = new HashMap<>();
+        props.put(MetricsConfigConstants.EXPORTER_URI_KEY, "prometheus://localhost:9090, ops://bucket");
+        S3PermissionProbe.ProbeResult result = S3PermissionProbe.probeMetrics(props);
+        assertTrue(result.isRequired());
+        assertFalse(result.shouldInitialize());
+        assertNotNull(result.reason());
+    }
+
+    @Test
     public void readinessFailurePreventsInitialization() {
         Map<String, String> props = new HashMap<>();
         props.put(LogConfigConstants.LOG_S3_ENABLE_KEY, "true");


### PR DESCRIPTION
This pull request introduces a new mechanism to check S3 readiness before initializing key AutoMQ components that rely on object storage, such as the S3 log uploader and the AutoMQ telemetry exporter. The main changes include the addition of the `S3PermissionProbe` utility, its integration into the CLI startup flow, and corresponding unit tests to ensure correct behavior.

**S3 readiness and initialization improvements:**

* Added a new utility class `S3PermissionProbe` that centralizes logic for probing S3 bucket readiness for both log uploading and metrics exporting. It checks configuration, validates bucket access, and reports whether initialization should proceed.
* Updated `AbstractConnectCli` to use `S3PermissionProbe` before initializing the S3 log uploader and AutoMQ telemetry exporter, ensuring these components only start if S3 is ready and logging a warning if not. [[1]](diffhunk://#diff-c2ab32537dbba0db245c37cc698be40d7d84b2ac57f07287d5f26fffcd07793bR25) [[2]](diffhunk://#diff-c2ab32537dbba0db245c37cc698be40d7d84b2ac57f07287d5f26fffcd07793bL102-R119)

**Testing enhancements:**

* Added a comprehensive test class `S3PermissionProbeTest` to verify correct behavior for various configuration scenarios, including missing buckets, readiness failures, and non-S3 exporters.