### PR TITLE
fix(perf): cherry pick fix backlog benchmark exits immediately due to time mismatch

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/PerfCommand.java
@@ -24,6 +24,7 @@ import org.apache.kafka.tools.automq.perf.ConsumerService;
 import org.apache.kafka.tools.automq.perf.PerfConfig;
 import org.apache.kafka.tools.automq.perf.ProducerService;
 import org.apache.kafka.tools.automq.perf.Stats;
+import org.apache.kafka.tools.automq.perf.StatsCollector;
 import org.apache.kafka.tools.automq.perf.StatsCollector.Result;
 import org.apache.kafka.tools.automq.perf.StatsCollector.StopCondition;
 import org.apache.kafka.tools.automq.perf.TopicService;
@@ -174,7 +175,7 @@ public class PerfCommand implements AutoCloseable {
             consumerService.pause();
             long backlogStart = System.currentTimeMillis();
             collectStats(Duration.ofSeconds(config.backlogDurationSeconds));
-            long backlogEnd = System.nanoTime();
+            long backlogEnd = StatsCollector.currentNanos();
 
             LOGGER.info("Resetting consumer offsets and resuming...");
             consumerService.resetOffset(backlogStart, TimeUnit.SECONDS.toMillis(config.groupStartDelaySeconds));


### PR DESCRIPTION
After commit https://github.com/AutoMQ/automq/commit/7db3c74cd3d4e402c5912bf248d4fe6e6f22b75a, sendTimeNanos was changed from System.nanoTime() to StatsCollector.currentNanos() (epoch-based). However, backlogEnd still used System.nanoTime(), causing the stop condition to always be true since epoch time (~10^18) is always greater than JVM relative time (~10^11).

cherry pick https://github.com/AutoMQ/automq/issues/3171 to 1.6

https://github.com/AutoMQ/automq/pull/3172

https://github.com/AutoMQ/automq/commit/c83763008c79047d72f9c44008f3103e963cbe7b