### PR TITLE
docs: Add GSoC 2026 documentation

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -1,0 +1,7 @@
+# AutoMQ Community
+
+Welcome to the AutoMQ community! This directory contains community-related resources and programs.
+
+## Contents
+
+- [GSoC 2026 (Google Summer of Code)](./gsoc/2026/) - Information about AutoMQ's participation in GSoC 2026

--- a/community/gsoc/2026/AutoMQ_ideas_list.md
+++ b/community/gsoc/2026/AutoMQ_ideas_list.md
@@ -1,0 +1,57 @@
+# AutoMQ Project Ideas
+
+If you are a GSoC candidate, please check out our **Contributor Guidance** to learn more about our project requirements, communication channels, and how to submit a successful proposal.
+
+If a project is successfully selected, you will be allocated a primary mentor and supported by the rest of the team. If you are interested in learning more about a particular project idea please contact us using kaiming.wan@automq.com or on our [AutoMQ Slack channel](https://go.automq.com/slack).
+
+## Idea 1: AutoMQ Table Topic Solution Workshop
+
+**Objective:**
+
+To build hands-on, visually impressive industry solution templates (e.g., FinTech, Gaming, or IoT) that demonstrate AutoMQ's "Table Topic" capability—automatically transforming Kafka streams into Apache Iceberg tables.
+
+**Description:**
+
+How can AutoMQ Table Topic simplify real-time data architectures? In this project, you will create end-to-end "Showcase Demos." You'll use AI-driven development (Vibe Coding with Claude) to build data generators and pipelines, focusing on the final "Hands-on" experience and high-quality visualization. You are encouraged to explore any industry scenario you are passionate about.
+
+**What you will do:**
+
+- Design and implement 2-3 industry demo scenarios (e.g., Anti-fraud, IoT monitoring).
+- Use AI (Claude) to quickly generate data simulators and processing logic.
+- Create beautiful, interactive dashboards (using Grafana, Streamlit, or custom web apps) to visualize the data in Iceberg.
+- Produce a "Quick Start" guide for each solution to help users experience the flow in minutes.
+
+**Skills Required:**
+
+- Experience with AI-assisted coding (Prompt engineering).
+- Basic understanding of data streaming (Kafka/Iceberg).
+- Language-agnostic (Python, Java, Go, or Node.js are all welcome).
+
+**Difficulty:** Medium
+
+**Project Size:** 175 hours (Medium)
+
+## Idea 2: Multi-Catalog Integration for AutoMQ Table Topic
+
+**Objective:**
+
+To make AutoMQ Table Topics instantly discoverable by connecting them to mainstream data catalogs like Apache Polaris or Unity Catalog.
+
+**Description:**
+
+AutoMQ transforms Kafka data into Iceberg tables automatically. This project focuses on integrating these tables with popular catalogs. Using AI/Vibe Coding (Claude), you will bridge the metadata gap, enabling a "Zero-ETL" experience where streaming data is immediately queryable by external SQL engines.
+
+**What you will do:**
+
+- Integrate AutoMQ with 2+ catalogs (e.g., Polaris, Unity, or DataHub) to sync metadata.
+- Use AI to accelerate API mapping and integration logic.
+- Demonstrate "Stream-to-SQL" by querying data via Trino or StarRocks.
+- Provide a simple docker-compose environment for the community.
+
+**Skills Required:**
+
+- AI-assisted coding, basic REST API knowledge, and curiosity about Data Lakes.
+
+**Difficulty:** Medium
+
+**Project Size:** 90~120 hours (Medium)

--- a/community/gsoc/2026/Contributor_Guidance_for_Google_Summer_of_Code.md
+++ b/community/gsoc/2026/Contributor_Guidance_for_Google_Summer_of_Code.md
@@ -1,0 +1,56 @@
+# Contributor Guidance for Google Summer of Code
+
+## General Guidelines
+
+1. **Read Official Guides:** Start by reading the [Contributor Guide](https://google.github.io/gsocguides/student/) written by the Google Summer of Code organizers.
+2. **Understand the Process:** Ensure you understand the GSoC timeline, application process, and the specific project you are applying for. We assume best intentions from all contributors throughout this period.
+3. **Join the Community:** Join our [Slack](https://go.automq.com/slack) and introduce yourself in the `#introduce` channel.
+4. **Start Early:** Begin drafting your proposal as early as possible using the template provided below. If you are new to AutoMQ, we highly recommend trying out our [Getting Started Guide](https://docs.automq.com/automq/getting-started) first.
+5. **Holistic Contribution:** We value all forms of contribution, including helping others on Slack, triaging GitHub issues, and reviewing pull requests. We prefer contributors who aim to support the community as a whole, not just the codebase.
+6. **Contributor Readiness:** Solving `good-first-issues` will show us that you can be a good GSoC contributor.
+7. **Mentor Interaction:** Reach out to and interact with mentors to discuss your solution and technical approach before submitting your final proposal.
+
+## 1. Picking up and Working on Issues
+
+- **Progressive Difficulty:** If you feel confident, you are welcome to help with other non-labeled issues, though we suggest starting with an easier task to familiarize yourself with our workflow.
+- **Assignment Policy:** To manage the influx of potential contributors and ensure timely resolutions, we will only assign issues to contributors who explicitly ask. If a PR is already open for an issue, please do not open a duplicate.
+- **The Value of Reviews:** We consider the quality of the reviews you leave on other contributors' PRs when evaluating your final proposal. Investigating an issue yourself—even if you don't solve it—helps you provide high-quality feedback. However, please refrain from "spammy" or low-effort reviews.
+- **Stuck? Reach Out:** If you find it difficult to claim an issue because others are faster, please message us on Slack. We will help find a suitable task for you.
+
+## 2. Writing Your Proposal
+
+Your proposal should demonstrate a clear understanding of how you plan to approach the project idea. Don't worry about building a perfect minute-by-minute schedule for the entire summer; we will refine the timeline together once the official mentoring period begins.
+
+## Proposal Template
+
+### [Project Title]
+
+#### About Me
+
+- Name, personal details, and contact information (Slack ID, Email).
+- Why are you the best person for this specific project?
+
+#### Past Experience
+
+Describe your coding experience. Refer to any internships, freelance work, professional roles, or open-source contributions (including personal projects).
+
+#### Past Contributions
+
+List your prior contributions to AutoMQ or other relevant open-source projects. Include links to Pull Requests, bug reports, or community support activities, organized in a neat table.
+
+| Contribution Type | Link | Description |
+|-------------------|------|-------------|
+| PR | [#xxx](link) | Brief description |
+| Issue | [#xxx](link) | Brief description |
+
+#### Project Proposal
+
+- **Abstract:** A short description of your project (max 10 lines). Do not copy-paste the official project description; provide your own perspective. Define the problem, describe the current state, and propose your solution.
+- **Motivation:** What excites you about this project? What do you plan to achieve personally and professionally, and how will you measure success?
+- **Project Plan:** This should be the most extensive portion of your proposal. List clear deliverables, technical intricacies, architecture diagrams, and code snippets. It should clearly depict your deep understanding of the problem.
+
+#### Additional Information
+
+- Why are you excited about working on AutoMQ (e.g., cloud-native, streaming, Kafka)?
+- What is your availability during the GSoC period? Do you have other commitments like classes or internships?
+- How do you plan to stay connected with the AutoMQ community after GSoC ends?


### PR DESCRIPTION
## Summary
Add Google Summer of Code (GSoC) 2026 documentation for AutoMQ.

## Changes
- Add `community/` directory with README
- Add `community/gsoc/2026/` containing:
  - `AutoMQ_ideas_list.md` - Project ideas for GSoC 2026 contributors
  - `Contributor_Guidance_for_Google_Summer_of_Code.md` - Guidelines for GSoC applicants

## Project Ideas Included
1. **AutoMQ Table Topic Solution Workshop** - Build industry solution templates demonstrating Table Topic capability (175 hours)
2. **Multi-Catalog Integration for AutoMQ Table Topic** - Connect Table Topics to data catalogs like Polaris/Unity Catalog (90-120 hours)
