### PR TITLE
fix(log): fix truncateFullyAndStartAt bug

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
@@ -621,7 +621,7 @@ class ElasticLog(val metaStream: MetaStream,
             })
             segments.clear()
             logMeta.getSegmentMetas.forEach(segMeta => {
-                val segment = new ElasticLogSegment(dir, segMeta, streamSliceManager, config, time, (_, _) => {}, logIdent)
+                val segment = new ElasticLogSegment(dir, segMeta, streamSliceManager, config, time, (_, _, _) => {}, logIdent)
                 segments.add(segment)
             })
         }

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegment.java
@@ -323,7 +323,7 @@ public class ElasticLogSegment extends LogSegment implements Comparable<ElasticL
     @Override
     public int recover(ProducerStateManager producerStateManager,
         Optional<LeaderEpochFileCache> leaderEpochCache) throws IOException {
-        logListener.onEvent(baseOffset, ElasticLogSegmentEvent.SEGMENT_UPDATE);
+        logListener.onEvent(baseOffset, null, ElasticLogSegmentEvent.SEGMENT_UPDATE);
         return recover0(producerStateManager, leaderEpochCache);
     }
 
@@ -447,7 +447,7 @@ public class ElasticLogSegment extends LogSegment implements Comparable<ElasticL
 
     @Override
     public void deleteIfExists() throws IOException {
-        logListener.onEvent(baseOffset, ElasticLogSegmentEvent.SEGMENT_DELETE);
+        logListener.onEvent(baseOffset, this, ElasticLogSegmentEvent.SEGMENT_DELETE);
     }
 
     @Override

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentEventListener.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentEventListener.java
@@ -20,5 +20,5 @@
 package kafka.log.streamaspect;
 
 public interface ElasticLogSegmentEventListener {
-    void onEvent(long segmentBaseOffset, ElasticLogSegmentEvent event);
+    void onEvent(long segmentBaseOffset, ElasticLogSegment segment, ElasticLogSegmentEvent event);
 }

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
@@ -48,7 +48,8 @@ public class ElasticLogSegmentManager {
      * The lock of {@link #segments} and {@link #inflightCleanedSegments}
      */
     private final ReentrantLock segmentLock = new ReentrantLock();
-    private final Map<Long, ElasticLogSegment> segments = new HashMap<>();
+    // visible to test
+    final Map<Long, ElasticLogSegment> segments = new HashMap<>();
     private final Map<Long, ElasticLogSegment> inflightCleanedSegments = new HashMap<>();
     private final EventListener innerListener = new EventListener();
     private final List<LogEventListener> logEventListeners = new CopyOnWriteArrayList<>();
@@ -105,6 +106,19 @@ public class ElasticLogSegmentManager {
                 notifyLogEventListeners(segment, LogEventListener.Event.SEGMENT_DELETE);
             }
             return segment;
+        } finally {
+            segmentLock.unlock();
+        }
+    }
+
+    public boolean remove(long baseOffset, ElasticLogSegment segment) {
+        segmentLock.lock();
+        try {
+            boolean removed = segments.remove(baseOffset, segment);
+            if (removed) {
+                notifyLogEventListeners(segment, LogEventListener.Event.SEGMENT_DELETE);
+            }
+            return removed;
         } finally {
             segmentLock.unlock();
         }
@@ -263,10 +277,10 @@ public class ElasticLogSegmentManager {
         private volatile CompletableFuture<ElasticLogMeta> pendingPersistentMetaCf = null;
 
         @Override
-        public void onEvent(long segmentBaseOffset, ElasticLogSegmentEvent event) {
+        public void onEvent(long segmentBaseOffset, ElasticLogSegment segment, ElasticLogSegmentEvent event) {
             switch (event) {
                 case SEGMENT_DELETE: {
-                    boolean deleted = remove(segmentBaseOffset) != null;
+                    boolean deleted = remove(segmentBaseOffset, segment);
                     if (deleted) {
                         // This may happen since kafka.log.LocalLog.deleteSegmentFiles schedules the delayed deletion task.
                         if (metaStream.isFenced()) {

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
@@ -8,17 +8,22 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -39,13 +44,19 @@ public class ElasticLogSegmentManagerTest {
         ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
 
         ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+        manager.put(1, logSegment);
 
-        when(manager.remove(anyLong())).thenReturn(logSegment);
-
-        when(manager.asyncPersistLogMeta()).thenReturn(CompletableFuture.completedFuture(logMeta));
+        doReturn(CompletableFuture.completedFuture(logMeta)).when(manager).asyncPersistLogMeta();
 
         ElasticLogSegmentManager.EventListener listener = manager.new EventListener();
-        listener.onEvent(1, ElasticLogSegmentEvent.SEGMENT_DELETE);
+
+        // mismatch
+        listener.onEvent(1, mock(ElasticLogSegment.class), ElasticLogSegmentEvent.SEGMENT_DELETE);
+        assertEquals(1, manager.segments.size());
+
+        // match
+        listener.onEvent(1, logSegment, ElasticLogSegmentEvent.SEGMENT_DELETE);
+        assertEquals(0, manager.segments.size());
 
         verify(manager, atLeastOnce()).asyncPersistLogMeta();
         verify(manager, atMost(2)).asyncPersistLogMeta();
@@ -54,7 +65,6 @@ public class ElasticLogSegmentManagerTest {
     @Test
     public void testLargeScaleSegmentDelete() throws InterruptedException {
         ElasticLogMeta logMeta = mock(ElasticLogMeta.class);
-        ElasticLogSegment logSegment = mock(ElasticLogSegment.class);
         MetaStream metaStream = mock(MetaStream.class);
 
         when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
@@ -62,33 +72,38 @@ public class ElasticLogSegmentManagerTest {
         ElasticLogStreamManager elasticLogStreamManager = mock(ElasticLogStreamManager.class);
 
         ElasticLogSegmentManager manager = spy(new ElasticLogSegmentManager(metaStream, elasticLogStreamManager, "testLargeScaleSegmentDelete"));
+        List<ElasticLogSegment> segments = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ElasticLogSegment segment = mock(ElasticLogSegment.class);
+            manager.put(i, segment);
+            segments.add(segment);
+        }
 
         Set<Long> removedSegmentId = new HashSet<>();
 
-        when(manager.remove(anyLong())).thenAnswer(invocation -> {
+        when(manager.remove(anyLong(), any())).thenAnswer(invocation -> {
             long id = invocation.getArgument(0);
             removedSegmentId.add(id);
-            return logSegment;
+            return invocation.callRealMethod();
         });
 
         CountDownLatch latch = new CountDownLatch(2);
 
-        when(manager.asyncPersistLogMeta())
-            .thenAnswer(invocation -> {
-                CompletableFuture<Object> cf = new CompletableFuture<>()
-                    .completeOnTimeout(logMeta, 100, TimeUnit.MILLISECONDS);
+        doAnswer(invocation -> {
+            CompletableFuture<Object> cf = new CompletableFuture<>()
+                .completeOnTimeout(logMeta, 100, TimeUnit.MILLISECONDS);
 
-                cf.whenComplete((res, e) -> {
-                    latch.countDown();
-                });
-
-                return cf;
+            cf.whenComplete((res, e) -> {
+                latch.countDown();
             });
+
+            return cf;
+        }).when(manager).asyncPersistLogMeta();
 
         ElasticLogSegmentManager.EventListener listener = spy(manager.new EventListener());
 
-        for (long i = 0L; i < 10L; i++) {
-            listener.onEvent(i, ElasticLogSegmentEvent.SEGMENT_DELETE);
+        for (int i = 0; i < 10; i++) {
+            listener.onEvent(i, segments.get(i), ElasticLogSegmentEvent.SEGMENT_DELETE);
         }
 
         latch.await();

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentTest.java
@@ -338,7 +338,7 @@ public class ElasticLogSegmentTest {
             }
         });
 
-        return new ElasticLogSegment(logDir, meta, manager, new LogConfig(props), time, (a, b) -> {
+        return new ElasticLogSegment(logDir, meta, manager, new LogConfig(props), time, (a,  b, c) -> {
         }, "");
     }
 


### PR DESCRIPTION
cherry-pick https://github.com/AutoMQ/automq/pull/3241
BUG description: when the newOffset of truncateFullyAndStartAt is the same as current log startOffset. The newSegment(newStartOffset) will be deleted by mistake

