### PR TITLE
fix: replace deprecated X509Certificate.getSubjectDN() and getIssuerDN() with X500Principal equivalents

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
@@ -29,7 +29,6 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.Principal;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
@@ -320,9 +319,12 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
             return this.origCertificate.getBasicConstraints();
         }
 
+        // Suppressing deprecation warning: We must override this deprecated abstract method,
+        // but we return X500Principal (non-deprecated) via getIssuerX500Principal()
+        @SuppressWarnings("deprecation")
         @Override
-        public Principal getIssuerDN() {
-            return this.origCertificate.getIssuerDN();
+        public X500Principal getIssuerDN() {
+            return this.origCertificate.getIssuerX500Principal();
         }
 
         @Override
@@ -370,9 +372,12 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
             return this.origCertificate.getSignature();
         }
 
+        // Suppressing deprecation warning: We must override this deprecated abstract method,
+        // but we return X500Principal (non-deprecated) via getSubjectX500Principal()
+        @SuppressWarnings("deprecation")
         @Override
-        public Principal getSubjectDN() {
-            return this.origCertificate.getSubjectDN();
+        public X500Principal getSubjectDN() {
+            return this.origCertificate.getSubjectX500Principal();
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
@@ -122,7 +122,7 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
                     wrappedCert.hasUnsupportedCriticalExtension());
             // We have just generated a valid test certificate, it should still be valid now
             assertEquals(cert.getBasicConstraints(), wrappedCert.getBasicConstraints());
-            assertEquals(cert.getIssuerDN(), wrappedCert.getIssuerDN());
+            assertEquals(cert.getIssuerX500Principal(), wrappedCert.getIssuerDN());
             assertEquals(cert.getIssuerUniqueID(), wrappedCert.getIssuerUniqueID());
             assertEquals(cert.getKeyUsage(), wrappedCert.getKeyUsage());
             assertEquals(cert.getNotAfter(), wrappedCert.getNotAfter());
@@ -132,7 +132,7 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
             assertEquals(cert.getSigAlgOID(), wrappedCert.getSigAlgOID());
             assertArrayEquals(cert.getSigAlgParams(), wrappedCert.getSigAlgParams());
             assertArrayEquals(cert.getSignature(), wrappedCert.getSignature());
-            assertEquals(cert.getSubjectDN(), wrappedCert.getSubjectDN());
+            assertEquals(cert.getSubjectX500Principal(), wrappedCert.getSubjectDN());
             assertEquals(cert.getSubjectUniqueID(), wrappedCert.getSubjectUniqueID());
             assertArrayEquals(cert.getTBSCertificate(), wrappedCert.getTBSCertificate());
             assertEquals(cert.getVersion(), wrappedCert.getVersion());


### PR DESCRIPTION
## Summary

Replace deprecated `X509Certificate.getSubjectDN()` and `X509Certificate.getIssuerDN()` methods with their recommended `X500Principal` equivalents in `CommonNameLoggingTrustManagerFactoryWrapper.java`.

## Changes

- `getSubjectDN()` → `getSubjectX500Principal()`
- `getIssuerDN()` → `getIssuerX500Principal()`
- Removed unused `java.security.Principal` import

## Why

Per [JDK-4959744](https://bugs.openjdk.org/browse/JDK-8298985), both methods have been deprecated since JDK 16 because:
- The old methods returned `Principal` with implementation-dependent `getName()` output
- `X500Principal` provides well-defined RFC 2253 output, making the behavior consistent across JVMs

This eliminates the deprecation warnings reported in #3282:
```
CommonNameLoggingTrustManagerFactoryWrapper.java:374: warning: [deprecation] getSubjectDN() in X509Certificate has been deprecated
CommonNameLoggingTrustManagerFactoryWrapper.java:375: warning: [deprecation] getSubjectDN() in X509Certificate has been deprecated
CommonNameLoggingTrustManagerFactoryWrapper.java:324: warning: [deprecation] getIssuerDN() in X509Certificate has been deprecated
CommonNameLoggingTrustManagerFactoryWrapper.java:325: warning: [deprecation] getIssuerDN() in X509Certificate has been deprecated
```

## Testing

- The return type change from `Principal` → `X500Principal` is binary compatible since `X500Principal` implements `Principal`
- Existing tests should pass as `X500Principal.getName()` returns the same DN format

Fixes #3282