### PR TITLE
fix(connect): correct KAFKA-17719 fix to prevent rebalance storm

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2258,12 +2258,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     private void publishConnectorTaskConfigs(String connName, List<Map<String, String>> taskProps, Callback<Void> cb) {
         List<Map<String, String>> rawTaskProps = reverseTransform(connName, configState, taskProps);
-        // KAFKA-17719: Always rewrite task configs to the config topic, even if unchanged.
-        // This ensures task config offsets are always greater than the connector config offset,
-        // preventing log compaction from reordering records into TCC order (task-commit-connector)
-        // which would cause task configs to be lost on worker restart.
-        if (log.isDebugEnabled() && !taskConfigsChanged(configState, connName, rawTaskProps)) {
-            log.debug("Task configs for connector '{}' are unchanged, but rewriting to prevent compaction reorder (KAFKA-17719)", connName);
+        if (!taskConfigsChanged(configState, connName, rawTaskProps)) {
+            return;
         }
 
         if (isLeader()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -550,10 +550,41 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
         log.debug("Removing connector configuration for connector '{}'", connector);
         try {
             Timer timer = time.timer(READ_WRITE_TOTAL_TIMEOUT_MS);
-            List<ProducerKeyValue> keyValues = Arrays.asList(
-                    new ProducerKeyValue(CONNECTOR_KEY(connector), null),
-                    new ProducerKeyValue(TARGET_STATE_KEY(connector), null)
-            );
+            List<ProducerKeyValue> keyValues = new ArrayList<>();
+            keyValues.add(new ProducerKeyValue(CONNECTOR_KEY(connector), null));
+            keyValues.add(new ProducerKeyValue(TARGET_STATE_KEY(connector), null));
+
+            // Write tombstones for all task config keys and the commit key so that log compaction
+            // will eventually remove them. Without these tombstones, orphaned task configs and commit
+            // records would persist indefinitely in the config topic after the connector is deleted,
+            // which is the root cause of KAFKA-16838.
+            synchronized (lock) {
+                Integer taskCount = connectorTaskCounts.get(connector);
+                if (taskCount != null) {
+                    // Also collect task IDs from taskConfigs and deferredTaskUpdates to handle the case
+                    // where task count was reduced (old task keys with higher indices still exist)
+                    Set<Integer> allTaskIds = new HashSet<>();
+                    for (int i = 0; i < taskCount; i++) {
+                        allTaskIds.add(i);
+                    }
+                    for (ConnectorTaskId taskId : taskConfigs.keySet()) {
+                        if (taskId.connector().equals(connector)) {
+                            allTaskIds.add(taskId.task());
+                        }
+                    }
+                    Map<ConnectorTaskId, Map<String, String>> deferred = deferredTaskUpdates.get(connector);
+                    if (deferred != null) {
+                        for (ConnectorTaskId taskId : deferred.keySet()) {
+                            allTaskIds.add(taskId.task());
+                        }
+                    }
+                    for (int taskId : allTaskIds) {
+                        keyValues.add(new ProducerKeyValue(TASK_KEY(new ConnectorTaskId(connector, taskId)), null));
+                    }
+                    keyValues.add(new ProducerKeyValue(COMMIT_TASKS_KEY(connector), null));
+                }
+            }
+
             sendPrivileged(keyValues, timer);
 
             configLog.readToEnd().get(timer.remainingMs(), TimeUnit.MILLISECONDS);
@@ -1039,6 +1070,11 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
                 // which were created with 0.9 Connect will be initialized in the STARTED state.
                 if (!connectorTargetStates.containsKey(connectorName))
                     connectorTargetStates.put(connectorName, TargetState.STARTED);
+
+                // If a task commit was previously received before this connector config (due to log compaction
+                // reordering), the task configs were deferred. Now that the connector config has arrived,
+                // attempt to apply those deferred task configs. See KAFKA-17719.
+                applyDeferredTaskConfigs(connectorName);
             }
         }
         if (started) {
@@ -1078,18 +1114,38 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
     private void processTasksCommitRecord(String connectorName, SchemaAndValue value) {
         List<ConnectorTaskId> updatedTasks = new ArrayList<>();
         synchronized (lock) {
-            // Edge case: connector was deleted before these task configs were published,
-            // but compaction took place and both the original connector config and the
-            // tombstone message for it have been removed from the config topic
-            // We should ignore these task configs
             Map<String, String> appliedConnectorConfig = connectorConfigs.get(connectorName);
             if (appliedConnectorConfig == null) {
-                processConnectorRemoval(connectorName);
-                log.debug(
-                        "Ignoring task configs for connector {}; it appears that the connector was deleted previously "
-                            + "and that log compaction has since removed any trace of its previous configurations "
-                            + "from the config topic",
-                        connectorName
+                // The connector config is not present. This can happen when log compaction reorders
+                // records (KAFKA-17719) such that the task commit appears before the connector config,
+                // or when orphaned task configs remain from a previously-deleted connector whose
+                // tombstone has been removed by delete.retention.ms.
+                //
+                // For tombstone records (written during connector deletion), simply ignore them.
+                if (value.value() == null) {
+                    log.debug("Ignoring tombstone commit record for connector '{}' whose config is not present",
+                            connectorName);
+                    return;
+                }
+                if (!(value.value() instanceof Map)) {
+                    log.error("Ignoring connector tasks configuration commit for connector '{}' "
+                        + "because it is in the wrong format: {}", connectorName, className(value.value()));
+                    return;
+                }
+                // Defer processing: store the task count and mark the connector as inconsistent.
+                // If the connector config arrives later (compaction reorder), applyDeferredTaskConfigs()
+                // will apply the deferred task configs at that point. If no connector config ever arrives
+                // (deleted connector), the deferred data remains inert.
+                @SuppressWarnings("unchecked")
+                int newTaskCount = intValue(((Map<String, Object>) value.value()).get("tasks"));
+                connectorTaskCounts.put(connectorName, newTaskCount);
+                inconsistent.add(connectorName);
+                log.warn(
+                        "Received task commit for connector '{}' (task count: {}) but its connector config "
+                            + "is not yet present. This may be due to log compaction reordering records "
+                            + "in the config topic (KAFKA-17719), or the connector may have been deleted. "
+                            + "Deferring task config application until the connector config is received.",
+                        connectorName, newTaskCount
                 );
                 return;
             }
@@ -1279,12 +1335,64 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
         }
     }
 
+    /**
+     * Attempt to apply deferred task configs that were received before the connector config
+     * due to log compaction reordering records in the config topic (KAFKA-17719).
+     *
+     * <p>When log compaction reorders records, the task configs and commit record may appear
+     * before the connector config record. In that case, {@link #processTasksCommitRecord} stores
+     * the task count in {@link #connectorTaskCounts} and marks the connector as inconsistent,
+     * while the task configs remain in {@link #deferredTaskUpdates}. When the connector config
+     * finally arrives and this method is called, it attempts to apply those deferred task configs.</p>
+     *
+     * <p>This method must be called while holding {@link #lock}.</p>
+     *
+     * @param connectorName the name of the connector whose deferred task configs should be applied
+     */
+    private void applyDeferredTaskConfigs(String connectorName) {
+        Integer pendingTaskCount = connectorTaskCounts.get(connectorName);
+        if (pendingTaskCount == null || !inconsistent.contains(connectorName)) {
+            return;
+        }
+
+        Map<ConnectorTaskId, Map<String, String>> deferred = deferredTaskUpdates.get(connectorName);
+        Set<Integer> taskIdSet = taskIds(connectorName, deferred);
+        if (completeTaskIdSet(taskIdSet, pendingTaskCount)) {
+            if (deferred != null) {
+                taskConfigs.putAll(deferred);
+                connectorTaskConfigGenerations.compute(connectorName,
+                    (ignored, generation) -> generation != null ? generation + 1 : 0);
+                deferred.clear();
+            }
+            inconsistent.remove(connectorName);
+            connectorsPendingFencing.add(connectorName);
+
+            Map<String, String> currentConfig = connectorConfigs.get(connectorName);
+            if (currentConfig != null) {
+                appliedConnectorConfigs.put(
+                        connectorName,
+                        new AppliedConnectorConfig(currentConfig)
+                );
+            }
+
+            log.info("Successfully applied deferred task configs for connector '{}' after receiving "
+                    + "its connector config (likely due to log compaction reordering, see KAFKA-17719)",
+                    connectorName);
+        } else {
+            log.warn("Connector '{}' has deferred task configs but they are incomplete "
+                    + "(expected {} tasks, got task IDs {}). Connector will remain inconsistent "
+                    + "until a complete set of task configs is written.",
+                    connectorName, pendingTaskCount, taskIdSet);
+        }
+    }
+
     private void processConnectorRemoval(String connectorName) {
         connectorConfigs.remove(connectorName);
         connectorTaskCounts.remove(connectorName);
         taskConfigs.keySet().removeIf(taskId -> taskId.connector().equals(connectorName));
         deferredTaskUpdates.remove(connectorName);
         appliedConnectorConfigs.remove(connectorName);
+        inconsistent.remove(connectorName);
     }
 
     private ConnectorTaskId parseTaskId(String key) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -141,7 +141,6 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -1047,8 +1046,6 @@ public class DistributedHerderTest {
         time.sleep(1000L);
         assertStatistics("leaderUrl", true, 3, 1, 100, 2100L);
 
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore, putConnectorCallback);
 
         assertEquals(
@@ -1098,8 +1095,6 @@ public class DistributedHerderTest {
         verify(worker, times(2)).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), any());
         verify(worker, times(2)).connectorTaskConfigs(eq(CONN1), any());
         verify(worker).stopAndAwaitConnector(CONN1);
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2137,8 +2132,6 @@ public class DistributedHerderTest {
         herder.tick();
 
         verify(configBackingStore, times(2)).refresh(anyLong(), any(TimeUnit.class));
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2215,8 +2208,6 @@ public class DistributedHerderTest {
         herder.tick();
         assertEquals(before + coordinatorDiscoveryTimeoutMs, time.milliseconds());
 
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2301,8 +2292,6 @@ public class DistributedHerderTest {
 
         herder.tick();
 
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2444,8 +2433,6 @@ public class DistributedHerderTest {
 
         // Once after initial rebalance and assignment; another after config update
         verify(worker, times(2)).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), any());
-        // KAFKA-17719: task configs are always rewritten to prevent compaction reorder
-        verify(configBackingStore, atLeast(0)).putTaskConfigs(any(), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -1601,6 +1601,229 @@ public class KafkaConfigBackingStoreTest {
         verify(configLog).stop();
     }
 
+    /**
+     * Test KAFKA-17719: When log compaction reorders records such that task configs and commit
+     * appear before the connector config, the task configs should be deferred and applied when
+     * the connector config finally arrives.
+     */
+    @Test
+    public void testCompactionReorderConnectorConfigAfterCommit() {
+        // Simulate compaction reorder: task configs + commit appear BEFORE connector config
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
+                // Connector config arrives AFTER commit due to compaction reorder
+                new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));
+        deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        deserialized.put(CONFIGS_SERIALIZED.get(3), CONNECTOR_CONFIG_STRUCTS.get(0));
+        logOffset = 4;
+
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should be fully loaded with task configs applied
+        assertEquals(4, configState.offset());
+        assertEquals(Collections.singletonList(CONNECTOR_IDS.get(0)), new ArrayList<>(configState.connectors()));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
+        assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(TASK_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(TASK_IDS.get(1)));
+        assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Test KAFKA-16838: When a connector is deleted and its tombstone is present in the config topic,
+     * orphaned task configs and commit records should be properly ignored.
+     */
+    @Test
+    public void testDeletedConnectorWithTombstoneIgnoresOrphanTaskConfigs() {
+        // Simulate: orphan task configs + commit appear, then connector tombstone
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
+                // Connector tombstone arrives after orphan task configs
+                new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        null, new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));
+        deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        logOffset = 4;
+
+        expectStart(existingRecords, deserialized);
+        // null value (tombstone) → SchemaAndValue.NULL
+        when(converter.toConnectData(TOPIC, null)).thenReturn(SchemaAndValue.NULL);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should NOT be present — it was deleted
+        assertEquals(4, configState.offset());
+        assertFalse(configState.contains(CONNECTOR_IDS.get(0)));
+        assertEquals(0, configState.taskCount(CONNECTOR_IDS.get(0)));
+        // Deferred task updates should be cleaned up by processConnectorRemoval
+        assertEquals(Collections.emptyMap(), configStorage.deferredTaskUpdates);
+        assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Test KAFKA-16838 with tombstone compacted away: When a connector was deleted but its tombstone
+     * has been removed by delete.retention.ms, orphaned task configs remain inert because no
+     * connector config will ever arrive to trigger applyDeferredTaskConfigs.
+     */
+    @Test
+    public void testOrphanTaskConfigsWithDeletedTombstoneCompacted() {
+        // Simulate: only orphan task configs + commit remain (tombstone already compacted away)
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));
+        deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        logOffset = 3;
+
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should NOT be present in connectors list
+        assertEquals(3, configState.offset());
+        assertFalse(configState.contains(CONNECTOR_IDS.get(0)));
+        // The connector is marked inconsistent (deferred data exists but no connector config)
+        assertTrue(configState.inconsistentConnectors().contains(CONNECTOR_IDS.get(0)));
+        // Task configs should NOT have been applied (still in deferred)
+        assertNull(configState.taskConfig(TASK_IDS.get(0)));
+        assertNull(configState.taskConfig(TASK_IDS.get(1)));
+        // tasks() should return empty for inconsistent connectors
+        assertEquals(Collections.emptyList(), configState.tasks(CONNECTOR_IDS.get(0)));
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Test that removeConnectorConfig writes tombstones for all task config keys and the commit key,
+     * in addition to the connector config and target state keys.
+     */
+    @Test
+    public void testRemoveConnectorConfigWritesFullTombstones() throws Exception {
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        // Bootstrap: add a connector with 2 tasks
+        addConnector(CONNECTOR_IDS.get(0), SAMPLE_CONFIGS.get(0),
+                Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1)));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(configLog.sendWithReceipt(keyCaptor.capture(), isNull()))
+                .thenReturn(producerFuture);
+        when(producerFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(null);
+
+        @SuppressWarnings("unchecked")
+        Future<Void> readFuture = mock(Future.class);
+        when(configLog.readToEnd()).thenReturn(readFuture);
+        when(readFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(null);
+
+        configStorage.removeConnectorConfig(CONNECTOR_IDS.get(0));
+
+        // Verify all expected tombstone keys were written
+        List<String> capturedKeys = keyCaptor.getAllValues();
+        assertTrue(capturedKeys.contains(CONNECTOR_CONFIG_KEYS.get(0)),
+                "Should write tombstone for connector config key");
+        assertTrue(capturedKeys.contains(TARGET_STATE_KEYS.get(0)),
+                "Should write tombstone for target state key");
+        assertTrue(capturedKeys.contains(TASK_CONFIG_KEYS.get(0)),
+                "Should write tombstone for task-0 config key");
+        assertTrue(capturedKeys.contains(TASK_CONFIG_KEYS.get(1)),
+                "Should write tombstone for task-1 config key");
+        assertTrue(capturedKeys.contains(COMMIT_TASKS_CONFIG_KEYS.get(0)),
+                "Should write tombstone for commit key");
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Test that full tombstones written during deletion are properly handled on restart:
+     * all tombstone records should be safely ignored.
+     */
+    @Test
+    public void testRestartWithFullTombstonesAfterDeletion() {
+        // Simulate: all keys have tombstones (full tombstone deletion)
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        null, new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TARGET_STATE_KEYS.get(0),
+                        null, new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        null, new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        null, new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        null, new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        logOffset = 5;
+
+        expectStart(existingRecords, deserialized);
+        // All records have null value → tombstone
+        when(converter.toConnectData(TOPIC, null)).thenReturn(SchemaAndValue.NULL);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Everything should be clean — no connectors, no tasks, no inconsistencies
+        assertEquals(5, configState.offset());
+        assertTrue(configState.connectors().isEmpty());
+        assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
+        assertEquals(Collections.emptyMap(), configStorage.deferredTaskUpdates);
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
     private void verifyConfigure() {
         verify(configStorage).createKafkaBasedLog(capturedTopic.capture(), capturedProducerProps.capture(),
                 capturedConsumerProps.capture(), capturedConsumedCallback.capture(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -148,10 +148,17 @@ public class KafkaConfigBackingStoreTest {
             Collections.singletonMap("config-key-two", "config-value-two"),
             Collections.singletonMap("config-key-three", "config-value-three")
     );
+    // Distinct v2 task configs used to verify that later task configs override earlier ones
+    private static final Map<String, String> SAMPLE_CONFIG_TASK_0_V2 = Collections.singletonMap("config-key-one", "config-value-one-v2");
+    private static final Map<String, String> SAMPLE_CONFIG_TASK_1_V2 = Collections.singletonMap("config-key-two", "config-value-two-v2");
     private static final List<Struct> TASK_CONFIG_STRUCTS = Arrays.asList(
             new Struct(KafkaConfigBackingStore.TASK_CONFIGURATION_V0).put("properties", SAMPLE_CONFIGS.get(0)),
             new Struct(KafkaConfigBackingStore.TASK_CONFIGURATION_V0).put("properties", SAMPLE_CONFIGS.get(1))
     );
+    private static final Struct TASK_CONFIG_STRUCT_0_V2 =
+            new Struct(KafkaConfigBackingStore.TASK_CONFIGURATION_V0).put("properties", SAMPLE_CONFIG_TASK_0_V2);
+    private static final Struct TASK_CONFIG_STRUCT_1_V2 =
+            new Struct(KafkaConfigBackingStore.TASK_CONFIGURATION_V0).put("properties", SAMPLE_CONFIG_TASK_1_V2);
     private static final Struct ONLY_FAILED_MISSING_STRUCT = new Struct(KafkaConfigBackingStore.RESTART_REQUEST_V0).put(INCLUDE_TASKS_FIELD_NAME, false);
     private static final Struct INCLUDE_TASKS_MISSING_STRUCT = new Struct(KafkaConfigBackingStore.RESTART_REQUEST_V0).put(ONLY_FAILED_FIELD_NAME, true);
     private static final List<Struct> RESTART_REQUEST_STRUCTS = Arrays.asList(
@@ -1946,7 +1953,7 @@ public class KafkaConfigBackingStoreTest {
                         CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
                         CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
-                // Second round: task-0-v2, task-1-v2, commit
+                // Second round: task-0-v2, task-1-v2, commit (using distinct configs to prove latest wins)
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
                         CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
@@ -1960,8 +1967,8 @@ public class KafkaConfigBackingStoreTest {
         deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));        // task-0-v1
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));        // task-1-v1
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit-1
-        deserialized.put(CONFIGS_SERIALIZED.get(3), TASK_CONFIG_STRUCTS.get(0));        // task-0-v2
-        deserialized.put(CONFIGS_SERIALIZED.get(4), TASK_CONFIG_STRUCTS.get(1));        // task-1-v2
+        deserialized.put(CONFIGS_SERIALIZED.get(3), TASK_CONFIG_STRUCT_0_V2);           // task-0-v2 (distinct from v1)
+        deserialized.put(CONFIGS_SERIALIZED.get(4), TASK_CONFIG_STRUCT_1_V2);           // task-1-v2 (distinct from v1)
         deserialized.put(CONFIGS_SERIALIZED.get(5), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit-2
         deserialized.put(CONFIGS_SERIALIZED.get(6), CONNECTOR_CONFIG_STRUCTS.get(0));  // connector config
         logOffset = 7;
@@ -1974,13 +1981,14 @@ public class KafkaConfigBackingStoreTest {
         configStorage.start();
 
         ClusterConfigState configState = configStorage.snapshot();
-        // Connector should be fully loaded with v2 task configs
+        // Connector should be fully loaded with v2 task configs (not v1)
         assertEquals(7, configState.offset());
         assertEquals(Collections.singletonList(CONNECTOR_IDS.get(0)), new ArrayList<>(configState.connectors()));
         assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
         assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
-        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(TASK_IDS.get(0)));
-        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(TASK_IDS.get(1)));
+        // Assert v2 task configs are used, proving that later task configs override earlier ones
+        assertEquals(SAMPLE_CONFIG_TASK_0_V2, configState.taskConfig(TASK_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIG_TASK_1_V2, configState.taskConfig(TASK_IDS.get(1)));
         assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
 
         configStorage.stop();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -1663,16 +1663,15 @@ public class KafkaConfigBackingStoreTest {
                         CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
                 // Connector tombstone arrives after orphan task configs
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
-                        null, new RecordHeaders(), Optional.empty()));
+                        CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()));
         LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        deserialized.put(CONFIGS_SERIALIZED.get(3), null);  // tombstone: structToMap(null) → null → SchemaAndValue(null, null)
         logOffset = 4;
 
         expectStart(existingRecords, deserialized);
-        // null value (tombstone) → SchemaAndValue.NULL
-        when(converter.toConnectData(TOPIC, null)).thenReturn(SchemaAndValue.NULL);
         when(configLog.partitionCount()).thenReturn(1);
 
         configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
@@ -1792,21 +1791,24 @@ public class KafkaConfigBackingStoreTest {
         // Simulate: all keys have tombstones (full tombstone deletion)
         List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
                 new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
-                        null, new RecordHeaders(), Optional.empty()),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TARGET_STATE_KEYS.get(0),
-                        null, new RecordHeaders(), Optional.empty()),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
-                        null, new RecordHeaders(), Optional.empty()),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
-                        null, new RecordHeaders(), Optional.empty()),
+                        CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()),
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
-                        null, new RecordHeaders(), Optional.empty()));
+                        CONFIGS_SERIALIZED.get(4), new RecordHeaders(), Optional.empty()));
         LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), null);  // connector tombstone
