### PR TITLE
fix(e2e): change runner

### DIFF
--- a/.github/workflows/nightly-extra-e2e.yml
+++ b/.github/workflows/nightly-extra-e2e.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       suite-id: "benchmarks"
       test-path: "tests/kafkatest/benchmarks"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   connect_e2e_1:
     name: "Run connect E2E Tests 1"
     uses: ./.github/workflows/e2e-run.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       suite-id: "connect1"
       test-yaml: "tests/suites/connect_test_suite1.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   connect_e2e_2:
     name: "Run connect E2E Tests 2"
     uses: ./.github/workflows/e2e-run.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       suite-id: "connect2"
       test-yaml: "tests/suites/connect_test_suite2.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   connect_e2e_3:
     name: "Run connect E2E Tests 3"
     uses: ./.github/workflows/e2e-run.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       suite-id: "connect3"
       test-yaml: "tests/suites/connect_test_suite3.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   streams_e2e:
     name: "Run streams E2E Tests"
     uses: ./.github/workflows/e2e-run.yml
@@ -44,10 +44,10 @@ jobs:
     with:
       suite-id: "streams"
       test-path: "tests/kafkatest/tests/streams"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   e2e_summary:
     name: "E2E Tests Summary"
-    runs-on: "e2e"
+    runs-on: "ubicloud-standard-8-arm"
     if: ${{ always() && github.repository_owner == 'AutoMQ' }}
     needs: [ benchmarks_e2e, connect_e2e_1, connect_e2e_2, connect_e2e_3, streams_e2e ]
     steps:

--- a/.github/workflows/nightly-main-e2e.yml
+++ b/.github/workflows/nightly-main-e2e.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       suite-id: "main1"
       test-yaml: "tests/suites/main_kos_test_suite1.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   main_e2e_2:
     name: "Run Main E2E Tests 2"
     uses: ./.github/workflows/e2e-run.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       suite-id: "main2"
       test-yaml: "tests/suites/main_kos_test_suite2.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   main_e2e_3:
     name: "Run Main E2E Tests 3"
     uses: ./.github/workflows/e2e-run.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       suite-id: "main3"
       test-yaml: "tests/suites/main_kos_test_suite3.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   main_e2e_4:
     name: "Run Main E2E Tests 4"
     uses: ./.github/workflows/e2e-run.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       suite-id: "main4"
       test-yaml: "tests/suites/main_kos_test_suite4.yml"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   main_e2e_5:
     name: "Run Main E2E Tests 5"
     uses: ./.github/workflows/e2e-run.yml
@@ -44,9 +44,9 @@ jobs:
     with:
       suite-id: "main5"
       test-path: "tests/kafkatest/automq"
-      runner: "e2e"
+      runner: "ubicloud-standard-8-arm"
   e2e_summary:
-    runs-on: "e2e"
+    runs-on: "ubicloud-standard-8-arm"
     name: "E2E Tests Summary"
     if: ${{ always() && github.repository_owner == 'AutoMQ' }}
     needs: [ main_e2e_1, main_e2e_2, main_e2e_3, main_e2e_4, main_e2e_5 ]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for nightly end-to-end (E2E) test jobs. The main change is switching the runner environment from the generic `e2e` runner to the `ubicloud-standard-8-arm` runner for all relevant test jobs and their summaries. This ensures that all nightly E2E tests are executed on the specified ARM-based runner.

**Workflow runner environment updates:**

* Updated all E2E test jobs in `.github/workflows/nightly-extra-e2e.yml` to use the `ubicloud-standard-8-arm` runner instead of the previous `e2e` runner.
* Updated all E2E test jobs in `.github/workflows/nightly-main-e2e.yml` to use the `ubicloud-standard-8-arm` runner instead of the previous `e2e` runner.