### PR TITLE
perf(zerozone): isolate the ObjectRouterChannel's alloc

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/ByteBufSeqAlloc.java
+++ b/s3stream/src/main/java/com/automq/stream/ByteBufSeqAlloc.java
@@ -20,12 +20,13 @@
 package com.automq.stream;
 
 import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.ByteBufSupplier;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.netty.buffer.ByteBuf;
 
-public class ByteBufSeqAlloc {
+public class ByteBufSeqAlloc implements ByteBufSupplier {
     public static final int HUGE_BUF_SIZE = ByteBufAlloc.getChunkSize().orElse(4 << 20);
     // why not use ThreadLocal? the partition open has too much threads
     final AtomicReference<HugeBuf>[] hugeBufArray;
@@ -40,7 +41,8 @@ public class ByteBufSeqAlloc {
         }
     }
 
-    public ByteBuf byteBuffer(int capacity) {
+    @Override
+    public ByteBuf alloc(int capacity) {
         if (capacity > HUGE_BUF_SIZE) {
             // if the request capacity is larger than HUGE_BUF_SIZE, just allocate a new ByteBuf
             return ByteBufAlloc.byteBuffer(capacity, allocType);

--- a/s3stream/src/main/java/com/automq/stream/s3/ByteBufSupplier.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ByteBufSupplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3;
+
+import io.netty.buffer.ByteBuf;
+
+public interface ByteBufSupplier {
+
+    ByteBuf alloc(int capacity);
+
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/DefaultByteBufSupplier.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/DefaultByteBufSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3;
+
+import io.netty.buffer.ByteBuf;
+
+public class DefaultByteBufSupplier implements ByteBufSupplier {
+    private final int type;
+
+    public DefaultByteBufSupplier(int type) {
+        this.type = type;
+    }
+
+    @Override
+    public ByteBuf alloc(int capacity) {
+        return ByteBufAlloc.byteBuffer(capacity, type);
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
@@ -53,8 +53,8 @@ import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
 import static com.automq.stream.s3.ByteBufAlloc.SNAPSHOT_READ_CACHE;
 
 public class SnapshotReadCache {
-    public static final ByteBufSeqAlloc DECODE_LINK_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 8);
-    public static final ByteBufSeqAlloc ENCODE_ALLOC = new ByteBufSeqAlloc(SNAPSHOT_READ_CACHE, 8);
+    public static final ByteBufSeqAlloc DECODE_LINK_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 4);
+    public static final ByteBufSeqAlloc ENCODE_ALLOC = new ByteBufSeqAlloc(SNAPSHOT_READ_CACHE, 1);
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotReadCache.class);
     private static final long MAX_INFLIGHT_LOAD_BYTES = 100L * 1024 * 1024;
 

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/operator/DataBlockReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/operator/DataBlockReader.java
@@ -209,7 +209,7 @@ public class DataBlockReader {
         if (throttleBucket == null) {
             return objectStorage.rangeRead(new ReadOptions().throttleStrategy(ThrottleStrategy.COMPACTION).bucket(metadata.bucket()), objectKey, start, end).thenApply(buf -> {
                 // convert heap buffer to direct buffer
-                ByteBuf directBuf = DIRECT_ALLOC.byteBuffer(buf.readableBytes());
+                ByteBuf directBuf = DIRECT_ALLOC.alloc(buf.readableBytes());
                 directBuf.writeBytes(buf);
                 buf.release();
                 return directBuf;
@@ -219,7 +219,7 @@ public class DataBlockReader {
                 .thenCompose(v ->
                     objectStorage.rangeRead(new ReadOptions().throttleStrategy(ThrottleStrategy.COMPACTION).bucket(metadata.bucket()), objectKey, start, end).thenApply(buf -> {
                         // convert heap buffer to direct buffer
-                        ByteBuf directBuf = DIRECT_ALLOC.byteBuffer(buf.readableBytes());
+                        ByteBuf directBuf = DIRECT_ALLOC.alloc(buf.readableBytes());
                         directBuf.writeBytes(buf);
                         buf.release();
                         return directBuf;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -343,7 +343,7 @@ public class DefaultWriter implements Writer {
                 record.offset = nextOffset;
                 lastRecordOffset = record.offset;
                 ByteBuf data = record.streamRecordBatch.encoded();
-                ByteBuf header = BYTE_BUF_ALLOC.byteBuffer(RECORD_HEADER_SIZE);
+                ByteBuf header = BYTE_BUF_ALLOC.alloc(RECORD_HEADER_SIZE);
                 header = WALUtil.generateHeader(data, header, 0, nextOffset);
                 nextOffset += record.size;
                 dataBuffer.addComponent(true, header);

--- a/s3stream/src/test/java/com/automq/stream/ByteBufSeqAllocTest.java
+++ b/s3stream/src/test/java/com/automq/stream/ByteBufSeqAllocTest.java
@@ -35,20 +35,20 @@ public class ByteBufSeqAllocTest {
 
         AtomicReference<ByteBufSeqAlloc.HugeBuf> bufRef = alloc.hugeBufArray[Math.abs(Thread.currentThread().hashCode() % alloc.hugeBufArray.length)];
 
-        ByteBuf buf1 = alloc.byteBuffer(12);
+        ByteBuf buf1 = alloc.alloc(12);
         buf1.writeLong(1);
         buf1.writeInt(2);
 
-        ByteBuf buf2 = alloc.byteBuffer(20);
+        ByteBuf buf2 = alloc.alloc(20);
         buf2.writeLong(3);
         buf2.writeInt(4);
         buf2.writeLong(5);
 
-        ByteBuf buf3 = alloc.byteBuffer(ByteBufSeqAlloc.HUGE_BUF_SIZE - 12 - 20 - 4);
+        ByteBuf buf3 = alloc.alloc(ByteBufSeqAlloc.HUGE_BUF_SIZE - 12 - 20 - 4);
 
         ByteBuf oldHugeBuf = bufRef.get().buf;
 
-        ByteBuf buf4 = alloc.byteBuffer(16);
+        ByteBuf buf4 = alloc.alloc(16);
         buf4.writeLong(6);
         buf4.writeLong(7);
 
@@ -71,8 +71,8 @@ public class ByteBufSeqAllocTest {
 
         ByteBuf oldHugeBuf2 = bufRef.get().buf;
 
-        alloc.byteBuffer(ByteBufSeqAlloc.HUGE_BUF_SIZE - 12).release();
-        alloc.byteBuffer(12).release();
+        alloc.alloc(ByteBufSeqAlloc.HUGE_BUF_SIZE - 12).release();
+        alloc.alloc(12).release();
         assertEquals(0, oldHugeBuf2.refCnt());
     }
 


### PR DESCRIPTION
cherry-pick https://github.com/AutoMQ/automq/pull/3161
Main changes:
- Set ObjectRouterChannel's allocator to isolated allocator
- Set S3Storage LinkRecord encode allocator to DefaultByteBufSupplier