### PR TITLE
fix(connect): skip writing unchanged connector config to config topic (KAFKA-17719)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1176,10 +1176,19 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         }
 
                         log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
-                        writeToConfigTopicAsLeader(
-                                "writing a config for connector " + connName + " to the config topic",
-                                () -> configBackingStore.putConnectorConfig(connName, config, targetState)
-                        );
+
+                        // KAFKA-17719: Skip writing to config topic if the connector config is unchanged.
+                        // This avoids unnecessary task config generation which can cause task restarts
+                        // even when the connector configuration hasn't actually changed.
+                        Map<String, String> existingConfig = configState.rawConnectorConfig(connName);
+                        if (exists && config.equals(existingConfig) && targetState == null) {
+                            log.debug("Connector {} config unchanged, skipping write to config topic", connName);
+                        } else {
+                            writeToConfigTopicAsLeader(
+                                    "writing a config for connector " + connName + " to the config topic",
+                                    () -> configBackingStore.putConnectorConfig(connName, config, targetState)
+                            );
+                        }
 
                         // Note that we use the updated connector config despite the fact that we don't have an updated
                         // snapshot yet. The existing task info should still be accurate.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2565,6 +2565,120 @@ public class DistributedHerderTest {
     }
 
     @Test
+    public void testPutConnectorConfigUnchangedSkipsWrite() throws Exception {
+        // KAFKA-17719: Verify that when connector config is unchanged, we skip writing to config topic
+        when(herder.connectorType(anyMap())).thenReturn(ConnectorType.SOURCE);
+        when(member.memberId()).thenReturn("leader");
+        when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
+
+        // The connector is pre-existing with CONN1_CONFIG
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+
+        expectMemberPoll();
+
+        expectRebalance(1, singletonList(CONN1), Collections.emptyList(), true);
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN1_CONFIG), validateCallback.capture());
+
+        // Put the same config (unchanged)
+        FutureCallback<Herder.Created<ConnectorInfo>> putCallback = new FutureCallback<>();
+        herder.putConnectorConfig(CONN1, CONN1_CONFIG, true, putCallback);
+        herder.tick();
+        assertTrue(putCallback.isDone());
+
+        // Verify the callback succeeded
+        Herder.Created<ConnectorInfo> result = putCallback.get();
+        assertFalse(result.created()); // Not newly created
+        assertEquals(CONN1_CONFIG, result.result().config());
+
+        // KAFKA-17719: The key assertion - putConnectorConfig should NOT be called
+        // because the config is unchanged
+        verify(configBackingStore, never()).putConnectorConfig(any(), any(), any());
+        verifyNoMoreInteractions(configBackingStore);
+    }
+
+    @Test
+    public void testPutConnectorConfigUnchangedWithTargetStateStillWrites() throws Exception {
+        // KAFKA-17719: Verify that when connector config is unchanged but targetState is specified,
+        // we still write to config topic (because targetState needs to be updated)
+        when(herder.connectorType(anyMap())).thenReturn(ConnectorType.SOURCE);
+        when(member.memberId()).thenReturn("leader");
+        when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
+
+        // The connector is pre-existing with CONN1_CONFIG
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+
+        expectMemberPoll();
+
+        expectRebalance(1, singletonList(CONN1), Collections.emptyList(), true);
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN1_CONFIG), validateCallback.capture());
+
+        // Put the same config but with a targetState
+        FutureCallback<Herder.Created<ConnectorInfo>> putCallback = new FutureCallback<>();
+        herder.putConnectorConfig(CONN1, CONN1_CONFIG, TargetState.PAUSED, true, putCallback);
+        herder.tick();
+        assertTrue(putCallback.isDone());
+
+        // Verify the callback succeeded
+        Herder.Created<ConnectorInfo> result = putCallback.get();
+        assertFalse(result.created());
+
+        // Even though config is unchanged, putConnectorConfig SHOULD be called because targetState is specified
+        verify(configBackingStore).putConnectorConfig(eq(CONN1), eq(CONN1_CONFIG), eq(TargetState.PAUSED));
+    }
+
+    @Test
+    public void testPatchConnectorConfigUnchangedSkipsWrite() throws Exception {
+        // KAFKA-17719: Verify that PATCH with no actual changes also skips writing to config topic
+        when(herder.connectorType(anyMap())).thenReturn(ConnectorType.SOURCE);
+        when(member.memberId()).thenReturn("leader");
+        when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
+
+        // The connector is pre-existing with CONN1_CONFIG
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+
+        expectMemberPoll();
+
+        expectRebalance(1, singletonList(CONN1), Collections.emptyList(), true);
+
+        // Patch with values that result in the same config (setting existing values)
+        Map<String, String> noOpPatch = new HashMap<>();
+        noOpPatch.put(ConnectorConfig.NAME_CONFIG, CONN1); // Same as existing
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN1_CONFIG), validateCallback.capture());
+
+        FutureCallback<Herder.Created<ConnectorInfo>> patchCallback = new FutureCallback<>();
+        herder.patchConnectorConfig(CONN1, noOpPatch, patchCallback);
+        herder.tick();
+        assertTrue(patchCallback.isDone());
+
+        // Verify the callback succeeded
+        Herder.Created<ConnectorInfo> result = patchCallback.get();
+        assertFalse(result.created());
+        assertEquals(CONN1_CONFIG, result.result().config());
+
+        // KAFKA-17719: putConnectorConfig should NOT be called because the patched config equals existing
+        verify(configBackingStore, never()).putConnectorConfig(any(), any(), any());
+        verifyNoMoreInteractions(configBackingStore);
+    }
+
+    @Test
     public void testKeyRotationWhenWorkerBecomesLeader() {
         long rotationTtlDelay = DistributedConfig.INTER_WORKER_KEY_TTL_MS_MS_DEFAULT;
         when(member.memberId()).thenReturn("member");


### PR DESCRIPTION
## Summary

Cherry-pick from 1.6 branch (#3292).

When PUT/PATCH connector config API is called with the same configuration, skip writing to config topic to avoid unnecessary connector/task restarts.

**Problem:**
- Even when connector config is unchanged, writing to config topic triggers the full reconfiguration chain: `onConnectorConfigUpdate` -> connector restart -> task config regeneration -> task restarts
- This causes unnecessary service disruption

**Solution:**
- In `doPutConnectorConfig()`, compare new config with existing `rawConnectorConfig`
- Skip write if: connector exists AND config unchanged AND no targetState change
- Still write when targetState is specified (e.g., PAUSED) even if config unchanged

## Code Review Verification

| Check | Result |
|-------|--------|
| Uses `rawConnectorConfig()` for comparison | ✅ Matches config topic format |
| `targetState == null` condition | ✅ State changes are not skipped |
| `exists` condition | ✅ New connector creation is not skipped |
| PATCH scenario | ✅ Works correctly (`connectorInfo.config()` returns rawConnectorConfig) |
| API response behavior | ✅ Unchanged (returns `Created<ConnectorInfo>` as before) |
| Task config rewriting | ✅ No impact (handled separately in `publishConnectorTaskConfigs`) |

## Behavior Change

- Users can no longer trigger connector restart by PUT-ing identical config
- Use `POST /connectors/{name}/restart?includeTasks=true` for explicit restart

## Test Plan

- [x] `testPutConnectorConfigUnchangedSkipsWrite` - PUT same config skips write
- [x] `testPutConnectorConfigUnchangedWithTargetStateStillWrites` - PUT same config with targetState still writes
- [x] `testPatchConnectorConfigUnchangedSkipsWrite` - PATCH with no actual changes skips write

## Related Issue

https://issues.apache.org/jira/browse/KAFKA-17719

🤖 Generated with [Claude Code](https://claude.ai/code)