### PR TITLE
fix: add gRPC sender support for OTLP metrics exporter without sender…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2357,6 +2357,11 @@ project(':automq-metrics') {
     api libs.opentelemetryExporterProm
     api libs.opentelemetryExporterOTLP
     api libs.opentelemetryExporterSenderJdk
+    api libs.opentelemetryExporterSenderGrpc
+
+    // gRPC transport required by sender-grpc-managed-channel at runtime
+    runtimeOnly 'io.grpc:grpc-netty-shaded:1.63.0'
+    
     api libs.opentelemetryJmx
 
     // Logging dependencies

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -301,6 +301,7 @@ libs += [
   opentelemetryExporterProm: "io.opentelemetry:opentelemetry-exporter-prometheus:$versions.opentelemetrySDKAlpha",
   opentelemetryExporterOTLP: "io.opentelemetry:opentelemetry-exporter-otlp:$versions.opentelemetrySDK",
   opentelemetryExporterSenderJdk: "io.opentelemetry:opentelemetry-exporter-sender-jdk:$versions.opentelemetrySDK",
+  opentelemetryExporterSenderGrpc: "io.opentelemetry:opentelemetry-exporter-sender-grpc-managed-channel:$versions.opentelemetrySDK",
   opentelemetryJmx: "io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:$versions.opentelemetryInstrument",
   oshi: "com.github.oshi:oshi-core-java11:$versions.oshi",
   bucket4j: "com.bucket4j:bucket4j-core:$versions.bucket4j",


### PR DESCRIPTION
…-okhttp

fixes #3260 
relates to #3217 

## Description

PR #3124 excluded `sender-okhttp` and added `sender-jdk` to fix the `AbstractMethodError` crash when using OTLP HTTP metrics export (#3111). However, `sender-jdk` only provides `HttpSenderProvider` and it does not provide `GrpcSenderProvider`. This caused the broker to crash on startup when `protocol=grpc` with: `IllegalStateException: No GrpcSenderProvider found on classpath`.

## Solution
This PR adds `opentelemetry-exporter-sender-grpc-managed-channel` and `grpc-netty-shaded` to restore gRPC support **without reintroducing `sender-okhttp`**. And for not re-introducing sender-okhttp the reason is identified in #3260, where the Strimzi image bundles OTel 1.34.1 via `kafka-thirdparty-libs`, while AutoMQ ships OTel 1.40.0. When `sender-okhttp` from both versions coexist on the flat classpath (`/opt/kafka/libs/`), `ServiceLoader` may resolve `OkHttpHttpSenderProvider` from the wrong version, causing `AbstractMethodError`.

By using `sender-jdk` (HTTP) + `sender-grpc-managed-channel` (gRPC) instead, there is no overlap with Strimzi's bundled OTel jars.

## Changes

- `gradle/dependencies.gradle`: Added `opentelemetryExporterSenderGrpc` lib alias
- `build.gradle` (`automq-metrics`): Added `sender-grpc-managed-channel` as `api`
  dependency and `grpc-netty-shaded` as `runtimeOnly`

## Testing
**Dependency verification**: confirmed correct senders on classpath, `sender-okhttp` absent:

```
$ ./gradlew :automq-metrics:dependencies --configuration runtimeClasspath | grep -E "sender-jdk|sender-grpc|sender-okhttp|grpc-netty" 
+--- io.opentelemetry:opentelemetry-exporter-sender-jdk:1.40.0 
+--- io.opentelemetry:opentelemetry-exporter-sender-grpc-managed-channel:1.40.0 
+--- io.grpc:grpc-netty-shaded:1.63.0 
+--- io.opentelemetry:opentelemetry-exporter-sender-jdk:{strictly 1.40.0} -> 1.40.0 (c) 
+--- io.opentelemetry:opentelemetry-exporter-sender-grpc-managed-channel:{strictly 1.40.0} -> 1.40.0 (c)
```

**Build verification**: `automq-metrics` module builds successfully:
```
$ ./gradlew :automq-metrics:jar
 BUILD SUCCESSFUL in 58s 7 actionable tasks: 4 executed, 3 up-to-date
```

