### PR TITLE
feat(s3): isolated default credentials

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -404,7 +404,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     }
 
     protected List<AwsCredentialsProvider> credentialsProviders0(BucketURI bucketURI) {
-        return List.of(new AutoMQStaticCredentialsProvider(bucketURI), DefaultCredentialsProvider.create());
+        return List.of(new AutoMQStaticCredentialsProvider(bucketURI), DefaultCredentialsProvider.builder().build());
     }
 
     private String range(long start, long end) {


### PR DESCRIPTION
This pull request makes a minor update to the way AWS credentials providers are instantiated in the `AwsObjectStorage` class. The change replaces the direct use of `DefaultCredentialsProvider.create()` with the builder pattern `DefaultCredentialsProvider.builder().build()`, which can provide better extensibility and clarity.

- Updated the `credentialsProviders0` method in `AwsObjectStorage.java` to use `DefaultCredentialsProvider.builder().build()` instead of `DefaultCredentialsProvider.create()`.