### PR TITLE
fix(e2e): support runner run in single

### DIFF
--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -1,5 +1,19 @@
 name: Run E2E tests
 on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        required: true
+        type: string
+      suite-id:
+        required: true
+        type: string
+      test-yaml:
+        required: false
+        type: string
+      test-path:
+        required: false
+        type: string
   workflow_call:
     inputs:
       runner:


### PR DESCRIPTION
This pull request updates the `.github/workflows/e2e-run.yml` workflow to allow manual triggering with additional input parameters. The most important change is the introduction of the `workflow_dispatch` event with customizable inputs, making it easier to run E2E tests manually with specific configurations.

Workflow enhancements:

* Added `workflow_dispatch` to allow manual triggering of the workflow with the following inputs: `runner` (required), `suite-id` (required), `test-yaml` (optional), and `test-path` (optional).