### PR TITLE
docs: add Kafka compatibility documentation (fixes #3301)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,50 @@
+# Compatibility with Apache Kafka
+
+AutoMQ is a next-generation Apache Kafka® distribution redesigned based on cloud-native concepts. It is fully compatible with the Apache Kafka® protocol and features.
+
+## Architecture & Compatibility Approach
+
+In terms of technical architecture, AutoMQ reuses the compute layer code of Apache Kafka® and only replaces minimal components at the storage layer. This ensures complete compatibility with the relevant versions of Apache Kafka®. Applications based on Apache Kafka® can be seamlessly migrated to AutoMQ.
+
+AutoMQ employs a micro-layer storage replacement method to adapt to Apache Kafka, enabling rapid updates to new community versions and supporting the latest Apache Kafka version updates as quickly as within **T+1 month**.
+
+During the compatibility verification phase, AutoMQ used Apache Kafka® test case projects and successfully passed the relevant version tests.
+
+## Version Compatibility Matrix
+
+The following table shows the compatibility relationship between AutoMQ releases and the Apache Kafka versions they are based on:
+
+| AutoMQ Version | Based on Apache Kafka | Backward Compatible With Kafka Clients | Status          |
+|----------------|-----------------------|----------------------------------------|-----------------|
+| v1.6.x         | 3.9.x                | 0.9.x – 3.9.x                         | Latest (v1.6.5) |
+| v1.5.x         | 3.8.x                | 0.9.x – 3.8.x                         | Stable          |
+| v1.4.x         | 3.8.x                | 0.9.x – 3.8.x                         | Stable          |
+| v1.1.x – v1.3.x | 3.7.x              | 0.9.x – 3.7.x                         | Stable          |
+| v1.0.x         | 3.4.x                | 0.9.x – 3.4.x                         | Legacy          |
+
+> **Note:** AutoMQ versions align directly with Apache Kafka versions. Each AutoMQ version is compatible with the Kafka Client, Connector, Kafka Streams, and other components within the Apache Kafka ecosystem for the corresponding Kafka version range.
+
+## Kafka 4.x Compatibility
+
+As of AutoMQ v1.6.5, the project has **not** yet adopted Apache Kafka 4.x. The current latest adapted version is Apache Kafka **3.9.x**. Once Apache Kafka 4.x support is implemented, this document will be updated accordingly.
+
+## Ecosystem Compatibility
+
+AutoMQ is compatible with the following components from the Apache Kafka ecosystem:
+
+- **Kafka Clients** (Producer / Consumer API)
+- **Kafka Connect** (Source & Sink Connectors)
+- **Kafka Streams**
+- **Schema Registry** (Confluent-compatible)
+- **Kafka Proxy**
+- **MirrorMaker 2**
+
+## Further Resources
+
+- [AutoMQ Documentation](https://www.automq.com/docs/automq/what-is-automq/overview)
+- [AutoMQ GitHub Repository](https://github.com/AutoMQ/automq)
+- [Apache Kafka Compatibility Wiki](https://github.com/AutoMQ/automq/wiki/Compatibility-with-Apache-Kafka) *(Note: Wiki might be outdated)*
+
+## Trademarks
+
+Apache®, Apache Kafka®, Kafka®, and associated open source project names are trademarks of the Apache Software Foundation.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Here are some key highlights of AutoMQ that make it an ideal choice to replace y
     - High throughput: Leverage pre-fetching, batch processing, and parallel technologies to maximize the capabilities of cloud object storage. Refer to the [AutoMQ Performance White Paper](https://www.automq.com/docs/automq/benchmarks/automq-vs-apache-kafka-benchmarks-and-cost?utm_source=github_automq) to see how we achieve this.
     - Low Latency: AutoMQ defaults to running on S3 directly, resulting in hundreds of milliseconds of latency. The enterprise version offers single-digit millisecond latency. [Contact us](https://www.automq.com/contact?utm_source=github_automq) for more details.
 - **Built-in Metrics Export**: Natively export Prometheus and OpenTelemetry metrics, supporting both push and pull. Ditch inefficient JMX and monitor your cluster with modern tools. Refer to [full metrics list](https://www.automq.com/docs/automq/observability/metrics?utm_source=github_automq) provided by AutoMQ.
-- **100% Kafka Compatible**: Fully compatible with Apache Kafka, offering all features with greater cost-effectiveness and operational efficiency.
+- **100% Kafka Compatible**: Built on Apache Kafka 3.9.x. Fully compatible with Apache Kafka protocols and features, including Kafka Client, Connector, and other ecosystem components (backward compatible with Kafka 0.9.x through 3.9.x). See [COMPATIBILITY.md](COMPATIBILITY.md) for the detailed version mapping.
 
 ## ✨Architecture
 AutoMQ is a fork of the open-source [Apache Kafka](https://github.com/apache/kafka). We've introduced a new storage engine based on object storage, transforming the classic shared-nothing architecture into a shared storage architecture.


### PR DESCRIPTION
Fixes #3301

Hello,  

I noticed in Kafka compatibility wiki page(https://github.com/AutoMQ/automq/wiki/Compatibility-with-Apache-Kafka) is outdated .It still mentions v1.1.x as an upcoming release with Kafka 3.7.x, while AutoMQ is already at v1.6.5 running on Kafka 3.9.x 

Since wiki pages can't be updated through a PR, I went ahead and created a new `COMPATIBILITY.md` in the repo root that covers:

A clear version matrix mapping AutoMQ releases to their Apache Kafka base (v1.0.x through v1.6.x)
A note clarifying that Kafka 4.x hasn't been adopted yet (which was the reporter's main question)
Ecosystem compatibility info (Clients, Connect, Streams, etc.)

I also updated the "100% Kafka Compatible" line in README.md to mention the actual version (3.9.x) and link to the new doc.

Version info was pulled from `gradle.properties`, `docs/js/templateData.js`, and the v1.6.5 release notes. The older version mappings (v1.0.x–v1.5.x) are based on what the wiki originally had, so please correct anything in this PR if you found any mismatches. 

This is a docs only change. No code involved.


