### PR TITLE
feat(kv): add namespace support for KV store

### DIFF
--- a/clients/src/main/resources/common/message/DeleteKVsRequest.json
+++ b/clients/src/main/resources/common/message/DeleteKVsRequest.json
@@ -21,7 +21,7 @@
     "broker"
   ],
   "name": "DeleteKVsRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -35,6 +35,14 @@
           "type": "string",
           "versions": "0+",
           "about": "Key is the key to delete"
+        },
+        {
+          "name": "Namespace",
+          "type": "string",
+          "versions": "1+",
+          "nullableVersions": "1+",
+          "default": "null",
+          "about": "The namespace for the key"
         }
       ]
     }

--- a/clients/src/main/resources/common/message/GetKVsRequest.json
+++ b/clients/src/main/resources/common/message/GetKVsRequest.json
@@ -21,7 +21,7 @@
     "broker"
   ],
   "name": "GetKVsRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -35,6 +35,14 @@
           "type": "string",
           "versions": "0+",
           "about": "Key is the key to get"
+        },
+        {
+          "name": "Namespace",
+          "type": "string",
+          "versions": "1+",
+          "nullableVersions": "1+",
+          "default": "null",
+          "about": "The namespace for the key"
         }
       ]
     }

--- a/clients/src/main/resources/common/message/PutKVsRequest.json
+++ b/clients/src/main/resources/common/message/PutKVsRequest.json
@@ -21,7 +21,7 @@
     "broker"
   ],
   "name": "PutKVsRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -47,6 +47,14 @@
           "type": "bool",
           "versions": "0+",
           "about": "overwrite put kv"
+        },
+        {
+          "name": "Namespace",
+          "type": "string",
+          "versions": "1+",
+          "nullableVersions": "1+",
+          "default": "null",
+          "about": "The namespace for the key-value entry"
         }
       ]
     }

