### PR TITLE
fix: Prevent broker startup crash when using GRPC for metrics to prevent broker crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2352,7 +2352,6 @@ project(':automq-metrics') {
     api libs.opentelemetryExporterLogging
     api libs.opentelemetryExporterProm
     api libs.opentelemetryExporterOTLP
-    api libs.opentelemetryExporterSenderJdk
     api libs.opentelemetryExporterSenderOkhttp
     api libs.opentelemetryJmx
 

--- a/build.gradle
+++ b/build.gradle
@@ -2341,11 +2341,7 @@ project(':automq-metrics') {
     configProperties = checkstyleConfigProperties("import-control-server.xml")
   }
 
-  configurations {
-    all {
-      exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-sender-okhttp'
-    }
-  }
+
     
   dependencies {
     // OpenTelemetry core dependencies
@@ -2357,6 +2353,7 @@ project(':automq-metrics') {
     api libs.opentelemetryExporterProm
     api libs.opentelemetryExporterOTLP
     api libs.opentelemetryExporterSenderJdk
+    api libs.opentelemetryExporterSenderOkhttp
     api libs.opentelemetryJmx
 
     // Logging dependencies

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -301,6 +301,7 @@ libs += [
   opentelemetryExporterProm: "io.opentelemetry:opentelemetry-exporter-prometheus:$versions.opentelemetrySDKAlpha",
   opentelemetryExporterOTLP: "io.opentelemetry:opentelemetry-exporter-otlp:$versions.opentelemetrySDK",
   opentelemetryExporterSenderJdk: "io.opentelemetry:opentelemetry-exporter-sender-jdk:$versions.opentelemetrySDK",
+  opentelemetryExporterSenderOkhttp: "io.opentelemetry:opentelemetry-exporter-sender-okhttp:$versions.opentelemetrySDK",
   opentelemetryJmx: "io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:$versions.opentelemetryInstrument",
   oshi: "com.github.oshi:oshi-core-java11:$versions.oshi",
   bucket4j: "com.bucket4j:bucket4j-core:$versions.bucket4j",


### PR DESCRIPTION
fixes #3217 

The changes fix a bug where configuring the OTLP metrics exporter to use the grpc protocol would cause the broker to immediately crash during startup.

A recent update (PR #3124 ) removed the OkHttp network library to rely on the built-in JDK client instead. This worked fine for sending metrics over standard HTTP, but it removed the ability to send metrics over GRPC.

As a result, if a user configured their metrics exporter to use GRPC, the system lacked the tool needed to send the data and crashed on startup with an `IllegalStateException: No GrpcSenderProvider found` error. 

The changes re-introduce the `opentelemetry-exporter-sender-okhttp` dependency to the `automq-metrics` module. This naturally restores the missing GRPC tool for OpenTelemetry, allowing the broker to start safely and transmit metrics over GRPC again.

It should now successfully boot up and begin exporting telemetry without throwing a missing classpath exception.