### PR TITLE
fix: ServerSocket leak in AutoBalancerTestUtils#findLocalPorts

### DIFF
--- a/core/src/test/java/kafka/autobalancer/utils/AutoBalancerTestUtils.java
+++ b/core/src/test/java/kafka/autobalancer/utils/AutoBalancerTestUtils.java
@@ -91,14 +91,22 @@ public final class AutoBalancerTestUtils {
         for (int i = 0; i < portNum; i++) {
             int port = -1;
             while (port < 0) {
+                ServerSocket socket = null;
                 try {
-                    ServerSocket socket = new ServerSocket(0);
+                    socket = new ServerSocket(0);
                     socket.setReuseAddress(true);
                     port = socket.getLocalPort();
                     ports[i] = port;
                     sockets.add(socket);
                 } catch (IOException ie) {
-                    // let it go.
+                    // close socket if setReuseAddress throws
+                    if (socket != null) {
+                        try {
+                            socket.close();
+                        } catch (IOException e) {
+                            // Ignore IOException on close()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Linked Issue
Fixes #3243

### What changed
Ensure `ServerSocket` is closed when an `IOException` occurs after the socket is created but before it is added to the tracking list (e.g., during `setReuseAddress(true)`).

### Why
Prevents leaking file descriptors in the test utility, avoiding potential flakiness/resource exhaustion in CI.

### Testing
No behavior change in the success path; only improves cleanup on failure.