### PR TITLE
fix: Re-enable -Werror and fix all compile warnings (#2717)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,10 +264,7 @@ subprojects {
       options.compilerArgs << "-Xlint:-rawtypes"
     options.compilerArgs << "-Xlint:-serial"
     options.compilerArgs << "-Xlint:-try"
-    // AutoMQ inject start
-    // TODO: remove me, when upgrade to 4.x
-//    options.compilerArgs << "-Werror"
-    // AutoMQ inject start
+    options.compilerArgs << "-Werror"
 
     // --release is the recommended way to select the target release, but it's only supported in Java 9 so we also
     // set --source and --target via `sourceCompatibility` and `targetCompatibility` a couple of lines below

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientCallbackHandler.java
@@ -53,6 +53,7 @@ public class SaslClientCallbackHandler implements AuthenticateCallbackHandler {
         this.mechanism  = saslMechanism;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
         Subject subject = Subject.getSubject(AccessController.getContext());

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientCallbackHandler.java
@@ -75,6 +75,7 @@ public class OAuthBearerSaslClientCallbackHandler implements AuthenticateCallbac
         configured = true;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
         if (!configured())
@@ -94,6 +95,7 @@ public class OAuthBearerSaslClientCallbackHandler implements AuthenticateCallbac
         // empty
     }
 
+    @SuppressWarnings("removal")
     private void handleCallback(OAuthBearerTokenCallback callback) throws IOException {
         if (callback.token() != null)
             throw new IllegalArgumentException("Callback had a token already");

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
@@ -320,6 +320,7 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
             return this.origCertificate.getBasicConstraints();
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public Principal getIssuerDN() {
             return this.origCertificate.getIssuerDN();
@@ -370,6 +371,7 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
             return this.origCertificate.getSignature();
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public Principal getSubjectDN() {
             return this.origCertificate.getSubjectDN();

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClientCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClientCallbackHandlerTest.java
@@ -76,6 +76,7 @@ public class OAuthBearerSaslClientCallbackHandlerTest {
         assertEquals(IOException.class, e.getCause().getClass());
     }
 
+    @SuppressWarnings("removal")
     @Test()
     public void testWithPotentiallyMultipleTokens() throws Exception {
         OAuthBearerSaslClientCallbackHandler handler = createCallbackHandler();

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
@@ -66,6 +66,7 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
         chainWithValidAndInvalidEndCertificates = generateKeyChainIncludingCA(false, true, true, false);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testNeverExpiringX509Certificate() throws Exception {
         final KeyPair keyPair = TestSslUtils.generateKeyPair("RSA");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -255,6 +255,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * @param uponShutdown       any {@link AutoCloseable} objects that should be closed when this herder is {@link #stop() stopped},
      *                           after all services and resources owned by this herder are stopped
      */
+    @SuppressWarnings("this-escape")
     public DistributedHerder(DistributedConfig config,
                              Time time,
                              Worker worker,
@@ -272,6 +273,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     // visible for testing
+    @SuppressWarnings("this-escape")
     DistributedHerder(DistributedConfig config,
                       Worker worker,
                       String workerId,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ClassLoaderFactory.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ClassLoaderFactory.java
@@ -26,12 +26,14 @@ import java.security.PrivilegedAction;
  */
 public class ClassLoaderFactory implements PluginClassLoaderFactory {
 
+    @SuppressWarnings("removal")
     public DelegatingClassLoader newDelegatingClassLoader(ClassLoader parent) {
         return AccessController.doPrivileged(
                 (PrivilegedAction<DelegatingClassLoader>) () -> new DelegatingClassLoader(parent)
         );
     }
 
+    @SuppressWarnings("removal")
     public PluginClassLoader newPluginClassLoader(URL pluginLocation, URL[] urls, ClassLoader parent) {
         return AccessController.doPrivileged(
                 (PrivilegedAction<PluginClassLoader>) () -> new PluginClassLoader(pluginLocation, urls, parent)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanner.java
@@ -90,6 +90,7 @@ public abstract class PluginScanner {
      */
     protected abstract PluginScanResult scanPlugins(PluginSource source);
 
+    @SuppressWarnings("removal")
     private void loadJdbcDrivers(final ClassLoader loader) {
         // Apply here what java.sql.DriverManager does to discover and register classes
         // implementing the java.sql.Driver interface.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -91,6 +91,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      * @param time              The time.
      * @param eventAccumulator  The event accumulator.
      */
+    @SuppressWarnings("this-escape")
     public MultiThreadedEventProcessor(
         LogContext logContext,
         String threadPrefix,


### PR DESCRIPTION
- Re-enabled -Werror flag in build.gradle to treat warnings as errors
- Fixed [deprecation] warnings for getIssuerDN()/getSubjectDN() with @SuppressWarnings
- Fixed [removal] warnings for AccessController/Subject.getSubject() with @SuppressWarnings
- Fixed [this-escape] warnings in constructors with @SuppressWarnings

All Java source and test compilation now passes cleanly with -Werror enabled. All suppressions use minimal scope (method-level, not class-level).

Fixes #2717

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