--- a/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
+++ b/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
@@ -19,6 +19,7 @@
 
 package kafka.automq.zerozone;
 
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.controller.stream.RouterChannelEpoch;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -125,7 +126,7 @@ public class DefaultRouterChannelProvider implements RouterChannelProvider {
         if (delta.kvDelta() == null) {
             return;
         }
-        ByteBuffer value = delta.kvDelta().changedKV().get(RouterChannelEpoch.ROUTER_CHANNEL_EPOCH_KEY);
+        ByteBuffer value = delta.kvDelta().changedKV().get(KVKey.of(RouterChannelEpoch.ROUTER_CHANNEL_EPOCH_KEY));
         if (value == null) {
             return;
         }

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.message._
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataResponse
+import org.apache.kafka.controller.stream.KVKey
 import org.apache.kafka.image.{MetadataImage, S3StreamMetadataImage}
 import org.apache.kafka.metadata.{BrokerRegistration, PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.automq.AutoMQVersion
@@ -97,7 +98,7 @@ class KRaftMetadataCache(
   private def checkFailoverSuccess(topicPartition: TopicPartition, topicId: Uuid, tpRegistration: PartitionRegistration): Boolean = {
     safeRun((image: MetadataImage) => {
       val key = ElasticLog.formatStreamKey(ElasticLogManager.NAMESPACE, topicPartition, Some(topicId))
-      val buffer = image.kv().getValue(key)
+      val buffer = image.kv().getValue(KVKey.of(key))
       if (buffer == null) {
         // when immediately request after topic creation, the key may not be found
         return false
@@ -668,7 +669,7 @@ class KRaftMetadataCache(
   }
 
   override def getValue(key: String): ByteBuffer = {
-    _currentImage.kv().getValue(key)
+    _currentImage.kv().getValue(KVKey.of(key))
   }
 
   override def getStreamEndOffset(streamId: Long): OptionalLong = {

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2139,9 +2139,6 @@ public final class QuorumController implements Controller {
         this.time = time;
         this.controllerMetrics = controllerMetrics;
         this.snapshotRegistry = new SnapshotRegistry(logContext);
-        // AutoMQ for Kafka inject start
-        this.kvControlManager = new KVControlManager(snapshotRegistry, logContext);
-        // AutoMQ for Kafka inject end
         this.deferredEventQueue = new DeferredEventQueue(logContext);
         this.deferredUnstableEventQueue = new DeferredEventQueue(logContext);
         this.offsetControl = new OffsetControlManager.Builder().
@@ -2178,6 +2175,9 @@ public final class QuorumController implements Controller {
             setMetadataVersion(MetadataVersion.MINIMUM_KRAFT_VERSION).
             setClusterFeatureSupportDescriber(clusterSupportDescriber).
             build();
+        // AutoMQ for Kafka inject start
+        this.kvControlManager = new KVControlManager(snapshotRegistry, logContext, featureControl::autoMQVersion);
+        // AutoMQ for Kafka inject end
         this.clusterControl = new ClusterControlManager.Builder().
             setLogContext(logContext).
             setClusterId(clusterId).

--- a/metadata/src/main/java/org/apache/kafka/controller/stream/KVControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/KVControlManager.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metadata.RemoveKVRecord;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.controller.ControllerResult;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 
@@ -38,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.apache.kafka.common.protocol.Errors.KEY_EXIST;
 import static org.apache.kafka.common.protocol.Errors.KEY_NOT_EXIST;
@@ -46,30 +48,38 @@ public class KVControlManager {
 
     private final SnapshotRegistry registry;
     private final Logger log;
-    private final TimelineHashMap<String, ByteBuffer> kv;
+    private final TimelineHashMap<KVKey, ByteBuffer> kv;
+    private final Supplier<AutoMQVersion> autoMQVersionSupplier;
 
-    public KVControlManager(SnapshotRegistry registry, LogContext logContext) {
+    public KVControlManager(SnapshotRegistry registry, LogContext logContext,
+        Supplier<AutoMQVersion> autoMQVersionSupplier) {
         this.registry = registry;
         this.log = logContext.logger(KVControlManager.class);
         this.kv = new TimelineHashMap<>(registry, 0);
+        this.autoMQVersionSupplier = autoMQVersionSupplier;
     }
 
     public GetKVResponse getKV(GetKVRequest request) {
-        String key = request.key();
-        byte[] value = kv.containsKey(key) ? kv.get(key).array() : null;
+        KVKey kvKey = KVKey.of(request.namespace(), request.key());
+        byte[] value = kv.containsKey(kvKey) ? kv.get(kvKey).array() : null;
         return new GetKVResponse()
             .setValue(value);
     }
 
     public ControllerResult<PutKVResponse> putKV(PutKVRequest request) {
+        AutoMQVersion version = autoMQVersionSupplier.get();
+        String namespace = version.isKVNamespaceSupported() ? request.namespace() : null;
         String key = request.key();
-        ByteBuffer value = kv.get(key);
+        KVKey kvKey = KVKey.of(namespace, key);
+        ByteBuffer value = kv.get(kvKey);
         if (value == null || request.overwrite()) {
             // generate kv record
             ApiMessageAndVersion record = new ApiMessageAndVersion(new KVRecord()
                 .setKeyValues(Collections.singletonList(new KeyValue()
                     .setKey(key)
-                    .setValue(request.value()))), (short) 0);
+                    .setValue(request.value())
+                    .setNamespace(namespace))),
+                version.kvRecordVersion());
             return ControllerResult.of(Collections.singletonList(record), new PutKVResponse().setValue(request.value()));
         }
         // exist and not allow overwriting
@@ -80,12 +90,20 @@ public class KVControlManager {
 
     public ControllerResult<DeleteKVResponse> deleteKV(DeleteKVRequest request) {
         log.trace("DeleteKVRequestData: {}", request);
+        AutoMQVersion version = autoMQVersionSupplier.get();
+        String namespace = version.isKVNamespaceSupported() ? request.namespace() : null;
+        KVKey kvKey = KVKey.of(namespace, request.key());
         DeleteKVResponse resp = new DeleteKVResponse();
-        ByteBuffer value = kv.get(request.key());
+        ByteBuffer value = kv.get(kvKey);
         if (value != null) {
             // generate remove-kv record
-            ApiMessageAndVersion record = new ApiMessageAndVersion(new RemoveKVRecord()
-                .setKeys(Collections.singletonList(request.key())), (short) 0);
+            RemoveKVRecord removeRecord = new RemoveKVRecord()
+                .setKeys(Collections.singletonList(kvKey.key()));
+            if (namespace != null) {
+                removeRecord.setNamespaces(Collections.singletonList(namespace));
+            }
+            ApiMessageAndVersion record = new ApiMessageAndVersion(removeRecord,
+                version.isKVNamespaceSupported() ? (short) 1 : (short) 0);
             return ControllerResult.of(Collections.singletonList(record), resp.setValue(value.array()));
         }
         return ControllerResult.of(Collections.emptyList(), resp.setErrorCode(KEY_NOT_EXIST.code()));
@@ -94,18 +112,24 @@ public class KVControlManager {
     public void replay(KVRecord record) {
         List<KeyValue> keyValues = record.keyValues();
         for (KeyValue keyValue : keyValues) {
-            kv.put(keyValue.key(), ByteBuffer.wrap(keyValue.value()));
+            kv.put(KVKey.of(keyValue.namespace(), keyValue.key()), ByteBuffer.wrap(keyValue.value()));
         }
     }
 
     public void replay(RemoveKVRecord record) {
         List<String> keys = record.keys();
-        for (String key : keys) {
-            kv.remove(key);
+        List<String> namespaces = record.namespaces();
+        if (namespaces != null && namespaces.size() != keys.size()) {
+            throw new IllegalArgumentException("RemoveKVRecord: namespaces length " + namespaces.size()
+                + " does not match keys length " + keys.size());
+        }
+        for (int i = 0; i < keys.size(); i++) {
+            String ns = namespaces != null ? namespaces.get(i) : null;
+            kv.remove(KVKey.of(ns, keys.get(i)));
         }
     }
 
-    public Map<String, ByteBuffer> kv() {
+    public Map<KVKey, ByteBuffer> kv() {
         return kv;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/stream/KVKey.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/KVKey.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller.stream;
+
+import java.util.Objects;
+
+/**
+ * Composite key for KV store entries, combining an optional namespace with a key.
+ * A null namespace represents legacy (v0) records with no namespace.
+ */
+public class KVKey {
+    private final String namespace;
+    private final String key;
+
+    private KVKey(String namespace, String key) {
+        this.namespace = namespace;
+        this.key = key;
+    }
+
+    public static KVKey of(String key) {
+        return new KVKey(null, key);
+    }
+
+    public static KVKey of(String namespace, String key) {
+        return new KVKey(namespace, key);
+    }
+
+    public String namespace() {
+        return namespace;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof KVKey)) return false;
+        KVKey other = (KVKey) o;
+        return Objects.equals(namespace, other.namespace) && Objects.equals(key, other.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, key);
+    }
+
+    @Override
+    public String toString() {
+        return namespace == null ? key : namespace + "/" + key;
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/stream/TopicDeletionManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/TopicDeletionManager.java
@@ -119,7 +119,7 @@ public class TopicDeletionManager {
             String metaStreamKvPrefix = ObjectUtils.genMetaStreamKvPrefix(topicId);
             kvControlManager.kv().forEach((k, v) -> {
                 if (k.key().startsWith(metaStreamKvPrefix)) {
-                    metaStreamKvList.add(k.toString());
+                    metaStreamKvList.add(k.key());
                 }
             });
             records.add(new ApiMessageAndVersion(new RemoveKVRecord().setKeys(metaStreamKvList), (short) 0));

--- a/metadata/src/main/java/org/apache/kafka/controller/stream/TopicDeletionManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/TopicDeletionManager.java
@@ -118,8 +118,8 @@ public class TopicDeletionManager {
             List<String> metaStreamKvList = new ArrayList<>();
             String metaStreamKvPrefix = ObjectUtils.genMetaStreamKvPrefix(topicId);
             kvControlManager.kv().forEach((k, v) -> {
-                if (k.startsWith(metaStreamKvPrefix)) {
-                    metaStreamKvList.add(k);
+                if (k.key().startsWith(metaStreamKvPrefix)) {
+                    metaStreamKvList.add(k.toString());
                 }
             });
             records.add(new ApiMessageAndVersion(new RemoveKVRecord().setKeys(metaStreamKvList), (short) 0));

--- a/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
@@ -19,19 +19,21 @@ package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.KVRecord;
 import org.apache.kafka.common.metadata.RemoveKVRecord;
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.timeline.TimelineHashMap;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public final class KVDelta {
     private final KVImage image;
 
-    private final Map<String/*key*/, ByteBuffer/*value*/> changedKV = new HashMap<>();
-    private final Set<String/*key*/> removedKeys = new HashSet<>();
+    private final Map<KVKey, ByteBuffer> changedKV = new HashMap<>();
+    private final Set<KVKey> removedKeys = new HashSet<>();
 
     public KVDelta(KVImage image) {
         this.image = image;
@@ -43,22 +45,31 @@ public final class KVDelta {
 
     public void replay(KVRecord record) {
         record.keyValues().forEach(keyValue -> {
-            changedKV.put(keyValue.key(), ByteBuffer.wrap(keyValue.value()));
-            removedKeys.remove(keyValue.key());
+            KVKey kvKey = KVKey.of(keyValue.namespace(), keyValue.key());
+            changedKV.put(kvKey, ByteBuffer.wrap(keyValue.value()));
+            removedKeys.remove(kvKey);
         });
     }
 
     public void replay(RemoveKVRecord record) {
-        record.keys().forEach(key -> {
-            removedKeys.add(key);
-            changedKV.remove(key);
-        });
+        List<String> keys = record.keys();
+        List<String> namespaces = record.namespaces();
+        if (namespaces != null && namespaces.size() != keys.size()) {
+            throw new IllegalArgumentException("RemoveKVRecord: namespaces length " + namespaces.size()
+                + " does not match keys length " + keys.size());
+        }
+        for (int i = 0; i < keys.size(); i++) {
+            String ns = namespaces != null ? namespaces.get(i) : null;
+            KVKey kvKey = KVKey.of(ns, keys.get(i));
+            removedKeys.add(kvKey);
+            changedKV.remove(kvKey);
+        }
     }
 
     public KVImage apply() {
         RegistryRef registry = image.registryRef();
         // get original objects first
-        TimelineHashMap<String, ByteBuffer> newKVs;
+        TimelineHashMap<KVKey, ByteBuffer> newKVs;
 
         if (registry == RegistryRef.NOOP) {
             registry = new RegistryRef();
@@ -67,7 +78,8 @@ public final class KVDelta {
             newKVs = image.timelineKVs();
         }
 
-        registry.inLock(() -> {
+        RegistryRef finalRegistry = registry;
+        finalRegistry.inLock(() -> {
             newKVs.putAll(changedKV);
             removedKeys.forEach(newKVs::remove);
         });
@@ -77,7 +89,7 @@ public final class KVDelta {
         return new KVImage(newKVs, registry);
     }
 
-    public Map<String, ByteBuffer> changedKV() {
+    public Map<KVKey, ByteBuffer> changedKV() {
         return changedKV;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/KVImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/KVImage.java
@@ -20,18 +20,20 @@ package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.KVRecord;
 import org.apache.kafka.common.metadata.KVRecord.KeyValue;
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.timeline.TimelineHashMap;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
@@ -41,34 +43,32 @@ public final class KVImage extends AbstractReferenceCounted {
 
     private final RegistryRef registryRef;
 
-    private final TimelineHashMap<String, ByteBuffer> kv;
+    private final TimelineHashMap<KVKey, ByteBuffer> kv;
 
-    public KVImage(TimelineHashMap<String, ByteBuffer> kv, RegistryRef registryRef) {
+    public KVImage(TimelineHashMap<KVKey, ByteBuffer> kv, RegistryRef registryRef) {
         this.registryRef = registryRef;
         this.kv = kv;
     }
 
-    public ByteBuffer getValue(String key) {
+    public ByteBuffer getValue(KVKey kvKey) {
         if (kv == null || registryRef == RegistryRef.NOOP) {
             return null;
         }
-
-        return registryRef.inLock(() -> this.kv.get(key, registryRef.epoch()));
+        return registryRef.inLock(() -> this.kv.get(kvKey, registryRef.epoch()));
     }
 
-    public Map<String, ByteBuffer> kvs() {
+    public Map<KVKey, ByteBuffer> kvs() {
         if (kv == null || registryRef == RegistryRef.NOOP) {
             return Collections.emptyMap();
         }
-
         return registryRef.inLock(() -> {
-            Map<String, ByteBuffer> result = new HashMap<>();
+            Map<KVKey, ByteBuffer> result = new HashMap<>();
             kv.entrySet(registryRef().epoch()).forEach(e -> result.put(e.getKey(), e.getValue()));
             return result;
         });
     }
 
-    public TimelineHashMap<String, ByteBuffer> timelineKVs() {
+    public TimelineHashMap<KVKey, ByteBuffer> timelineKVs() {
         return kv;
     }
 
@@ -81,14 +81,19 @@ public final class KVImage extends AbstractReferenceCounted {
             return;
         }
 
-        List<List<KeyValue>> keyValues = registryRef.inLock(() -> kv.entrySet(registryRef.epoch())
-            .stream()
-            .map(e -> List.of(new KeyValue().setKey(e.getKey()).setValue(e.getValue().array())))
-            .collect(Collectors.toList()));
+        AutoMQVersion autoMQVersion = options.metadataVersion().autoMQVersion();
+        short kvVersion = autoMQVersion.kvRecordVersion();
 
-        keyValues.forEach(kvs -> {
+        List<Map.Entry<KVKey, ByteBuffer>> entries = registryRef.inLock(() ->
+            new ArrayList<>(kv.entrySet(registryRef.epoch())));
+
+        entries.forEach(e -> {
+            KVKey kvKey = e.getKey();
+            String namespace = kvVersion >= 1 ? kvKey.namespace() : null;
             writer.write(new ApiMessageAndVersion(new KVRecord()
-                .setKeyValues(kvs), (short) 0));
+                .setKeyValues(Collections.singletonList(
+                    new KeyValue().setKey(kvKey.key()).setValue(e.getValue().array()).setNamespace(namespace))),
+                kvVersion));
         });
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/node/automq/KVImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/automq/KVImageNode.java
@@ -26,11 +26,15 @@ import org.apache.kafka.image.node.MetadataNode;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 public class KVImageNode implements MetadataNode {
     public static final String NAME = "kv";
+    /** Node name used for KV entries that have no namespace (legacy v0 records). */
+    public static final String DEFAULT_NAMESPACE = "__automq_default";
+
     private final KVImage kvImage;
 
     public KVImageNode(KVImage kvImage) {
@@ -39,19 +43,54 @@ public class KVImageNode implements MetadataNode {
 
     @Override
     public Collection<String> childNames() {
-        List<String> keys = new LinkedList<>();
-        kvImage.kvs().forEach((k, v) -> keys.add(k));
-        return keys;
+        // Return the set of namespace node names
+        Map<String, Object> namespaces = new HashMap<>();
+        kvImage.kvs().forEach((k, v) -> namespaces.put(nodeName(k.namespace()), null));
+        return namespaces.keySet();
     }
 
     @Override
     public MetadataNode child(String name) {
-        ByteBuffer valueBuf = kvImage.getValue(name);
-        if (valueBuf == null) {
+        // name is a namespace node name; return a sub-node for that namespace
+        String namespace = name.equals(DEFAULT_NAMESPACE) ? null : name;
+        Map<String, ByteBuffer> entries = new HashMap<>();
+        kvImage.kvs().forEach((k, v) -> {
+            if (Objects.equals(k.namespace(), namespace)) {
+                entries.put(k.key(), v);
+            }
+        });
+        if (entries.isEmpty()) {
             return null;
         }
-        byte[] value = new byte[valueBuf.remaining()];
-        valueBuf.duplicate().get(value);
-        return new MetadataLeafNode(Arrays.toString(value));
+        return new NamespaceNode(entries);
+    }
+
+    private static String nodeName(String namespace) {
+        return namespace == null ? DEFAULT_NAMESPACE : namespace;
+    }
+
+    /** A directory node representing one namespace, whose children are the KV keys. */
+    private static class NamespaceNode implements MetadataNode {
+        private final Map<String, ByteBuffer> entries;
+
+        NamespaceNode(Map<String, ByteBuffer> entries) {
+            this.entries = entries;
+        }
+
+        @Override
+        public Collection<String> childNames() {
+            return entries.keySet();
+        }
+
+        @Override
+        public MetadataNode child(String name) {
+            ByteBuffer valueBuf = entries.get(name);
+            if (valueBuf == null) {
+                return null;
+            }
+            byte[] value = new byte[valueBuf.remaining()];
+            valueBuf.duplicate().get(value);
+            return new MetadataLeafNode(Arrays.toString(value));
+        }
     }
 }

--- a/metadata/src/main/resources/common/metadata/KVRecord.json
+++ b/metadata/src/main/resources/common/metadata/KVRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 516,
   "type": "metadata",
   "name": "KVRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -37,6 +37,14 @@
           "type": "bytes",
           "versions": "0+",
           "about": "Value"
+        },
+        {
+          "name": "Namespace",
+          "type": "string",
+          "versions": "1+",
+          "nullableVersions": "1+",
+          "default": "null",
+          "about": "The namespace for the key-value entry"
         }
       ]
     }

--- a/metadata/src/main/resources/common/metadata/RemoveKVRecord.json
+++ b/metadata/src/main/resources/common/metadata/RemoveKVRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 517,
   "type": "metadata",
   "name": "RemoveKVRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -25,6 +25,14 @@
       "type": "[]string",
       "versions": "0+",
       "about": "Keys"
+    },
+    {
+      "name": "Namespaces",
+      "type": "[]string",
+      "versions": "1+",
+      "nullableVersions": "1+",
+      "default": "null",
+      "about": "Namespaces corresponding to each key"
     }
   ]
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -55,6 +55,7 @@ import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.common.TestFeatureVersion;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.Assertions;
@@ -891,7 +892,7 @@ public class ClusterControlManagerTest {
     public void testReusableNodeIds() {
         MockTime time = new MockTime(0, 0, 0);
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        KVControlManager kvControl = new KVControlManager(snapshotRegistry, new LogContext());
+        KVControlManager kvControl = new KVControlManager(snapshotRegistry, new LogContext(), () -> AutoMQVersion.LATEST);
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,

--- a/metadata/src/test/java/org/apache/kafka/controller/KVControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/KVControlManagerTest.java
@@ -30,7 +30,9 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.controller.stream.KVControlManager;
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,11 +40,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(40)
 @Tag("S3Unit")
@@ -54,7 +59,7 @@ public class KVControlManagerTest {
     public void setUp() {
         LogContext logContext = new LogContext();
         SnapshotRegistry registry = new SnapshotRegistry(logContext);
-        this.manager = new KVControlManager(registry, logContext);
+        this.manager = new KVControlManager(registry, logContext, () -> AutoMQVersion.LATEST);
     }
 
     @Test
@@ -111,6 +116,118 @@ public class KVControlManagerTest {
             .setKey("key1"));
         assertEquals(0, result3.records().size());
         assertEquals(Errors.KEY_NOT_EXIST.code(), result3.response().errorCode());
+    }
+
+    @Test
+    public void testNamespaceIsolation() {
+        // Put same key in two different namespaces
+        ControllerResult<PutKVResponse> r1 = manager.putKV(new PutKVRequest()
+            .setKey("key1").setValue("ns1-value".getBytes()).setNamespace("ns1"));
+        assertEquals(Errors.NONE.code(), r1.response().errorCode());
+        replay(manager, r1.records());
+
+        ControllerResult<PutKVResponse> r2 = manager.putKV(new PutKVRequest()
+            .setKey("key1").setValue("ns2-value".getBytes()).setNamespace("ns2"));
+        assertEquals(Errors.NONE.code(), r2.response().errorCode());
+        replay(manager, r2.records());
+
+        // Each namespace sees its own value
+        assertEquals("ns1-value", new String(manager.getKV(new GetKVRequest().setKey("key1").setNamespace("ns1")).value()));
+        assertEquals("ns2-value", new String(manager.getKV(new GetKVRequest().setKey("key1").setNamespace("ns2")).value()));
+
+        // Null namespace does not see namespaced entries
+        assertNull(manager.getKV(new GetKVRequest().setKey("key1")).value());
+    }
+
+    @Test
+    public void testNamespacedDelete() {
+        ControllerResult<PutKVResponse> put = manager.putKV(new PutKVRequest()
+            .setKey("key1").setValue("value".getBytes()).setNamespace("ns1"));
+        replay(manager, put.records());
+
+        // Delete from wrong namespace → not found
+        ControllerResult<DeleteKVResponse> miss = manager.deleteKV(new DeleteKVRequest()
+            .setKey("key1").setNamespace("ns2"));
+        assertEquals(Errors.KEY_NOT_EXIST.code(), miss.response().errorCode());
+        assertEquals(0, miss.records().size());
+
+        // Delete from correct namespace → success
+        ControllerResult<DeleteKVResponse> del = manager.deleteKV(new DeleteKVRequest()
+            .setKey("key1").setNamespace("ns1"));
+        assertEquals(Errors.NONE.code(), del.response().errorCode());
+        assertEquals("value", new String(del.response().value()));
+        replay(manager, del.records());
+
+        assertNull(manager.getKV(new GetKVRequest().setKey("key1").setNamespace("ns1")).value());
+    }
+
+    @Test
+    public void testNamespacedOverwrite() {
+        manager.putKV(new PutKVRequest().setKey("k").setValue("v1".getBytes()).setNamespace("ns"));
+        ControllerResult<PutKVResponse> put1 = manager.putKV(new PutKVRequest()
+            .setKey("k").setValue("v1".getBytes()).setNamespace("ns"));
+        replay(manager, put1.records());
+
+        // Overwrite=false → KEY_EXIST
+        ControllerResult<PutKVResponse> put2 = manager.putKV(new PutKVRequest()
+            .setKey("k").setValue("v2".getBytes()).setNamespace("ns"));
+        assertEquals(Errors.KEY_EXIST.code(), put2.response().errorCode());
+
+        // Overwrite=true → success
+        ControllerResult<PutKVResponse> put3 = manager.putKV(new PutKVRequest()
+            .setKey("k").setValue("v2".getBytes()).setNamespace("ns").setOverwrite(true));
+        assertEquals(Errors.NONE.code(), put3.response().errorCode());
+        replay(manager, put3.records());
+
+        assertEquals("v2", new String(manager.getKV(new GetKVRequest().setKey("k").setNamespace("ns")).value()));
+    }
+
+    @Test
+    public void testNullAndNamespacedCoexist() {
+        ControllerResult<PutKVResponse> p1 = manager.putKV(new PutKVRequest()
+            .setKey("k").setValue("no-ns".getBytes()));
+        replay(manager, p1.records());
+
+        ControllerResult<PutKVResponse> p2 = manager.putKV(new PutKVRequest()
+            .setKey("k").setValue("with-ns".getBytes()).setNamespace("ns"));
+        replay(manager, p2.records());
+
+        assertEquals("no-ns", new String(manager.getKV(new GetKVRequest().setKey("k")).value()));
+        assertEquals("with-ns", new String(manager.getKV(new GetKVRequest().setKey("k").setNamespace("ns")).value()));
+    }
+
+    @Test
+    public void testReplayRemoveKVRecord() {
+        // Setup: put a null-namespace kv and a namespaced kv
+        KVRecord kvRecord = new KVRecord().setKeyValues(List.of(
+            new KVRecord.KeyValue().setKey("k1").setValue("v1".getBytes())));
+        manager.replay(kvRecord);
+        KVRecord nsKvRecord = new KVRecord().setKeyValues(List.of(
+            new KVRecord.KeyValue().setKey("k1").setValue("v2".getBytes()).setNamespace("ns")));
+        manager.replay(nsKvRecord);
+
+        // 1) Null namespaces (v0 record) removes old-style null-namespace kv
+        RemoveKVRecord v0Remove = new RemoveKVRecord()
+            .setKeys(Collections.singletonList("k1"));
+        // namespaces is null by default
+        assertNull(v0Remove.namespaces());
+        manager.replay(v0Remove);
+        // null-namespace k1 removed, namespaced k1 still exists
+        assertTrue(manager.kv().containsKey(KVKey.of("ns", "k1")));
+        assertTrue(!manager.kv().containsKey(KVKey.of(null, "k1")));
+
+        // 2) Non-null namespaces (v1 record) removes namespaced kv
+        RemoveKVRecord v1Remove = new RemoveKVRecord()
+            .setKeys(Collections.singletonList("k1"))
+            .setNamespaces(Collections.singletonList("ns"));
+        manager.replay(v1Remove);
+        assertTrue(!manager.kv().containsKey(KVKey.of("ns", "k1")));
+
+        // 3) Mismatched namespaces/keys sizes throws IllegalArgumentException
+        RemoveKVRecord mismatch = new RemoveKVRecord()
+            .setKeys(List.of("k1", "k2"))
+            .setNamespaces(Collections.singletonList("ns"));
+        assertThrows(IllegalArgumentException.class, () -> manager.replay(mismatch));
     }
 
     private void replay(KVControlManager manager, List<ApiMessageAndVersion> records) {

--- a/metadata/src/test/java/org/apache/kafka/controller/KVControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/KVControlManagerTest.java
@@ -163,7 +163,6 @@ public class KVControlManagerTest {
 
     @Test
     public void testNamespacedOverwrite() {
-        manager.putKV(new PutKVRequest().setKey("k").setValue("v1".getBytes()).setNamespace("ns"));
         ControllerResult<PutKVResponse> put1 = manager.putKV(new PutKVRequest()
             .setKey("k").setValue("v1".getBytes()).setNamespace("ns"));
         replay(manager, put1.records());

--- a/metadata/src/test/java/org/apache/kafka/controller/stream/TopicDeletionManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/stream/TopicDeletionManagerTest.java
@@ -68,7 +68,7 @@ public class TopicDeletionManagerTest {
     TimelineHashMap<Long, StreamRuntimeMetadata> streams;
     StreamControlManager streamControlManager;
 
-    TimelineHashMap<String, ByteBuffer> kvs;
+    TimelineHashMap<KVKey, ByteBuffer> kvs;
     KVControlManager kvControlManager;
 
     TopicDeletionManager topicDeletionManager;
@@ -102,8 +102,8 @@ public class TopicDeletionManagerTest {
             ObjectUtils.genMetaStreamKvPrefix(topicId.toString()) + 1,
             ObjectUtils.genMetaStreamKvPrefix(topicId.toString()) + 2
         );
-        metadataKvList.forEach(str -> kvs.put(str, ByteBuffer.wrap(new byte[0])));
-        kvs.put(ObjectUtils.genMetaStreamKvPrefix(topicId + "others") + 1, ByteBuffer.wrap(new byte[0]));
+        metadataKvList.forEach(str -> kvs.put(KVKey.of(str), ByteBuffer.wrap(new byte[0])));
+        kvs.put(KVKey.of(ObjectUtils.genMetaStreamKvPrefix(topicId + "others") + 1), ByteBuffer.wrap(new byte[0]));
 
         streams.put(1L, new StreamRuntimeMetadata(1L, 0, 0, 0,
             StreamState.CLOSED, Collections.emptyMap(), registry));

--- a/metadata/src/test/java/org/apache/kafka/image/KVImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/KVImageTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.metadata.KVRecord;
 import org.apache.kafka.common.metadata.KVRecord.KeyValue;
 import org.apache.kafka.common.metadata.RemoveKVRecord;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.RecordTestUtils;
@@ -53,10 +54,10 @@ public class KVImageTest {
 
     static {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        TimelineHashMap<String, ByteBuffer> map = new TimelineHashMap<>(registry, 10000);
+        TimelineHashMap<KVKey, ByteBuffer> map = new TimelineHashMap<>(registry, 10000);
         RegistryRef ref = new RegistryRef(registry, 0, new ArrayList<>());
-        map.put("key1", ByteBuffer.wrap(new String("value1").getBytes()));
-        map.put("key2", ByteBuffer.wrap(new String("value2").getBytes()));
+        map.put(KVKey.of("key1"), ByteBuffer.wrap("value1".getBytes()));
+        map.put(KVKey.of("key2"), ByteBuffer.wrap("value2".getBytes()));
         registry.getOrCreateSnapshot(0);
 
         IMAGE1 = new KVImage(map, ref);
@@ -75,11 +76,11 @@ public class KVImageTest {
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
         registry = new SnapshotRegistry(new LogContext());
-        TimelineHashMap<String, ByteBuffer> map2 = new TimelineHashMap<>(registry, 10000);
+        TimelineHashMap<KVKey, ByteBuffer> map2 = new TimelineHashMap<>(registry, 10000);
         RegistryRef ref2 = new RegistryRef(registry, 0, new ArrayList<>());
 
-        map2.put("key2", ByteBuffer.wrap(new String("value2").getBytes()));
-        map2.put("key3", ByteBuffer.wrap(new String("value3").getBytes()));
+        map2.put(KVKey.of("key2"), ByteBuffer.wrap("value2".getBytes()));
+        map2.put(KVKey.of("key3"), ByteBuffer.wrap("value3".getBytes()));
         registry.getOrCreateSnapshot(0);
 
         IMAGE2 = new KVImage(map2, ref2);

--- a/server-common/src/main/java/org/apache/kafka/server/common/automq/AutoMQVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/automq/AutoMQVersion.java
@@ -40,10 +40,12 @@ public enum AutoMQVersion implements FeatureVersion {
     // Support zero zone v2
     V3((short) 4, MetadataVersion.IBP_3_9_IV0),
     // Support proxy-main dual mapping
-    V4((short) 5, MetadataVersion.IBP_3_9_IV0);
+    V4((short) 5, MetadataVersion.IBP_3_9_IV0),
+    // Support KV namespace
+    V5((short) 6, MetadataVersion.IBP_3_9_IV0);
 
     public static final String FEATURE_NAME = "automq.version";
-    public static final AutoMQVersion LATEST = V4;
+    public static final AutoMQVersion LATEST = V5;
 
     private final short level;
     private final Version s3streamVersion;
@@ -127,6 +129,10 @@ public enum AutoMQVersion implements FeatureVersion {
         return isAtLeast(V4);
     }
 
+    public boolean isKVNamespaceSupported() {
+        return isAtLeast(V5);
+    }
+
     public short streamRecordVersion() {
         if (isReassignmentV1Supported()) {
             return 1;
@@ -159,6 +165,10 @@ public enum AutoMQVersion implements FeatureVersion {
         }
     }
 
+    public short kvRecordVersion() {
+        return isKVNamespaceSupported() ? (short) 1 : (short) 0;
+    }
+
     public Version s3streamVersion() {
         return s3streamVersion;
     }
@@ -170,7 +180,7 @@ public enum AutoMQVersion implements FeatureVersion {
     private Version mapS3StreamVersion(short automqVersion) {
         return switch (automqVersion) {
             case 1, 2 -> Version.V0;
-            case 3, 4, 5 -> Version.V1;
+            case 3, 4, 5, 6 -> Version.V1;
             default -> throw new IllegalArgumentException("Unknown AutoMQVersion level: " + automqVersion);
         };
     }


### PR DESCRIPTION
## Summary
Add namespace support to the KV store.

## Changes
- Add `KVKey` composite key (namespace + key) replacing plain String keys
- Bump `KVRecord`/`RemoveKVRecord` to v1 with optional namespace field
- Bump `PutKVs`/`GetKVs`/`DeleteKVs` requests to v1 with namespace field
- Add `AutoMQVersion.V5` (level 6) gating namespace support
- Update `KVControlManager` to use `KVKey` and version-aware serialization
- Update `KVImage`/`KVDelta` to use `KVKey` throughout
- Add namespace hierarchy to `KVImageNode` metadata tree
- Update all callers and tests