### PR TITLE
fix(perf): fix backlog benchmark exits immediately due to time mismatch

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
@@ -24,6 +24,7 @@ import org.apache.kafka.tools.automq.perf.ConsumerService;
 import org.apache.kafka.tools.automq.perf.PerfConfig;
 import org.apache.kafka.tools.automq.perf.ProducerService;
 import org.apache.kafka.tools.automq.perf.Stats;
+import org.apache.kafka.tools.automq.perf.StatsCollector;
 import org.apache.kafka.tools.automq.perf.StatsCollector.Result;
 import org.apache.kafka.tools.automq.perf.StatsCollector.StopCondition;
 import org.apache.kafka.tools.automq.perf.TopicService;
@@ -174,7 +175,7 @@ public class PerfCommand implements AutoCloseable {
             consumerService.pause();
             long backlogStart = System.currentTimeMillis();
             collectStats(Duration.ofSeconds(config.backlogDurationSeconds));
-            long backlogEnd = System.nanoTime();
+            long backlogEnd = StatsCollector.currentNanos();
 
             LOGGER.info("Resetting consumer offsets and resuming...");
             consumerService.resetOffset(backlogStart, TimeUnit.SECONDS.toMillis(config.groupStartDelaySeconds));


### PR DESCRIPTION
After commit 7db3c74cd3, sendTimeNanos was changed from System.nanoTime() to StatsCollector.currentNanos() (epoch-based). However, backlogEnd still used System.nanoTime(), causing the stop condition to always be true since epoch time (~10^18) is always greater than JVM relative time (~10^11).

Verified no other time base inconsistencies exist in the perf tool.
Unit tests for perf tool are planned to improve code robustness.

https://github.com/AutoMQ/automq/issues/3171

