### PR TITLE
test(perf): add unit tests for perf tool core classes

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/automq/perf/PerfConfigTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/automq/perf/PerfConfigTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools.automq.perf;
+
+import org.apache.kafka.common.utils.Exit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link PerfConfig}.
+ */
+public class PerfConfigTest {
+
+    @BeforeEach
+    void setUp() {
+        // Prevent System.exit() from terminating the test process
+        Exit.setExitProcedure((statusCode, message) -> {
+            throw new RuntimeException("Exit called with status " + statusCode + ": " + message);
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        Exit.resetExitProcedure();
+    }
+
+    @Test
+    void testDefaultValues() {
+        String[] args = {"--bootstrap-server", "localhost:9092"};
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("localhost:9092", config.bootstrapServer);
+        assertEquals(1, config.topics);
+        assertEquals(1, config.partitionsPerTopic);
+        assertEquals(1, config.producersPerTopic);
+        assertEquals(1, config.groupsPerTopic);
+        assertEquals(1, config.consumersPerGroup);
+        assertEquals(1024, config.recordSize);
+        assertEquals(1000, config.sendRate);
+        assertEquals(5, config.testDurationMinutes);
+        assertEquals(1, config.warmupDurationMinutes);
+        assertEquals(0, config.backlogDurationSeconds);
+        assertFalse(config.reset);
+        assertTrue(config.awaitTopicReady);
+    }
+
+    @Test
+    void testBootstrapServerDefault() {
+        String[] args = {};
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("localhost:9092", config.bootstrapServer);
+    }
+
+    @Test
+    void testBacklogDurationParsing() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--backlog-duration", "300"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(300, config.backlogDurationSeconds);
+    }
+
+    @Test
+    void testBacklogDurationMinimumValidation() {
+        // backlog-duration must be >= 300 (or 0 for disabled)
+        // Values between 1 and 299 should fail
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--backlog-duration", "100"
+        };
+        
+        assertThrows(RuntimeException.class, () -> new PerfConfig(args));
+    }
+
+    @Test
+    void testBacklogDurationZeroIsAllowed() {
+        // 0 means disabled, should be allowed
+        String[] args = {
+            "--bootstrap-server", "localhost:9092"
+            // backlog-duration defaults to 0
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(0, config.backlogDurationSeconds);
+    }
+
+    @Test
+    void testBacklogDurationVsGroupDelayValidation() {
+        // backlog >= groups * delay
+        // With 2 groups and 200s delay, backlog must be >= 400
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--backlog-duration", "300",
+            "--groups-per-topic", "2",
+            "--group-start-delay", "200"
+        };
+        
+        assertThrows(IllegalArgumentException.class, () -> new PerfConfig(args));
+    }
+
+    @Test
+    void testBacklogDurationVsGroupDelayValid() {
+        // backlog >= groups * delay
+        // With 2 groups and 100s delay, backlog 300 should be valid
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--backlog-duration", "300",
+            "--groups-per-topic", "2",
+            "--group-start-delay", "100"
+        };
+        
+        PerfConfig config = new PerfConfig(args);
+        assertEquals(300, config.backlogDurationSeconds);
+        assertEquals(2, config.groupsPerTopic);
+        assertEquals(100, config.groupStartDelaySeconds);
+    }
+
+    @Test
+    void testTopicConfigsParsing() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "-T", "retention.ms=3600000", "cleanup.policy=delete"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("3600000", config.topicConfigs.get("retention.ms"));
+        assertEquals("delete", config.topicConfigs.get("cleanup.policy"));
+    }
+
+    @Test
+    void testProducerConfigsParsing() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "-P", "acks=all", "linger.ms=5"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("all", config.producerConfigs.get("acks"));
+        assertEquals("5", config.producerConfigs.get("linger.ms"));
+    }
+
+    @Test
+    void testConsumerConfigsParsing() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "-C", "max.poll.records=500", "fetch.min.bytes=1024"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("500", config.consumerConfigs.get("max.poll.records"));
+        assertEquals("1024", config.consumerConfigs.get("fetch.min.bytes"));
+    }
+
+    @Test
+    void testSendRateParsing() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--send-rate", "5000"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(5000, config.sendRate);
+    }
+
+    @Test
+    void testSendThroughputConversion() {
+        // --send-throughput in MB/s should be converted to send-rate
+        // With record-size=1024 bytes, 1 MB/s = 1024 msg/s
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--send-throughput", "1.0",
+            "--record-size", "1024"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        // 1 MB/s / 1024 bytes = 1024 msg/s
+        assertEquals(1024, config.sendRate);
+    }
+
+    @Test
+    void testSendThroughputConversionWithDifferentRecordSize() {
+        // With record-size=512 bytes, 1 MB/s = 2048 msg/s
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--send-throughput", "1.0",
+            "--record-size", "512"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        // 1 MB/s / 512 bytes = 2048 msg/s
+        assertEquals(2048, config.sendRate);
+    }
+
+    @Test
+    void testTopicPrefixGeneration() {
+        String[] args = {"--bootstrap-server", "localhost:9092"};
+        PerfConfig config = new PerfConfig(args);
+        
+        // When no prefix is specified, a random one should be generated
+        assertNotNull(config.topicPrefix);
+        assertTrue(config.topicPrefix.startsWith("topic_"));
+    }
+
+    @Test
+    void testTopicPrefixCustom() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--topic-prefix", "my-test-topic"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("my-test-topic", config.topicPrefix);
+    }
+
+    @Test
+    void testResetFlag() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--reset"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertTrue(config.reset);
+    }
+
+    @Test
+    void testReuseTopicsFlag() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--reuse-topics"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertTrue(config.reuseTopics);
+    }
+
+    @Test
+    void testCatchupTopicPrefix() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--catchup-topic-prefix", "existing-topic"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals("existing-topic", config.catchupTopicPrefix);
+    }
+
+    @Test
+    void testConsumersDuringCatchupPercentage() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--consumers-during-catchup", "50"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(50, config.consumersDuringCatchupPercentage);
+    }
+
+    @Test
+    void testConsumersDuringCatchupPercentageDefault() {
+        String[] args = {"--bootstrap-server", "localhost:9092"};
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(100, config.consumersDuringCatchupPercentage);
+    }
+
+    @Test
+    void testConsumersDuringCatchupPercentageValidation() {
+        // Must be between 0 and 100
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--consumers-during-catchup", "150"
+        };
+        
+        assertThrows(RuntimeException.class, () -> new PerfConfig(args));
+    }
+
+    @Test
+    void testMultipleTopicsAndPartitions() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--topics", "5",
+            "--partitions-per-topic", "10"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(5, config.topics);
+        assertEquals(10, config.partitionsPerTopic);
+    }
+
+    @Test
+    void testSendRateDuringCatchup() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--send-rate", "1000",
+            "--send-rate-during-catchup", "500"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(1000, config.sendRate);
+        assertEquals(500, config.sendRateDuringCatchup);
+    }
+
+    @Test
+    void testSendRateDuringCatchupDefaultsToSendRate() {
+        String[] args = {
+            "--bootstrap-server", "localhost:9092",
+            "--send-rate", "2000"
+        };
+        PerfConfig config = new PerfConfig(args);
+        
+        assertEquals(2000, config.sendRate);
+        assertEquals(2000, config.sendRateDuringCatchup);
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/automq/perf/StatsCollectorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/automq/perf/StatsCollectorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools.automq.perf;
+
+import org.apache.kafka.tools.automq.perf.StatsCollector.StopCondition;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link StatsCollector}.
+ */
+public class StatsCollectorTest {
+
+    @Test
+    void testCurrentNanosReturnsEpochBasedTime() {
+        // This test prevents regression of the time base mismatch bug.
+        // currentNanos() should return epoch-based nanoseconds, not System.nanoTime().
+        
+        long currentNanos = StatsCollector.currentNanos();
+        
+        // Epoch time for year 2020+ should be > 1.5 * 10^18 nanoseconds
+        // System.nanoTime() returns JVM-relative time which is typically much smaller
+        assertTrue(currentNanos > 1_500_000_000_000_000_000L,
+            "currentNanos() should return epoch-based time (> 1.5 * 10^18 for year 2020+), " +
+            "but got: " + currentNanos);
+    }
+
+    @Test
+    void testCurrentNanosMatchesInstantNow() {
+        // Verify currentNanos() is consistent with Instant.now()
+        Instant before = Instant.now();
+        long currentNanos = StatsCollector.currentNanos();
+        Instant after = Instant.now();
+        
+        long beforeNanos = TimeUnit.SECONDS.toNanos(before.getEpochSecond()) + before.getNano();
+        long afterNanos = TimeUnit.SECONDS.toNanos(after.getEpochSecond()) + after.getNano();
+        
+        assertTrue(currentNanos >= beforeNanos, 
+            "currentNanos should be >= before instant");
+        assertTrue(currentNanos <= afterNanos + TimeUnit.MILLISECONDS.toNanos(10), 
+            "currentNanos should be <= after instant (with small tolerance)");
+    }
+
+    @Test
+    void testCurrentNanosIsMonotonicallyIncreasing() {
+        long first = StatsCollector.currentNanos();
+        
+        // Small delay to ensure time passes
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        
+        long second = StatsCollector.currentNanos();
+        
+        assertTrue(second >= first, 
+            "currentNanos() should be monotonically increasing");
+    }
+
+    @Test
+    void testCurrentNanosNotSystemNanoTime() {
+        // System.nanoTime() is JVM-relative and typically much smaller than epoch time
+        long systemNano = System.nanoTime();
+        long currentNanos = StatsCollector.currentNanos();
+        
+        // The difference should be huge (epoch time is ~10^18, System.nanoTime is ~10^14 or less)
+        // If they were the same base, the difference would be small
+        long diff = Math.abs(currentNanos - systemNano);
+        
+        assertTrue(diff > 1_000_000_000_000_000_000L,
+            "currentNanos() should use different time base than System.nanoTime(). " +
+            "currentNanos=" + currentNanos + ", System.nanoTime()=" + systemNano);
+    }
+
+    @Test
+    void testStopConditionWithDuration() {
+        // Test duration-based stop condition
+        Duration duration = Duration.ofSeconds(5);
+        StopCondition condition = (startNanos, nowNanos) -> 
+            Duration.ofNanos(nowNanos - startNanos).compareTo(duration) >= 0;
+        
+        long start = System.nanoTime();
+        
+        // Should not stop immediately
+        assertFalse(condition.shouldStop(start, start));
+        
+        // Should not stop after 1 second
+        long after1Sec = start + TimeUnit.SECONDS.toNanos(1);
+        assertFalse(condition.shouldStop(start, after1Sec));
+        
+        // Should stop after 5 seconds
+        long after5Sec = start + TimeUnit.SECONDS.toNanos(5);
+        assertTrue(condition.shouldStop(start, after5Sec));
+        
+        // Should stop after 10 seconds
+        long after10Sec = start + TimeUnit.SECONDS.toNanos(10);
+        assertTrue(condition.shouldStop(start, after10Sec));
+    }
+
+    @Test
+    void testStopConditionWithCatchUp() {
+        // Test catch-up stop condition (used in backlog/cold-read scenario)
+        // This is the condition that was broken by the time base mismatch bug
+        Stats stats = new Stats();
+        long targetTime = StatsCollector.currentNanos();
+        
+        StopCondition condition = (startNanos, nowNanos) -> 
+            stats.maxSendTimeNanos.get() >= targetTime;
+        
+        // Should not stop initially (maxSendTimeNanos is 0)
+        assertFalse(condition.shouldStop(0, 0));
+        
+        // Should not stop after receiving message with older timestamp
+        stats.messageReceived(1, 100, targetTime - 1000);
+        assertFalse(condition.shouldStop(0, 0));
+        
+        // Should stop after receiving message with target timestamp
+        stats.messageReceived(1, 100, targetTime);
+        assertTrue(condition.shouldStop(0, 0));
+    }
+
+    @Test
+    void testStopConditionWithCatchUpUsingEpochTime() {
+        // This test specifically validates the fix for the time base mismatch bug.
+        // Both targetTime and sendTime must use the same time base (epoch).
+        Stats stats = new Stats();
+        
+        // Simulate the backlog scenario:
+        // 1. Record backlogEnd using epoch time (the fix)
+        long backlogEnd = StatsCollector.currentNanos();
+        
+        // 2. Create stop condition
+        StopCondition condition = (startNanos, nowNanos) -> 
+            stats.maxSendTimeNanos.get() >= backlogEnd;
+        
+        // 3. Initially should not stop
+        assertFalse(condition.shouldStop(0, 0));
+        
+        // 4. Receive message with send time before backlogEnd
+        long sendTimeBeforeBacklog = backlogEnd - TimeUnit.SECONDS.toNanos(10);
+        stats.messageReceived(1, 100, sendTimeBeforeBacklog);
+        assertFalse(condition.shouldStop(0, 0), 
+            "Should not stop when received message is from before backlog end");
+        
+        // 5. Receive message with send time at backlogEnd
+        stats.messageReceived(1, 100, backlogEnd);
+        assertTrue(condition.shouldStop(0, 0), 
+            "Should stop when received message reaches backlog end time");
+    }
+
+    @Test
+    void testStopConditionWithMismatchedTimeBaseWouldFail() {
+        // This test demonstrates what happens with mismatched time bases.
+        // It shows why the bug occurred and validates our understanding.
+        Stats stats = new Stats();
+        
+        // BAD: Using System.nanoTime() for target (this was the bug)
+        long badTargetTime = System.nanoTime(); // ~10^14 or less
+        
+        // Message send time uses epoch (StatsCollector.currentNanos())
+        long sendTime = StatsCollector.currentNanos(); // ~10^18
+        
+        // The epoch time is always much larger than System.nanoTime()
+        assertTrue(sendTime > badTargetTime,
+            "Epoch time should always be > System.nanoTime(), " +
+            "which would cause immediate stop condition satisfaction");
+        
+        // This demonstrates the bug: condition would be immediately true
+        stats.messageReceived(1, 100, sendTime);
+        assertTrue(stats.maxSendTimeNanos.get() >= badTargetTime,
+            "With mismatched time bases, condition is always true");
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/automq/perf/StatsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/automq/perf/StatsTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools.automq.perf;
+
+import org.apache.kafka.tools.automq.perf.Stats.CumulativeStats;
+import org.apache.kafka.tools.automq.perf.Stats.PeriodStats;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link Stats}.
+ */
+public class StatsTest {
+
+    private Stats stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = new Stats();
+    }
+
+    @Test
+    void testMaxSendTimeNanosUpdatedOnMessageReceived() {
+        // This test prevents regression of the time base mismatch bug.
+        // maxSendTimeNanos should be updated when messageReceived is called.
+        long sendTime = StatsCollector.currentNanos();
+        
+        stats.messageReceived(1, 100, sendTime);
+        
+        assertEquals(sendTime, stats.maxSendTimeNanos.get());
+    }
+
+    @Test
+    void testMaxSendTimeNanosOnlyUpdatesWhenLarger() {
+        long olderTime = 1000L;
+        long newerTime = 2000L;
+        
+        // First update with newer time
+        stats.messageReceived(1, 100, newerTime);
+        assertEquals(newerTime, stats.maxSendTimeNanos.get());
+        
+        // Try to update with older time - should not change
+        stats.messageReceived(1, 100, olderTime);
+        assertEquals(newerTime, stats.maxSendTimeNanos.get());
+        
+        // Update with even newer time - should change
+        long newestTime = 3000L;
+        stats.messageReceived(1, 100, newestTime);
+        assertEquals(newestTime, stats.maxSendTimeNanos.get());
+    }
+
+    @Test
+    void testMaxSendTimeNanosUsesEpochTimeBase() {
+        // Ensure maxSendTimeNanos uses the same time base as StatsCollector.currentNanos()
+        // Epoch time for year 2020+ should be > 1.5 * 10^18 nanoseconds
+        long sendTime = StatsCollector.currentNanos();
+        assertTrue(sendTime > 1_500_000_000_000_000_000L, 
+            "sendTime should be epoch-based (> 1.5 * 10^18 for year 2020+)");
+        
+        stats.messageReceived(1, 100, sendTime);
+        
+        assertTrue(stats.maxSendTimeNanos.get() > 1_500_000_000_000_000_000L,
+            "maxSendTimeNanos should be epoch-based");
+    }
+
+    @Test
+    void testMessageSentUpdatesCounters() {
+        long sendTime = StatsCollector.currentNanos();
+        
+        stats.messageSent(100, sendTime);
+        stats.messageSent(200, sendTime);
+        
+        PeriodStats period = stats.toPeriodStats();
+        assertEquals(2, period.messagesSent);
+        assertEquals(300, period.bytesSent);
+    }
+
+    @Test
+    void testMessageReceivedUpdatesCounters() {
+        long sendTime = StatsCollector.currentNanos();
+        
+        stats.messageReceived(5, 500, sendTime);
+        stats.messageReceived(3, 300, sendTime);
+        
+        PeriodStats period = stats.toPeriodStats();
+        assertEquals(8, period.messagesReceived);
+        assertEquals(800, period.bytesReceived);
+    }
+
+    @Test
+    void testMessageFailedUpdatesCounters() {
+        stats.messageFailed();
+        stats.messageFailed();
+        stats.messageFailed();
+        
+        PeriodStats period = stats.toPeriodStats();
+        assertEquals(3, period.messagesSendFailed);
+    }
+
+    @Test
+    void testResetClearsAllCounters() {
+        long sendTime = StatsCollector.currentNanos();
+        
+        // Add some data
+        stats.messageSent(100, sendTime);
+        stats.messageReceived(1, 100, sendTime);
+        stats.messageFailed();
+        
+        // Reset
+        CumulativeStats beforeReset = stats.reset();
+        
+        // Verify reset returned the cumulative stats
+        assertEquals(1, beforeReset.totalMessagesSent);
+        assertEquals(1, beforeReset.totalMessagesReceived);
+        assertEquals(1, beforeReset.totalMessagesSendFailed);
+        
+        // Verify counters are cleared
+        PeriodStats afterReset = stats.toPeriodStats();
+        assertEquals(0, afterReset.messagesSent);
+        assertEquals(0, afterReset.messagesReceived);
+        assertEquals(0, afterReset.messagesSendFailed);
+        assertEquals(0, afterReset.totalMessagesSent);
+        assertEquals(0, afterReset.totalMessagesReceived);
+    }
+
+    @Test
+    void testToPeriodStatsResetsIntervalCounters() {
+        long sendTime = StatsCollector.currentNanos();
+        
+        stats.messageSent(100, sendTime);
+        stats.messageReceived(1, 100, sendTime);
+        
+        // First call should return the data
+        PeriodStats first = stats.toPeriodStats();
+        assertEquals(1, first.messagesSent);
+        assertEquals(1, first.messagesReceived);
+        
+        // Second call should return zeros (interval counters reset)
+        PeriodStats second = stats.toPeriodStats();
+        assertEquals(0, second.messagesSent);
+        assertEquals(0, second.messagesReceived);
+        
+        // But total counters should still reflect the data
+        assertEquals(1, second.totalMessagesSent);
+        assertEquals(1, second.totalMessagesReceived);
+    }
+
+    @Test
+    void testToCumulativeStatsDoesNotModifyCounters() {
+        long sendTime = StatsCollector.currentNanos();
+        
+        stats.messageSent(100, sendTime);
+        stats.messageReceived(1, 100, sendTime);
+        
+        // Call toCumulativeStats multiple times
+        CumulativeStats first = stats.toCumulativeStats();
+        CumulativeStats second = stats.toCumulativeStats();
+        
+        // Both should return the same values
+        assertEquals(first.totalMessagesSent, second.totalMessagesSent);
+        assertEquals(first.totalMessagesReceived, second.totalMessagesReceived);
+        assertEquals(1, first.totalMessagesSent);
+        assertEquals(1, first.totalMessagesReceived);
+    }
+
+    @Test
+    void testConcurrentUpdates() throws InterruptedException {
+        int numThreads = 10;
+        int updatesPerThread = 1000;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < updatesPerThread; j++) {
+                        long sendTime = StatsCollector.currentNanos();
+                        stats.messageSent(100, sendTime);
+                        stats.messageReceived(1, 100, sendTime);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        
+        latch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        
+        CumulativeStats cumulative = stats.toCumulativeStats();
+        assertEquals(numThreads * updatesPerThread, cumulative.totalMessagesSent);
+        assertEquals(numThreads * updatesPerThread, cumulative.totalMessagesReceived);
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/automq/perf/UniformRateLimiterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/automq/perf/UniformRateLimiterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools.automq.perf;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link UniformRateLimiter}.
+ */
+public class UniformRateLimiterTest {
+
+    @Test
+    void testAcquireReturnsIncreasingTimes() {
+        double rate = 1000.0; // 1000 per second
+        UniformRateLimiter limiter = new UniformRateLimiter(rate);
+        
+        long first = limiter.acquire();
+        long second = limiter.acquire();
+        long third = limiter.acquire();
+        
+        assertTrue(second > first, "Second acquire should return later time than first");
+        assertTrue(third > second, "Third acquire should return later time than second");
+    }
+
+    @Test
+    void testAcquireIntervalMatchesRate() {
+        double rate = 1000.0; // 1000 per second = 1ms interval
+        UniformRateLimiter limiter = new UniformRateLimiter(rate);
+        
+        long first = limiter.acquire();
+        long second = limiter.acquire();
+        
+        long intervalNanos = second - first;
+        long expectedIntervalNanos = TimeUnit.SECONDS.toNanos(1) / (long) rate; // 1ms = 1,000,000 ns
+        
+        // Allow 10% tolerance
+        long tolerance = expectedIntervalNanos / 10;
+        assertTrue(Math.abs(intervalNanos - expectedIntervalNanos) <= tolerance,
+            "Interval should be approximately " + expectedIntervalNanos + " ns, but was " + intervalNanos + " ns");
+    }
+
+    @Test
+    void testLowRate() {
+        double rate = 10.0; // 10 per second = 100ms interval
+        UniformRateLimiter limiter = new UniformRateLimiter(rate);
+        
+        long first = limiter.acquire();
+        long second = limiter.acquire();
+        
+        long intervalNanos = second - first;
+        long expectedIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        
+        // Allow 10% tolerance
+        long tolerance = expectedIntervalNanos / 10;
+        assertTrue(Math.abs(intervalNanos - expectedIntervalNanos) <= tolerance,
+            "Interval should be approximately 100ms, but was " + TimeUnit.NANOSECONDS.toMillis(intervalNanos) + "ms");
+    }
+
+    @Test
+    void testHighRate() {
+        double rate = 100000.0; // 100,000 per second = 10us interval
+        UniformRateLimiter limiter = new UniformRateLimiter(rate);
+        
+        long first = limiter.acquire();
+        long second = limiter.acquire();
+        
+        long intervalNanos = second - first;
+        long expectedIntervalNanos = TimeUnit.MICROSECONDS.toNanos(10);
+        
+        // Allow 20% tolerance for high rates
+        long tolerance = expectedIntervalNanos / 5;
+        assertTrue(Math.abs(intervalNanos - expectedIntervalNanos) <= tolerance,
+            "Interval should be approximately 10us, but was " + intervalNanos + "ns");
+    }
+
+    @Test
+    void testMultipleAcquiresAccumulateCorrectly() {
+        double rate = 1000.0; // 1000 per second
+        UniformRateLimiter limiter = new UniformRateLimiter(rate);
+        
+        long first = limiter.acquire();
+        
+        // Acquire 100 times
+        long last = first;
+        for (int i = 0; i < 100; i++) {
+            last = limiter.acquire();
+        }
+        
+        // Total time should be approximately 100ms (100 acquires at 1000/s)
+        long totalNanos = last - first;
+        long expectedNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        
+        // Allow 10% tolerance
+        long tolerance = expectedNanos / 10;
+        assertTrue(Math.abs(totalNanos - expectedNanos) <= tolerance,
+            "Total time for 100 acquires should be approximately 100ms, but was " + 
+            TimeUnit.NANOSECONDS.toMillis(totalNanos) + "ms");
+    }
+
+    @Test
+    void testUninterruptibleSleepNs() {
+        // Test that uninterruptibleSleepNs works correctly
+        long targetTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(10);
+        
+        long before = System.nanoTime();
+        UniformRateLimiter.uninterruptibleSleepNs(targetTime);
+        long after = System.nanoTime();
+        
+        assertTrue(after >= targetTime, 
+            "Should sleep until at least the target time");
+        
+        // Should not overshoot by too much (allow 5ms tolerance)
+        long overshoot = after - targetTime;
+        assertTrue(overshoot < TimeUnit.MILLISECONDS.toNanos(5),
+            "Should not overshoot by more than 5ms, but overshot by " + 
+            TimeUnit.NANOSECONDS.toMillis(overshoot) + "ms");
+    }
+
+    @Test
+    void testUninterruptibleSleepNsWithPastTime() {
+        // If target time is in the past, should return immediately
+        long pastTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(100);
+        
+        long before = System.nanoTime();
+        UniformRateLimiter.uninterruptibleSleepNs(pastTime);
+        long after = System.nanoTime();
+        
+        // Should return almost immediately (within 1ms)
+        long elapsed = after - before;
+        assertTrue(elapsed < TimeUnit.MILLISECONDS.toNanos(1),
+            "Should return immediately for past time, but took " + 
+            TimeUnit.NANOSECONDS.toMicros(elapsed) + "us");
+    }
+}


### PR DESCRIPTION
Following the fix for #3171 (backlog benchmark exits immediately due to time base mismatch), we identified that the perf tool lacks unit test coverage. This PR adds comprehensive tests to prevent regression and ensure code correctness.

Changes
Added 4 test classes with 40+ test cases:

StatsTest.java
Tests for maxSendTimeNanos updates (key for catch-up stop condition)
Tests for message counters (sent/received/failed)
Tests for reset() and toPeriodStats() behavior
Thread safety tests for concurrent updates

StatsCollectorTest.java
Tests ensuring currentNanos() returns epoch-based time (not System.nanoTime())
Tests for duration-based and catch-up stop conditions
Tests demonstrating the time base mismatch bug behavior

PerfConfigTest.java
Tests for argument parsing and default values
Tests for validation logic (backlog duration, consumer percentage, etc.)
Tests for config conversion (throughput to rate)

UniformRateLimiterTest.java
Tests for rate limiting accuracy
Tests for edge cases (low rate, high rate)
Tests for sleep behavior


Closes #3189