+        deserialized.put(CONFIGS_SERIALIZED.get(1), null);  // target-state tombstone
+        deserialized.put(CONFIGS_SERIALIZED.get(2), null);  // task-0 tombstone
+        deserialized.put(CONFIGS_SERIALIZED.get(3), null);  // task-1 tombstone
+        deserialized.put(CONFIGS_SERIALIZED.get(4), null);  // commit tombstone
         logOffset = 5;
 
         expectStart(existingRecords, deserialized);
-        // All records have null value → tombstone
-        when(converter.toConnectData(TOPIC, null)).thenReturn(SchemaAndValue.NULL);
         when(configLog.partitionCount()).thenReturn(1);
 
         configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
@@ -1819,6 +1821,167 @@ public class KafkaConfigBackingStoreTest {
         assertTrue(configState.connectors().isEmpty());
         assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
         assertEquals(Collections.emptyMap(), configStorage.deferredTaskUpdates);
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Scenario 7: Delete + recreate same connector.
+     * Config topic: connector config A → tombstone → new connector config B → new tasks → new commit.
+     * Verify the new connector works correctly with configB, old data fully cleaned.
+     */
+    @Test
+    public void testDeleteAndRecreateSameConnector() {
+        // Simulate: connector created, deleted (tombstone), then recreated with different config
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                // Original connector config
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                // Connector tombstone (deletion)
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                // New connector config (recreated with different config)
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
+                // New task-0 config
+                new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()),
+                // New task-1 config
+                new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(4), new RecordHeaders(), Optional.empty()),
+                // New commit (2 tasks)
+                new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(5), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));  // original config A
+        deserialized.put(CONFIGS_SERIALIZED.get(1), null);                              // tombstone
+        deserialized.put(CONFIGS_SERIALIZED.get(2), CONNECTOR_CONFIG_STRUCTS.get(1));  // new config B
+        deserialized.put(CONFIGS_SERIALIZED.get(3), TASK_CONFIG_STRUCTS.get(0));        // task-0
+        deserialized.put(CONFIGS_SERIALIZED.get(4), TASK_CONFIG_STRUCTS.get(1));        // task-1
+        deserialized.put(CONFIGS_SERIALIZED.get(5), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit
+        logOffset = 6;
+
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should be present with the NEW config (configB = SAMPLE_CONFIGS.get(1))
+        assertEquals(6, configState.offset());
+        assertEquals(Collections.singletonList(CONNECTOR_IDS.get(0)), new ArrayList<>(configState.connectors()));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.connectorConfig(CONNECTOR_IDS.get(0)));
+        assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(TASK_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(TASK_IDS.get(1)));
+        assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
+        // deferredTaskUpdates may contain an empty map entry after deferred apply (deferred.clear())
+        Map<ConnectorTaskId, Map<String, String>> deferred = configStorage.deferredTaskUpdates.get(CONNECTOR_IDS.get(0));
+        assertTrue(deferred == null || deferred.isEmpty());
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Scenario 12: Compaction reorder with incomplete task configs.
+     * Config topic: task-0 (no task-1) → commit(tasks:2) → connector config.
+     * Verify connector is in connectors() but marked inconsistent, tasks() returns empty.
+     */
+    @Test
+    public void testCompactionReorderWithIncompleteTaskConfigs() {
+        // Simulate: only task-0 present (task-1 compacted away), then commit, then connector config
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                // Only task-0 config (task-1 was compacted away)
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                // Commit expects 2 tasks
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                // Connector config arrives last (compaction reorder)
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));        // task-0
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit(tasks:2)
+        deserialized.put(CONFIGS_SERIALIZED.get(2), CONNECTOR_CONFIG_STRUCTS.get(0));  // connector config
+        logOffset = 3;
+
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should be present but marked inconsistent (incomplete task set)
+        assertEquals(3, configState.offset());
+        assertTrue(configState.contains(CONNECTOR_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
+        assertTrue(configState.inconsistentConnectors().contains(CONNECTOR_IDS.get(0)));
+        // tasks() returns empty for inconsistent connectors
+        assertEquals(Collections.emptyList(), configState.tasks(CONNECTOR_IDS.get(0)));
+
+        configStorage.stop();
+        verify(configLog).stop();
+    }
+
+    /**
+     * Scenario 6: Compaction reorder with multiple commits (config update).
+     * Config topic: task-0-v1 → task-1-v1 → commit(tasks:2) → task-0-v2 → task-1-v2 → commit(tasks:2) → connector config.
+     * Verify final state uses v2 task configs (latest commit wins).
+     */
+    @Test
+    public void testCompactionReorderWithMultipleCommits() {
+        // Simulate: two rounds of task configs + commits, then connector config arrives last
+        List<ConsumerRecord<String, byte[]>> existingRecords = Arrays.asList(
+                // First round: task-0-v1, task-1-v1, commit
+                new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
+                // Second round: task-0-v2, task-1-v2, commit
+                new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0, 0, TASK_CONFIG_KEYS.get(1),
+                        CONFIGS_SERIALIZED.get(4), new RecordHeaders(), Optional.empty()),
+                new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(5), new RecordHeaders(), Optional.empty()),
+                // Connector config arrives last (compaction reorder)
+                new ConsumerRecord<>(TOPIC, 0, 6, 0L, TimestampType.CREATE_TIME, 0, 0, CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(6), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));        // task-0-v1
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));        // task-1-v1
+        deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit-1
+        deserialized.put(CONFIGS_SERIALIZED.get(3), TASK_CONFIG_STRUCTS.get(0));        // task-0-v2
+        deserialized.put(CONFIGS_SERIALIZED.get(4), TASK_CONFIG_STRUCTS.get(1));        // task-1-v2
+        deserialized.put(CONFIGS_SERIALIZED.get(5), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);  // commit-2
+        deserialized.put(CONFIGS_SERIALIZED.get(6), CONNECTOR_CONFIG_STRUCTS.get(0));  // connector config
+        logOffset = 7;
+
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        // Connector should be fully loaded with v2 task configs
+        assertEquals(7, configState.offset());
+        assertEquals(Collections.singletonList(CONNECTOR_IDS.get(0)), new ArrayList<>(configState.connectors()));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
+        assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(TASK_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(TASK_IDS.get(1)));
+        assertEquals(Collections.emptySet(), configState.inconsistentConnectors());
 
         configStorage.stop();
         verify(configLog).stop();


### PR DESCRIPTION
## Summary

- Revert the problematic fix `83c949f515` which caused E2E test failures
- Apply the correct fix from `fix/KAFKA-17719-full-tombstone-v2` branch

## Problem

The original fix removed the `return` statement in `publishConnectorTaskConfigs()`, causing task configs to be rewritten on every rebalance even when unchanged. This triggers a rebalance storm under `eager` protocol:

```
Rebalance → reconfigureConnector() → write task config → onTaskConfigUpdate()
    → needsReconfigRebalance=true → new Rebalance → loop...
```

Observed: 83 rebalances in 10 minutes, connectors never stabilize.

## Fix Approach

1. Revert the problematic change in `DistributedHerder`
2. Implement deferred processing in `KafkaConfigBackingStore` to handle compaction reorder
3. Write full tombstones on connector deletion to prevent orphaned task configs

## Test Plan

- [x] Unit tests added for compaction reorder scenarios
- [ ] E2E tests should pass with `eager` protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)