### PR TITLE
feat: add cluster events framework with protobuf-based event publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ __pycache__
 bin/
 !/bin/
 release/.venv/
+
+# Claude Code project config
+.claude/settings.local.json
+.claude/plans/

--- a/bin/kafka-cluster-events.sh
+++ b/bin/kafka-cluster-events.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ClusterEventsCommand "$@"

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ plugins {
   // Updating the shadow plugin version to 8.1.1 causes issue with signing and publishing the shadowed
   // artifacts - see https://github.com/johnrengelman/shadow/issues/901
   id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
+  id 'com.google.protobuf' version '0.9.4' apply false
   //  Spotless 6.13.0 has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), and Spotless 6.14.0+ requires JRE 11
   //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
   //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
@@ -789,7 +790,7 @@ subprojects {
     apply plugin: 'com.diffplug.spotless'
     spotless {
       java {
-        targetExclude('src/generated/**/*.java','src/generated-test/**/*.java')
+        targetExclude('src/generated/**/*.java', 'src/generated-test/**/*.java', 'build/generated/**/*.java')
         importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
         removeUnusedImports()
       }
@@ -1704,6 +1705,8 @@ project(':generator') {
 }
 
 project(':clients') {
+  apply plugin: 'com.google.protobuf'
+
   base {
     archivesName = "kafka-clients"
   }
@@ -1720,6 +1723,10 @@ project(':clients') {
     implementation libs.slf4jApi
     implementation libs.opentelemetryProto
     implementation libs.protobuf
+
+    // AutoMQ inject start
+    implementation libs.cloudeventsKafka
+    // AutoMQ inject end
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
     shadowed libs.zstd
@@ -1839,7 +1846,7 @@ project(':clients') {
   sourceSets {
     main {
       java {
-        srcDirs = ["src/generated/java", "src/main/java"]
+        srcDirs = ["src/generated/java", "src/main/java", "$buildDir/generated/source/proto/main/java"] // AutoMQ: add proto source
       }
     }
     test {
@@ -1849,7 +1856,28 @@ project(':clients') {
     }
   }
 
+  protobuf {
+    protoc {
+      artifact = "com.google.protobuf:protoc:$versions.protobuf"
+    }
+  }
+
+  // Exclude protobuf-generated sources from checkstyle and spotless
+  afterEvaluate {
+    checkstyleMain.source = checkstyleMain.source.filter { !it.path.contains('/generated/source/proto/') }
+    if (tasks.findByName('spotlessJava')) {
+      spotless {
+        java {
+          targetExclude('build/generated/source/proto/**/*.java')
+        }
+      }
+    }
+  }
+
   compileJava.dependsOn 'processMessages'
+  // AutoMQ inject start: ensure proto sources are generated before compilation
+  compileJava.dependsOn 'generateProto'
+  // AutoMQ inject end
   srcJar.dependsOn 'processMessages'
 
   compileTestJava.dependsOn 'processTestMessages'
@@ -2499,6 +2527,8 @@ project(':tools') {
     implementation (libs.oshi) {
       exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    implementation libs.cloudeventsKafka
+    implementation libs.protobuf
     // AutoMQ inject end
 
     // for SASL/OAUTHBEARER JWT validation

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1757,6 +1757,14 @@ public interface Admin extends AutoCloseable {
     }
 
     ExportClusterManifestResult exportClusterManifest(ExportClusterManifestOptions options);
+
+    /**
+     * Create a reader for the {@code __automq_cluster_events} internal topic.
+     *
+     * @param sinceMs only return events at or after this epoch-millisecond timestamp, or null for all
+     * @return a {@link ClusterEventsReader} that must be closed when done
+     */
+    ClusterEventsReader describeClusterEvents(Long sinceMs);
     // AutoMQ inject end
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventPublisher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventPublisher.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventSerializer;
+
+/**
+ * Publishes cluster events to the {@code __automq_cluster_events} internal topic.
+ *
+ * <p>Events are written asynchronously and best-effort: if the producer fails to send an event,
+ * a warning is logged and the event is dropped. Events must never block or fail the critical path
+ * (rebalancing, failover, request handling).
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * // At broker startup
+ * ClusterEventPublisher.setup(Map.of("bootstrap.servers", "localhost:9092"));
+ *
+ * // From any code path
+ * ClusterEventPublisher.publish(
+ *     "com.automq.risk.request_error",
+ *     "/automq/broker/0",
+ *     "PRODUCE:my-topic",
+ *     "com.automq.events.RequestErrorEvent",
+ *     requestErrorEvent.toByteArray());
+ *
+ * // At shutdown
+ * ClusterEventPublisher.shutdown();
+ * }</pre>
+ */
+public class ClusterEventPublisher implements IClusterEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(ClusterEventPublisher.class);
+
+    private static final AtomicReference<IClusterEventPublisher> INSTANCE =
+        new AtomicReference<>(NoopClusterEventPublisher.INSTANCE);
+
+    private final KafkaProducer<String, CloudEvent> producer;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    /**
+     * Create a publisher from a config map. The map should contain at least
+     * {@link ProducerConfig#BOOTSTRAP_SERVERS_CONFIG}. Any additional producer or security
+     * properties (e.g. SASL/SSL) can be included directly. Serializer, acks, retries,
+     * batch.size and linger.ms are set with sensible defaults if not provided.
+     *
+     * @param config producer configuration map
+     */
+    private ClusterEventPublisher(Map<String, Object> config) {
+        Map<String, Object> props = new HashMap<>(config);
+        props.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class.getName());
+        props.putIfAbsent(ProducerConfig.BATCH_SIZE_CONFIG, ClusterEventsConfig.DEFAULT_PUBLISHER_BATCH_SIZE);
+        props.putIfAbsent(ProducerConfig.LINGER_MS_CONFIG, ClusterEventsConfig.DEFAULT_PUBLISHER_LINGER_MS);
+        props.putIfAbsent(ProducerConfig.ACKS_CONFIG, "1");
+        props.putIfAbsent(ProducerConfig.RETRIES_CONFIG, 3);
+
+        this.producer = new KafkaProducer<>(props);
+    }
+
+    // ---- Global singleton ----
+
+    /**
+     * Initialize the global singleton publisher. If already set up, the previous instance
+     * is closed and replaced.
+     *
+     * @param config producer configuration map
+     */
+    public static void setup(Map<String, Object> config) {
+        IClusterEventPublisher prev = INSTANCE.getAndSet(new ClusterEventPublisher(config));
+        if (prev != null) {
+            prev.close();
+        }
+    }
+
+    /**
+     * Shut down the global singleton publisher, reverting to the no-op instance.
+     */
+    public static void shutdown() {
+        IClusterEventPublisher prev = INSTANCE.getAndSet(NoopClusterEventPublisher.INSTANCE);
+        if (prev != null) {
+            prev.close();
+        }
+    }
+
+    /**
+     * Publish an event via the global singleton. If {@link #setup(Map)} has not been called,
+     * this is a no-op.
+     */
+    public static void publish(String type, String source, String subject, String dataSchema, byte[] data) {
+        INSTANCE.get().publishEvent(type, source, subject, dataSchema, data);
+    }
+
+    // ---- Instance methods ----
+
+    @Override
+    public void publishEvent(String type, String source, String subject, String dataSchema, byte[] data) {
+        if (closed.get()) {
+            log.warn("ClusterEventPublisher is closed, dropping event type={}", type);
+            return;
+        }
+
+        CloudEvent event = buildEvent(type, source, subject, dataSchema, data);
+        String key = type + ":" + event.getId();
+        ProducerRecord<String, CloudEvent> record =
+            new ProducerRecord<>(Topic.CLUSTER_EVENTS_TOPIC_NAME, key, event);
+
+        producer.send(record, (metadata, exception) -> {
+            if (exception != null) {
+                log.warn("Failed to publish cluster event type={}, dropping: {}",
+                    record.value().getType(), exception.getMessage());
+            }
+        });
+    }
+
+    private CloudEvent buildEvent(String type, String source, String subject, String dataSchema, byte[] data) {
+        CloudEventBuilder builder = CloudEventBuilder.v1()
+            .withId(UUID.randomUUID().toString())
+            .withType(type)
+            .withSource(URI.create(source))
+            .withTime(OffsetDateTime.now())
+            .withDataContentType("application/protobuf")
+            .withDataSchema(URI.create(dataSchema))
+            .withData("application/protobuf", data);
+
+        if (subject != null) {
+            builder = builder.withSubject(subject);
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            producer.close();
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventTypeRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventTypeRegistry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+
+/**
+ * Maps CloudEvent {@code dataschema} values to their POJO wrappers.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * ClusterEventTypeRegistry.decode(event).ifPresent(obj -> {
+ *     if (obj instanceof RebalanceSummaryEventData summary) { ... }
+ *     else if (obj instanceof FailoverEventData failover) { ... }
+ * });
+ * }</pre>
+ */
+public class ClusterEventTypeRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(ClusterEventTypeRegistry.class);
+
+    private static final Map<String, Function<byte[], Object>> DECODERS = Map.of(
+        RebalanceSummaryEventData.DATA_SCHEMA,        b -> RebalanceSummaryEventData.fromByteArray(b),
+        RebalancePartitionEventData.DATA_SCHEMA,      b -> RebalancePartitionEventData.fromByteArray(b),
+        FailoverEventData.DATA_SCHEMA,                b -> FailoverEventData.fromByteArray(b),
+        RequestErrorEventData.DATA_SCHEMA,            b -> RequestErrorEventData.fromByteArray(b),
+        OffsetCommitFrequencyEventData.DATA_SCHEMA,   b -> OffsetCommitFrequencyEventData.fromByteArray(b)
+    );
+
+    private ClusterEventTypeRegistry() { }
+
+    /**
+     * Decode the protobuf payload of a CloudEvent into its POJO wrapper.
+     *
+     * @return the decoded wrapper, or empty if the dataschema is unknown or the payload is invalid
+     */
+    public static Optional<Object> decode(CloudEvent event) {
+        URI dataSchema = event.getDataSchema();
+        CloudEventData data = event.getData();
+        if (dataSchema == null || data == null) {
+            return Optional.empty();
+        }
+        Function<byte[], Object> decoder = DECODERS.get(dataSchema.toString());
+        if (decoder == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(decoder.apply(data.toBytes()));
+        } catch (Exception e) {
+            log.debug("Failed to decode CloudEvent payload for dataschema={}", dataSchema, e);
+            return Optional.empty();
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventsConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventsConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+/**
+ * Constants for the cluster events system.
+ */
+public class ClusterEventsConfig {
+
+    public static final int DEFAULT_PARTITIONS = 1;
+    public static final long DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000L; // 7 days
+    public static final int DEFAULT_PUBLISHER_BATCH_SIZE = 16384;
+    public static final long DEFAULT_PUBLISHER_LINGER_MS = 100L;
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventsReader.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterEventsReader.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventDeserializer;
+
+/**
+ * Reads events from the {@code __automq_cluster_events} internal topic.
+ *
+ * <p>Supports both one-shot reads and continuous polling (tail mode).
+ * Call {@link #poll(Duration)} repeatedly to consume new events as they arrive.
+ * Must be {@link #close() closed} when done.
+ */
+public class ClusterEventsReader implements Closeable {
+
+    private static final TopicPartition TP =
+        new TopicPartition(Topic.CLUSTER_EVENTS_TOPIC_NAME, 0);
+
+    private final KafkaConsumer<String, CloudEvent> consumer;
+    private long endOffset;
+
+    ClusterEventsReader(Map<String, Object> consumerConfig, Long sinceMs) {
+        this.consumer = createConsumer(consumerConfig);
+        consumer.assign(Collections.singletonList(TP));
+        seek(sinceMs);
+        refreshEndOffset();
+    }
+
+    /**
+     * Poll for new events.
+     *
+     * @return events received within the timeout, may be empty
+     */
+    public List<CloudEvent> poll(Duration timeout) {
+        List<CloudEvent> results = new ArrayList<>();
+        for (ConsumerRecord<String, CloudEvent> record : consumer.poll(timeout)) {
+            if (record.value() != null) {
+                results.add(record.value());
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Returns true if the consumer position has reached the end offset
+     * that was snapshotted when this reader was created.
+     */
+    public boolean isPolledToEnd() {
+        return consumer.position(TP) >= endOffset;
+    }
+
+    @Override
+    public void close() {
+        consumer.close();
+    }
+
+    private void refreshEndOffset() {
+        Long end = consumer.endOffsets(Collections.singletonList(TP)).get(TP);
+        this.endOffset = end != null ? end : 0L;
+    }
+
+    private void seek(Long sinceMs) {
+        if (sinceMs != null) {
+            Map<TopicPartition, OffsetAndTimestamp> offsets =
+                consumer.offsetsForTimes(Collections.singletonMap(TP, sinceMs));
+            OffsetAndTimestamp ot = offsets.get(TP);
+            if (ot != null) {
+                consumer.seek(TP, ot.offset());
+            } else {
+                consumer.seekToEnd(Collections.singletonList(TP));
+            }
+        } else {
+            consumer.seekToBeginning(Collections.singletonList(TP));
+        }
+    }
+
+    private static KafkaConsumer<String, CloudEvent> createConsumer(Map<String, Object> config) {
+        Properties props = new Properties();
+        props.putAll(config);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, CloudEventDeserializer.class.getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return new KafkaConsumer<>(props);
+    }
+
+    static Map<String, Object> buildConsumerConfig(AdminClientConfig config) {
+        Map<String, Object> result = new java.util.HashMap<>();
+        result.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            String.join(",", config.getList(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG)));
+        for (Map.Entry<String, ?> entry : config.values().entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value != null && (key.startsWith("ssl.") || key.startsWith("sasl.")
+                    || key.equals("security.protocol"))) {
+                result.put(key, value);
+            }
+        }
+        return result;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/FailoverEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FailoverEventData.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.FailoverEvent;
+
+/**
+ * POJO wrapper for {@link FailoverEvent} protobuf message.
+ */
+public class FailoverEventData {
+
+    public static final String TYPE = "com.automq.ops.failover";
+    public static final String DATA_SCHEMA = FailoverEvent.getDescriptor().getFullName();
+
+    private int failedNodeId;
+    private long detectedTimestamp;
+    private long completedTimestamp;
+    private String detail;
+
+    public FailoverEventData setFailedNodeId(int failedNodeId) {
+        this.failedNodeId = failedNodeId;
+        return this;
+    }
+
+    public FailoverEventData setDetectedTimestamp(long detectedTimestamp) {
+        this.detectedTimestamp = detectedTimestamp;
+        return this;
+    }
+
+    public FailoverEventData setCompletedTimestamp(long completedTimestamp) {
+        this.completedTimestamp = completedTimestamp;
+        return this;
+    }
+
+    public FailoverEventData setDetail(String detail) {
+        this.detail = detail;
+        return this;
+    }
+
+    public int failedNodeId() {
+        return failedNodeId;
+    }
+
+    public long detectedTimestamp() {
+        return detectedTimestamp;
+    }
+
+    public long completedTimestamp() {
+        return completedTimestamp;
+    }
+
+    public String detail() {
+        return detail;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("FailoverEvent{");
+        sb.append("failedNodeId=").append(failedNodeId);
+        sb.append(", detectedTimestamp=").append(detectedTimestamp);
+        sb.append(", completedTimestamp=").append(completedTimestamp);
+        if (detail != null) sb.append(", detail='").append(detail).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public byte[] toByteArray() {
+        FailoverEvent.Builder b = FailoverEvent.newBuilder()
+            .setFailedNodeId(failedNodeId)
+            .setDetectedTimestamp(detectedTimestamp)
+            .setCompletedTimestamp(completedTimestamp);
+        if (detail != null) b.setDetail(detail);
+        return b.build().toByteArray();
+    }
+
+    public static FailoverEventData fromByteArray(byte[] data) {
+        try {
+            FailoverEvent e = FailoverEvent.parseFrom(data);
+            return new FailoverEventData()
+                .setFailedNodeId(e.getFailedNodeId())
+                .setDetectedTimestamp(e.getDetectedTimestamp())
+                .setCompletedTimestamp(e.getCompletedTimestamp())
+                .setDetail(e.getDetail());
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to parse FailoverEvent", ex);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -335,5 +335,10 @@ public class ForwardingAdmin implements Admin {
         return delegate.exportClusterManifest(options);
     }
 
+    @Override
+    public ClusterEventsReader describeClusterEvents(Long sinceMs) {
+        return delegate.describeClusterEvents(sinceMs);
+    }
+
     // AutoMQ inject end
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/IClusterEventPublisher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/IClusterEventPublisher.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+/**
+ * Interface for publishing cluster events to the {@code __automq_cluster_events} internal topic.
+ */
+public interface IClusterEventPublisher extends AutoCloseable {
+
+    /**
+     * Publish a domain event to {@code __automq_cluster_events}.
+     *
+     * @param type       CloudEvent type (reverse-DNS), e.g. {@code "com.automq.ops.rebalance.summary"}
+     * @param source     CloudEvent source URI, e.g. {@code "/automq/broker/0"}
+     * @param subject    CloudEvent subject, or {@code null} if not applicable
+     * @param dataSchema fully-qualified protobuf message type name
+     * @param data       serialized protobuf payload
+     */
+    void publishEvent(String type, String source, String subject, String dataSchema, byte[] data);
+
+    @Override
+    void close();
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -420,6 +420,10 @@ public class KafkaAdminClient extends AdminClient {
     private final boolean clientTelemetryEnabled;
     private final MetadataRecoveryStrategy metadataRecoveryStrategy;
 
+    // AutoMQ inject start
+    private final AdminClientConfig adminClientConfig;
+    // AutoMQ inject end
+
     /**
      * The telemetry requests client instance id.
      */
@@ -633,6 +637,9 @@ public class KafkaAdminClient extends AdminClient {
             CommonClientConfigs.RETRY_BACKOFF_JITTER);
         this.clientTelemetryEnabled = config.getBoolean(AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG);
         this.metadataRecoveryStrategy = MetadataRecoveryStrategy.forName(config.getString(AdminClientConfig.METADATA_RECOVERY_STRATEGY_CONFIG));
+        // AutoMQ inject start
+        this.adminClientConfig = config;
+        // AutoMQ inject end
         config.logUnused();
         AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
         log.debug("Kafka admin client initialized");
@@ -2458,7 +2465,7 @@ public class KafkaAdminClient extends AdminClient {
         return new TopicDescription(topic.name(), topic.isInternal(), partitions, authorisedOperations, topic.topicId());
     }
 
-    // AutoMQ for Kafka inject start
+    // AutoMQ inject start
     @Override
     public GetNextNodeIdResult getNextNodeId(GetNextNodeIdOptions options) {
         KafkaFutureImpl<Integer> nodeIdFuture = new KafkaFutureImpl<>();
@@ -2615,7 +2622,12 @@ public class KafkaAdminClient extends AdminClient {
         runnable.call(call, now);
         return new ExportClusterManifestResult(future);
     }
-    // AutoMQ for Kafka inject end
+
+    @Override
+    public ClusterEventsReader describeClusterEvents(Long sinceMs) {
+        return new ClusterEventsReader(ClusterEventsReader.buildConsumerConfig(adminClientConfig), sinceMs);
+    }
+    // AutoMQ inject end
 
     private TopicDescription getTopicDescriptionFromCluster(Cluster cluster, String topicName, Uuid topicId,
                                                             Integer authorizedOperations) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoopClusterEventPublisher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoopClusterEventPublisher.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+/**
+ * No-op implementation used when the publisher has not been set up.
+ * All events are silently dropped.
+ */
+public class NoopClusterEventPublisher implements IClusterEventPublisher {
+
+    static final NoopClusterEventPublisher INSTANCE = new NoopClusterEventPublisher();
+
+    @Override
+    public void publishEvent(String type, String source, String subject, String dataSchema, byte[] data) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetCommitFrequencyEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetCommitFrequencyEventData.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.OffsetCommitFrequencyEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * POJO wrapper for {@link OffsetCommitFrequencyEvent} protobuf message.
+ */
+public class OffsetCommitFrequencyEventData {
+
+    public static final String TYPE = "com.automq.risk.offset_commit_frequency";
+    public static final String DATA_SCHEMA = OffsetCommitFrequencyEvent.getDescriptor().getFullName();
+
+    private List<String> clientIps = Collections.emptyList();
+    private List<String> clientIds = Collections.emptyList();
+    private String groupId;
+    private String topic;
+    private double rps;
+
+    public OffsetCommitFrequencyEventData setClientIps(List<String> clientIps) {
+        this.clientIps = clientIps != null ? clientIps : Collections.emptyList();
+        return this;
+    }
+
+    public OffsetCommitFrequencyEventData setClientIds(List<String> clientIds) {
+        this.clientIds = clientIds != null ? clientIds : Collections.emptyList();
+        return this;
+    }
+
+    public OffsetCommitFrequencyEventData setGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public OffsetCommitFrequencyEventData setTopic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    public OffsetCommitFrequencyEventData setRps(double rps) {
+        this.rps = rps;
+        return this;
+    }
+
+    public List<String> clientIps() {
+        return clientIps;
+    }
+
+    public List<String> clientIds() {
+        return clientIds;
+    }
+
+    public String groupId() {
+        return groupId;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public double rps() {
+        return rps;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("OffsetCommitFrequencyEvent{");
+        if (!clientIps.isEmpty()) sb.append("clientIps=").append(clientIps).append(", ");
+        if (!clientIds.isEmpty()) sb.append("clientIds=").append(clientIds).append(", ");
+        sb.append("groupId='").append(groupId).append('\'');
+        sb.append(", topic='").append(topic).append('\'');
+        sb.append(", rps=").append(rps);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public byte[] toByteArray() {
+        OffsetCommitFrequencyEvent.Builder b = OffsetCommitFrequencyEvent.newBuilder()
+            .addAllClientIps(clientIps)
+            .addAllClientIds(clientIds)
+            .setRps(rps);
+        if (groupId != null) b.setGroupId(groupId);
+        if (topic != null) b.setTopic(topic);
+        return b.build().toByteArray();
+    }
+
+    public static OffsetCommitFrequencyEventData fromByteArray(byte[] data) {
+        try {
+            OffsetCommitFrequencyEvent e = OffsetCommitFrequencyEvent.parseFrom(data);
+            return new OffsetCommitFrequencyEventData()
+                .setClientIps(new ArrayList<>(e.getClientIpsList()))
+                .setClientIds(new ArrayList<>(e.getClientIdsList()))
+                .setGroupId(e.getGroupId())
+                .setTopic(e.getTopic())
+                .setRps(e.getRps());
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to parse OffsetCommitFrequencyEvent", ex);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RebalancePartitionEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RebalancePartitionEventData.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.RebalancePartitionEvent;
+
+/**
+ * POJO wrapper for {@link RebalancePartitionEvent} protobuf message.
+ */
+public class RebalancePartitionEventData {
+
+    public static final String TYPE = "com.automq.ops.rebalance.partition";
+    public static final String DATA_SCHEMA = RebalancePartitionEvent.getDescriptor().getFullName();
+
+    private String rebalanceId;
+    private String topicPartition;
+    private int fromBroker;
+    private int toBroker;
+    private String reason;
+
+    public RebalancePartitionEventData setRebalanceId(String rebalanceId) {
+        this.rebalanceId = rebalanceId;
+        return this;
+    }
+
+    public RebalancePartitionEventData setTopicPartition(String topicPartition) {
+        this.topicPartition = topicPartition;
+        return this;
+    }
+
+    public RebalancePartitionEventData setFromBroker(int fromBroker) {
+        this.fromBroker = fromBroker;
+        return this;
+    }
+
+    public RebalancePartitionEventData setToBroker(int toBroker) {
+        this.toBroker = toBroker;
+        return this;
+    }
+
+    public RebalancePartitionEventData setReason(String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    public String rebalanceId() {
+        return rebalanceId;
+    }
+
+    public String topicPartition() {
+        return topicPartition;
+    }
+
+    public int fromBroker() {
+        return fromBroker;
+    }
+
+    public int toBroker() {
+        return toBroker;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RebalancePartitionEvent{");
+        sb.append("rebalanceId='").append(rebalanceId).append('\'');
+        sb.append(", topicPartition='").append(topicPartition).append('\'');
+        sb.append(", fromBroker=").append(fromBroker);
+        sb.append(", toBroker=").append(toBroker);
+        if (reason != null) sb.append(", reason='").append(reason).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public byte[] toByteArray() {
+        RebalancePartitionEvent.Builder b = RebalancePartitionEvent.newBuilder();
+        if (rebalanceId != null) b.setRebalanceId(rebalanceId);
+        if (topicPartition != null) b.setTopicPartition(topicPartition);
+        b.setFromBroker(fromBroker);
+        b.setToBroker(toBroker);
+        if (reason != null) b.setReason(reason);
+        return b.build().toByteArray();
+    }
+
+    public static RebalancePartitionEventData fromByteArray(byte[] data) {
+        try {
+            RebalancePartitionEvent e = RebalancePartitionEvent.parseFrom(data);
+            return new RebalancePartitionEventData()
+                .setRebalanceId(e.getRebalanceId())
+                .setTopicPartition(e.getTopicPartition())
+                .setFromBroker(e.getFromBroker())
+                .setToBroker(e.getToBroker())
+                .setReason(e.getReason());
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to parse RebalancePartitionEvent", ex);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RebalanceSummaryEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RebalanceSummaryEventData.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.RebalanceSummaryEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * POJO wrapper for {@link RebalanceSummaryEvent} protobuf message.
+ */
+public class RebalanceSummaryEventData {
+
+    public static final String TYPE = "com.automq.ops.rebalance.summary";
+    public static final String DATA_SCHEMA = RebalanceSummaryEvent.getDescriptor().getFullName();
+
+    private String rebalanceId;
+    private String triggerReason;
+    private int partitionCount;
+    private Map<Integer, Double> brokerLoadBefore = new HashMap<>();
+    private Map<Integer, Double> brokerLoadAfter = new HashMap<>();
+
+    public RebalanceSummaryEventData setRebalanceId(String rebalanceId) {
+        this.rebalanceId = rebalanceId;
+        return this;
+    }
+
+    public RebalanceSummaryEventData setTriggerReason(String triggerReason) {
+        this.triggerReason = triggerReason;
+        return this;
+    }
+
+    public RebalanceSummaryEventData setPartitionCount(int partitionCount) {
+        this.partitionCount = partitionCount;
+        return this;
+    }
+
+    public RebalanceSummaryEventData setBrokerLoadBefore(Map<Integer, Double> brokerLoadBefore) {
+        this.brokerLoadBefore = brokerLoadBefore != null ? brokerLoadBefore : new HashMap<>();
+        return this;
+    }
+
+    public RebalanceSummaryEventData setBrokerLoadAfter(Map<Integer, Double> brokerLoadAfter) {
+        this.brokerLoadAfter = brokerLoadAfter != null ? brokerLoadAfter : new HashMap<>();
+        return this;
+    }
+
+    public String rebalanceId() {
+        return rebalanceId;
+    }
+
+    public String triggerReason() {
+        return triggerReason;
+    }
+
+    public int partitionCount() {
+        return partitionCount;
+    }
+
+    public Map<Integer, Double> brokerLoadBefore() {
+        return brokerLoadBefore;
+    }
+
+    public Map<Integer, Double> brokerLoadAfter() {
+        return brokerLoadAfter;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RebalanceSummaryEvent{");
+        sb.append("rebalanceId='").append(rebalanceId).append('\'');
+        sb.append(", triggerReason='").append(triggerReason).append('\'');
+        sb.append(", partitionCount=").append(partitionCount);
+        if (!brokerLoadBefore.isEmpty()) sb.append(", brokerLoadBefore=").append(brokerLoadBefore);
+        if (!brokerLoadAfter.isEmpty()) sb.append(", brokerLoadAfter=").append(brokerLoadAfter);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public byte[] toByteArray() {
+        RebalanceSummaryEvent.Builder b = RebalanceSummaryEvent.newBuilder();
+        if (rebalanceId != null) b.setRebalanceId(rebalanceId);
+        if (triggerReason != null) b.setTriggerReason(triggerReason);
+        b.setPartitionCount(partitionCount);
+        b.putAllBrokerLoadBefore(brokerLoadBefore);
+        b.putAllBrokerLoadAfter(brokerLoadAfter);
+        return b.build().toByteArray();
+    }
+
+    public static RebalanceSummaryEventData fromByteArray(byte[] data) {
+        try {
+            RebalanceSummaryEvent e = RebalanceSummaryEvent.parseFrom(data);
+            return new RebalanceSummaryEventData()
+                .setRebalanceId(e.getRebalanceId())
+                .setTriggerReason(e.getTriggerReason())
+                .setPartitionCount(e.getPartitionCount())
+                .setBrokerLoadBefore(new HashMap<>(e.getBrokerLoadBeforeMap()))
+                .setBrokerLoadAfter(new HashMap<>(e.getBrokerLoadAfterMap()));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to parse RebalanceSummaryEvent", ex);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RequestErrorEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RequestErrorEventData.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.RequestErrorEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * POJO wrapper for {@link RequestErrorEvent} protobuf message.
+ * <p>
+ * This class hides all protobuf references so that modules with conflicting
+ * protobuf versions (shaded vs unshaded) can build and serialize
+ * {@code RequestErrorEvent} without directly touching protobuf classes.
+ */
+public class RequestErrorEventData {
+
+    public static final String TYPE = "com.automq.risk.request_error";
+    public static final String DATA_SCHEMA = RequestErrorEvent.getDescriptor().getFullName();
+
+    private int apiKey;
+    private int errorCode;
+    private String resource;
+    private List<String> clientIps = Collections.emptyList();
+    private List<String> clientIds = Collections.emptyList();
+    private double rps;
+    private String reason;
+
+    public RequestErrorEventData setApiKey(int apiKey) {
+        this.apiKey = apiKey;
+        return this;
+    }
+
+    public RequestErrorEventData setErrorCode(int errorCode) {
+        this.errorCode = errorCode;
+        return this;
+    }
+
+    public RequestErrorEventData setResource(String resource) {
+        this.resource = resource;
+        return this;
+    }
+
+    public RequestErrorEventData setClientIps(List<String> clientIps) {
+        this.clientIps = clientIps != null ? clientIps : Collections.emptyList();
+        return this;
+    }
+
+    public RequestErrorEventData setClientIds(List<String> clientIds) {
+        this.clientIds = clientIds != null ? clientIds : Collections.emptyList();
+        return this;
+    }
+
+    public RequestErrorEventData setRps(double rps) {
+        this.rps = rps;
+        return this;
+    }
+
+    public RequestErrorEventData setReason(String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    public int apiKey() {
+        return apiKey;
+    }
+
+    public int errorCode() {
+        return errorCode;
+    }
+
+    public String resource() {
+        return resource;
+    }
+
+    public List<String> clientIps() {
+        return clientIps;
+    }
+
+    public List<String> clientIds() {
+        return clientIds;
+    }
+
+    public double rps() {
+        return rps;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RequestErrorEvent{");
+        sb.append("apiKey=").append(apiKey);
+        sb.append(", errorCode=").append(errorCode);
+        if (resource != null) sb.append(", resource='").append(resource).append('\'');
+        if (!clientIps.isEmpty()) sb.append(", clientIps=").append(clientIps);
+        if (!clientIds.isEmpty()) sb.append(", clientIds=").append(clientIds);
+        sb.append(", rps=").append(rps);
+        if (reason != null) sb.append(", reason='").append(reason).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /**
+     * Serialize to protobuf byte array.
+     */
+    public byte[] toByteArray() {
+        RequestErrorEvent.Builder b = RequestErrorEvent.newBuilder()
+            .setApiKey(apiKey)
+            .setErrorCode(errorCode)
+            .addAllClientIps(clientIps)
+            .addAllClientIds(clientIds)
+            .setRps(rps);
+        if (resource != null) {
+            b.setResource(resource);
+        }
+        if (reason != null) {
+            b.setReason(reason);
+        }
+        return b.build().toByteArray();
+    }
+
+    /**
+     * Deserialize from protobuf byte array.
+     */
+    public static RequestErrorEventData fromByteArray(byte[] data) {
+        try {
+            RequestErrorEvent event = RequestErrorEvent.parseFrom(data);
+            return new RequestErrorEventData()
+                .setApiKey(event.getApiKey())
+                .setErrorCode(event.getErrorCode())
+                .setResource(event.hasResource() ? event.getResource() : null)
+                .setClientIps(new ArrayList<>(event.getClientIpsList()))
+                .setClientIds(new ArrayList<>(event.getClientIdsList()))
+                .setRps(event.getRps())
+                .setReason(event.hasReason() ? event.getReason() : null);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse RequestErrorEvent", e);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
@@ -35,6 +35,7 @@ public class Topic {
     public static final String AUTO_BALANCER_METRICS_TOPIC_NAME = "__auto_balancer_metrics";
     public static final String TABLE_TOPIC_CONTROL_TOPIC_NAME = "__automq_table_control";
     public static final String TABLE_TOPIC_DATA_TOPIC_NAME = "__automq_table_data";
+    public static final String CLUSTER_EVENTS_TOPIC_NAME = "__automq_cluster_events";
     // Full name: __automq_consumer_group_force_commit
     public static final String FORCE_COMMIT_SENTINEL_TOPIC = "__a.c.g.f.c";
     // AutoMQ inject end

--- a/clients/src/main/proto/com/automq/events/cluster_events.proto
+++ b/clients/src/main/proto/com/automq/events/cluster_events.proto
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.automq.events;
+
+option java_package = "com.automq.events";
+option java_multiple_files = true;
+option java_outer_classname = "ClusterEventsProto";
+
+// Emitted once per AutoBalancer rebalance action — summary of what moved and why.
+message RebalanceSummaryEvent {
+  string rebalance_id = 1;
+  string trigger_reason = 2;
+  int32 partition_count = 3;
+  map<int32, double> broker_load_before = 4;
+  map<int32, double> broker_load_after = 5;
+}
+
+// Emitted once per partition moved during a rebalance. Correlates with
+// RebalanceSummaryEvent via rebalance_id.
+message RebalancePartitionEvent {
+  string rebalance_id = 1;
+  string topic_partition = 2;
+  int32 from_broker = 3;
+  int32 to_broker = 4;
+  string reason = 5;
+}
+
+// Emitted when a broker failover completes.
+message FailoverEvent {
+  int32 failed_node_id = 1;
+  int64 detected_timestamp = 2;
+  int64 completed_timestamp = 3;
+  string detail = 4;
+}
+
+// Emitted when a broker detects a sustained rate of request errors
+// (e.g. auth failures, authorization errors) for a given API/resource.
+message RequestErrorEvent {
+  int32 api_key = 1;
+  int32 error_code = 2;
+  optional string resource = 3;
+  repeated string client_ips = 4;
+  repeated string client_ids = 5;
+  double rps = 6;
+  optional string reason = 7;
+}
+
+// Emitted when a consumer group is committing offsets at an excessive rate.
+message OffsetCommitFrequencyEvent {
+  repeated string client_ips = 1;
+  repeated string client_ids = 2;
+  string group_id = 3;
+  string topic = 4;
+  double rps = 5;
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ClusterEventTypeRegistryTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ClusterEventTypeRegistryTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import com.automq.events.FailoverEvent;
+import com.automq.events.OffsetCommitFrequencyEvent;
+import com.automq.events.RebalancePartitionEvent;
+import com.automq.events.RebalanceSummaryEvent;
+import com.automq.events.RequestErrorEvent;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClusterEventTypeRegistryTest {
+
+    @Test
+    void decodeRebalanceSummaryEvent() {
+        RebalanceSummaryEvent payload = RebalanceSummaryEvent.newBuilder()
+            .setRebalanceId("r1")
+            .setTriggerReason("load imbalance")
+            .setPartitionCount(3)
+            .build();
+
+        CloudEvent event = buildEvent(RebalanceSummaryEventData.DATA_SCHEMA, payload.toByteArray());
+        Optional<Object> result = ClusterEventTypeRegistry.decode(event);
+
+        assertTrue(result.isPresent());
+        RebalanceSummaryEventData decoded = assertInstanceOf(RebalanceSummaryEventData.class, result.get());
+        assertEquals("r1", decoded.rebalanceId());
+        assertEquals("load imbalance", decoded.triggerReason());
+        assertEquals(3, decoded.partitionCount());
+    }
+
+    @Test
+    void decodeRebalancePartitionEvent() {
+        RebalancePartitionEvent payload = RebalancePartitionEvent.newBuilder()
+            .setRebalanceId("r1")
+            .setTopicPartition("my-topic-0")
+            .setFromBroker(1)
+            .setToBroker(2)
+            .build();
+
+        CloudEvent event = buildEvent(RebalancePartitionEventData.DATA_SCHEMA, payload.toByteArray());
+        Optional<Object> result = ClusterEventTypeRegistry.decode(event);
+
+        assertTrue(result.isPresent());
+        RebalancePartitionEventData decoded = assertInstanceOf(RebalancePartitionEventData.class, result.get());
+        assertEquals("my-topic-0", decoded.topicPartition());
+        assertEquals(1, decoded.fromBroker());
+        assertEquals(2, decoded.toBroker());
+    }
+
+    @Test
+    void decodeFailoverEvent() {
+        FailoverEvent payload = FailoverEvent.newBuilder()
+            .setFailedNodeId(5)
+            .setDetectedTimestamp(1000L)
+            .setCompletedTimestamp(2000L)
+            .setDetail("node unreachable")
+            .build();
+
+        CloudEvent event = buildEvent(FailoverEventData.DATA_SCHEMA, payload.toByteArray());
+        Optional<Object> result = ClusterEventTypeRegistry.decode(event);
+
+        assertTrue(result.isPresent());
+        FailoverEventData decoded = assertInstanceOf(FailoverEventData.class, result.get());
+        assertEquals(5, decoded.failedNodeId());
+        assertEquals("node unreachable", decoded.detail());
+    }
+
+    @Test
+    void decodeRequestErrorEvent() {
+        RequestErrorEvent payload = RequestErrorEvent.newBuilder()
+            .setApiKey(0)
+            .setErrorCode(29)
+            .setResource("my-topic")
+            .setRps(42.0)
+            .build();
+
+        CloudEvent event = buildEvent(RequestErrorEventData.DATA_SCHEMA, payload.toByteArray());
+        Optional<Object> result = ClusterEventTypeRegistry.decode(event);
+
+        assertTrue(result.isPresent());
+        RequestErrorEventData decoded = assertInstanceOf(RequestErrorEventData.class, result.get());
+        assertEquals(0, decoded.apiKey());
+        assertEquals(29, decoded.errorCode());
+        assertEquals(42.0, decoded.rps(), 0.001);
+    }
+
+    @Test
+    void decodeOffsetCommitFrequencyEvent() {
+        OffsetCommitFrequencyEvent payload = OffsetCommitFrequencyEvent.newBuilder()
+            .setGroupId("my-group")
+            .setTopic("my-topic")
+            .setRps(5000.0)
+            .build();
+
+        CloudEvent event = buildEvent(OffsetCommitFrequencyEventData.DATA_SCHEMA, payload.toByteArray());
+        Optional<Object> result = ClusterEventTypeRegistry.decode(event);
+
+        assertTrue(result.isPresent());
+        OffsetCommitFrequencyEventData decoded = assertInstanceOf(OffsetCommitFrequencyEventData.class, result.get());
+        assertEquals("my-group", decoded.groupId());
+        assertEquals(5000.0, decoded.rps(), 0.001);
+    }
+
+    @Test
+    void returnsEmptyForUnknownSchema() {
+        CloudEvent event = buildEvent("com.example.UnknownEvent", new byte[]{1, 2, 3});
+        assertFalse(ClusterEventTypeRegistry.decode(event).isPresent());
+    }
+
+    @Test
+    void returnsEmptyForNullDataSchema() {
+        CloudEvent event = CloudEventBuilder.v1()
+            .withId("test-id")
+            .withType("com.automq.ops.failover")
+            .withSource(URI.create("/automq/broker/0"))
+            .withData("application/protobuf", new byte[]{1})
+            .build();
+        assertFalse(ClusterEventTypeRegistry.decode(event).isPresent());
+    }
+
+    @Test
+    void returnsEmptyForCorruptPayload() {
+        CloudEvent event = buildEvent(FailoverEventData.DATA_SCHEMA, new byte[]{(byte) 0xFF, (byte) 0xFF});
+        assertFalse(ClusterEventTypeRegistry.decode(event).isPresent());
+    }
+
+    private static CloudEvent buildEvent(String dataSchema, byte[] payload) {
+        return CloudEventBuilder.v1()
+            .withId("test-id")
+            .withType("com.automq.test")
+            .withSource(URI.create("/automq/broker/0"))
+            .withDataSchema(URI.create(dataSchema))
+            .withData("application/protobuf", payload)
+            .build();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1465,6 +1465,11 @@ public class MockAdminClient extends AdminClient {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public ClusterEventsReader describeClusterEvents(Long sinceMs) {
+        throw new UnsupportedOperationException();
+    }
+
     // AutoMQ inject end
 
 }

--- a/core/src/main/java/kafka/server/RequestErrorAccumulator.java
+++ b/core/src/main/java/kafka/server/RequestErrorAccumulator.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import org.apache.kafka.clients.admin.ClusterEventPublisher;
+import org.apache.kafka.clients.admin.RequestErrorEventData;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+public class RequestErrorAccumulator implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestErrorAccumulator.class);
+
+    private static final int MAX_CLIENTS = 10;
+
+    record ErrorKey(short apiKey, short errorCode, String resource) { }
+
+    static class ErrorBucket {
+        final LongAdder count = new LongAdder();
+        final Set<String> clientIps = ConcurrentHashMap.newKeySet();
+        final Set<String> clientIds = ConcurrentHashMap.newKeySet();
+    }
+
+    private final ConcurrentHashMap<ErrorKey, ErrorBucket> buckets = new ConcurrentHashMap<>();
+    private final int brokerId;
+    private final long flushIntervalMs;
+    private final ScheduledExecutorService scheduler;
+
+    public RequestErrorAccumulator(int brokerId, long flushIntervalMs) {
+        this.brokerId = brokerId;
+        this.flushIntervalMs = flushIntervalMs;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "request-error-accumulator-flush");
+            t.setDaemon(true);
+            return t;
+        });
+        this.scheduler.scheduleAtFixedRate(this::flush,
+            flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    public static boolean isRecordable(short errorCode) {
+        return errorCode != 0;
+    }
+
+    public void record(short apiKey, short errorCode, String resource,
+                       String clientIp, String clientId) {
+        ErrorKey key = new ErrorKey(apiKey, errorCode, resource);
+        ErrorBucket bucket = buckets.computeIfAbsent(key, k -> new ErrorBucket());
+        bucket.count.increment();
+        if (bucket.clientIps.size() < MAX_CLIENTS) {
+            bucket.clientIps.add(clientIp);
+        }
+        if (bucket.clientIds.size() < MAX_CLIENTS) {
+            bucket.clientIds.add(clientId);
+        }
+    }
+
+    void flush() {
+        try {
+            doFlush();
+        } catch (Throwable e) {
+            log.warn("Error flushing request error events", e);
+        }
+    }
+
+    private void doFlush() {
+        double intervalSec = flushIntervalMs / 1000.0;
+        Iterator<Map.Entry<ErrorKey, ErrorBucket>> it = buckets.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<ErrorKey, ErrorBucket> entry = it.next();
+            // Remove the entry atomically before reading its values so that any new records
+            // arriving after this point go into a fresh bucket and are not silently dropped.
+            it.remove();
+            ErrorKey key = entry.getKey();
+            ErrorBucket bucket = entry.getValue();
+            long count = bucket.count.sum();
+            if (count == 0) {
+                continue;
+            }
+
+            String apiName = ApiKeys.forId(key.apiKey()).name;
+
+            RequestErrorEventData data = new RequestErrorEventData()
+                .setApiKey(key.apiKey())
+                .setErrorCode(key.errorCode())
+                .setClientIps(List.copyOf(bucket.clientIps))
+                .setClientIds(List.copyOf(bucket.clientIds))
+                .setRps(count / intervalSec);
+            if (!key.resource().isEmpty()) {
+                data.setResource(key.resource());
+            }
+
+            String subject = key.resource().isEmpty()
+                ? apiName : apiName + ":" + key.resource();
+
+            ClusterEventPublisher.publish(
+                RequestErrorEventData.TYPE,
+                "/automq/broker/" + brokerId,
+                subject,
+                RequestErrorEventData.DATA_SCHEMA,
+                data.toByteArray());
+        }
+    }
+
+    @Override
+    public void close() {
+        scheduler.shutdownNow();
+    }
+}

--- a/core/src/main/java/kafka/server/ResourceErrorExtractor.java
+++ b/core/src/main/java/kafka/server/ResourceErrorExtractor.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import kafka.network.RequestChannel;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
+import org.apache.kafka.common.requests.AddPartitionsToTxnResponse;
+import org.apache.kafka.common.requests.AlterConfigsResponse;
+import org.apache.kafka.common.requests.ConsumerGroupDescribeRequest;
+import org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest;
+import org.apache.kafka.common.requests.CreatePartitionsResponse;
+import org.apache.kafka.common.requests.CreateTopicsResponse;
+import org.apache.kafka.common.requests.DeleteGroupsResponse;
+import org.apache.kafka.common.requests.DeleteTopicsResponse;
+import org.apache.kafka.common.requests.DescribeConfigsResponse;
+import org.apache.kafka.common.requests.DescribeGroupsResponse;
+import org.apache.kafka.common.requests.EndTxnRequest;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.HeartbeatRequest;
+import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.LeaveGroupRequest;
+import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
+import org.apache.kafka.common.requests.OffsetFetchResponse;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.requests.SyncGroupRequest;
+import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Extracts (errorCode, resource) pairs from request/response for recording in RequestErrorAccumulator.
+ */
+public class ResourceErrorExtractor {
+
+    public record ResourceError(short errorCode, String resource) { }
+
+    /**
+     * Extract recordable errors with their associated resource from a response.
+     */
+    public static List<ResourceError> extract(RequestChannel.Request request, AbstractResponse response) {
+        try {
+            return doExtract(request, response);
+        } catch (Exception e) {
+            // Never let extraction failures break request processing
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Best-effort resource extraction from request only (for closeConnection path).
+     */
+    public static String extractResourceFromRequest(RequestChannel.Request request) {
+        try {
+            return doExtractResourceFromRequest(request);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static List<ResourceError> doExtract(RequestChannel.Request request, AbstractResponse response) {
+        ApiKeys apiKey = request.header().apiKey();
+        switch (apiKey) {
+            case PRODUCE:
+                return extractProduce((ProduceResponse) response);
+            case FETCH:
+                return extractFetch((FetchResponse) response);
+            case LIST_OFFSETS:
+                return extractListOffsets((ListOffsetsResponse) response);
+            case METADATA:
+                return extractMetadata((MetadataResponse) response);
+            case OFFSET_COMMIT:
+                return extractOffsetCommit(request, (OffsetCommitResponse) response);
+            case OFFSET_FETCH:
+                return extractOffsetFetch((OffsetFetchResponse) response);
+            case FIND_COORDINATOR:
+                return extractFindCoordinator(request, (FindCoordinatorResponse) response);
+            case CREATE_TOPICS:
+                return extractCreateTopics((CreateTopicsResponse) response);
+            case DELETE_TOPICS:
+                return extractDeleteTopics((DeleteTopicsResponse) response);
+            case CREATE_PARTITIONS:
+                return extractCreatePartitions((CreatePartitionsResponse) response);
+            default:
+                return doExtractOther(request, response, apiKey);
+        }
+    }
+
+    private static List<ResourceError> doExtractOther(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
+        switch (apiKey) {
+            case JOIN_GROUP:
+                return extractSingleErrorFromRequest(response, () -> request.body(JoinGroupRequest.class).data().groupId());
+            case SYNC_GROUP:
+                return extractSingleErrorFromRequest(response, () -> request.body(SyncGroupRequest.class).data().groupId());
+            case HEARTBEAT:
+                return extractSingleErrorFromRequest(response, () -> request.body(HeartbeatRequest.class).data().groupId());
+            case LEAVE_GROUP:
+                return extractSingleErrorFromRequest(response, () -> request.body(LeaveGroupRequest.class).data().groupId());
+            case DESCRIBE_GROUPS:
+                return extractDescribeGroups((DescribeGroupsResponse) response);
+            case DELETE_GROUPS:
+                return extractDeleteGroups((DeleteGroupsResponse) response);
+            case LIST_GROUPS:
+                return extractSingleError(response, "cluster");
+            case INIT_PRODUCER_ID:
+                return extractSingleErrorFromRequest(response, () -> {
+                    String txnId = request.body(InitProducerIdRequest.class).data().transactionalId();
+                    return txnId != null ? txnId : "";
+                });
+            case ADD_PARTITIONS_TO_TXN:
+                return extractAddPartitionsToTxn((AddPartitionsToTxnResponse) response);
+            case ADD_OFFSETS_TO_TXN:
+                return extractSingleErrorFromRequest(response, () -> request.body(AddOffsetsToTxnRequest.class).data().transactionalId());
+            case END_TXN:
+                return extractSingleErrorFromRequest(response, () -> request.body(EndTxnRequest.class).data().transactionalId());
+            case TXN_OFFSET_COMMIT:
+                return extractTxnOffsetCommit((TxnOffsetCommitResponse) response);
+            default:
+                return doExtractAdmin(request, response, apiKey);
+        }
+    }
+
+    private static List<ResourceError> doExtractAdmin(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
+        switch (apiKey) {
+            case ALTER_CONFIGS:
+                return extractAlterConfigs((AlterConfigsResponse) response);
+            case DESCRIBE_CONFIGS:
+                return extractDescribeConfigs((DescribeConfigsResponse) response);
+            case INCREMENTAL_ALTER_CONFIGS:
+                return extractIncrementalAlterConfigs((IncrementalAlterConfigsResponse) response);
+            case CREATE_DELEGATION_TOKEN:
+            case RENEW_DELEGATION_TOKEN:
+            case EXPIRE_DELEGATION_TOKEN:
+                return extractSingleError(response, "delegation-token");
+            case SASL_HANDSHAKE:
+            case SASL_AUTHENTICATE:
+                return extractSingleError(response, "sasl");
+            case CREATE_ACLS:
+            case DELETE_ACLS:
+            case DESCRIBE_ACLS:
+                return extractSingleError(response, "cluster");
+            case CONSUMER_GROUP_HEARTBEAT:
+                return extractSingleErrorFromRequest(response, () -> request.body(ConsumerGroupHeartbeatRequest.class).data().groupId());
+            case CONSUMER_GROUP_DESCRIBE:
+                return extractSingleErrorFromRequest(response, () -> {
+                    List<String> ids = request.body(ConsumerGroupDescribeRequest.class).data().groupIds();
+                    return ids.isEmpty() ? "" : ids.get(0);
+                });
+            default:
+                return extractDefaultErrors(response);
+        }
+    }
+
+    // ---- Per-topic response extractors ----
+
+    private static List<ResourceError> extractProduce(ProduceResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().responses().forEach(topic ->
+            topic.partitionResponses().forEach(p ->
+                maybeAdd(result, p.errorCode(), topic.name())));
+        return result;
+    }
+
+    private static List<ResourceError> extractFetch(FetchResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        // top-level error
+        maybeAdd(result, response.error().code(), "");
+        response.data().responses().forEach(topic ->
+            topic.partitions().forEach(p ->
+                maybeAdd(result, p.errorCode(), topic.topic())));
+        return result;
+    }
+
+    private static List<ResourceError> extractListOffsets(ListOffsetsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().topics().forEach(topic ->
+            topic.partitions().forEach(p ->
+                maybeAdd(result, p.errorCode(), topic.name())));
+        return result;
+    }
+
+    private static List<ResourceError> extractMetadata(MetadataResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().topics().forEach(topic ->
+            maybeAdd(result, topic.errorCode(), topic.name() != null ? topic.name() : ""));
+        return result;
+    }
+
+    private static List<ResourceError> extractOffsetCommit(RequestChannel.Request request, OffsetCommitResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        String groupId = request.body(OffsetCommitRequest.class).data().groupId();
+        response.data().topics().forEach(topic ->
+            topic.partitions().forEach(p -> {
+                short code = p.errorCode();
+                if (code == Errors.GROUP_AUTHORIZATION_FAILED.code()) {
+                    maybeAdd(result, code, groupId);
+                } else {
+                    maybeAdd(result, code, topic.name());
+                }
+            }));
+        return result;
+    }
+
+    private static List<ResourceError> extractOffsetFetch(OffsetFetchResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        // v8+ batched groups
+        response.data().groups().forEach(group ->
+            maybeAdd(result, group.errorCode(), group.groupId()));
+        // older single-group
+        if (response.data().groups().isEmpty()) {
+            maybeAdd(result, response.data().errorCode(), "");
+        }
+        return result;
+    }
+
+    private static List<ResourceError> extractFindCoordinator(RequestChannel.Request request, FindCoordinatorResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        if (!response.data().coordinators().isEmpty()) {
+            response.data().coordinators().forEach(c ->
+                maybeAdd(result, c.errorCode(), c.key()));
+        } else {
+            String key = request.body(FindCoordinatorRequest.class).data().key();
+            maybeAdd(result, response.data().errorCode(), key != null ? key : "");
+        }
+        return result;
+    }
+
+    private static List<ResourceError> extractCreateTopics(CreateTopicsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().topics().forEach(topic ->
+            maybeAdd(result, topic.errorCode(), topic.name()));
+        return result;
+    }
+
+    private static List<ResourceError> extractDeleteTopics(DeleteTopicsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().responses().forEach(topic ->
+            maybeAdd(result, topic.errorCode(), topic.name() != null ? topic.name() : ""));
+        return result;
+    }
+
+    private static List<ResourceError> extractCreatePartitions(CreatePartitionsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().results().forEach(r ->
+            maybeAdd(result, r.errorCode(), r.name()));
+        return result;
+    }
+
+    // ---- Per-group response extractors ----
+
+    private static List<ResourceError> extractDescribeGroups(DescribeGroupsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().groups().forEach(g ->
+            maybeAdd(result, g.errorCode(), g.groupId()));
+        return result;
+    }
+
+    private static List<ResourceError> extractDeleteGroups(DeleteGroupsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().results().forEach(r ->
+            maybeAdd(result, r.errorCode(), r.groupId()));
+        return result;
+    }
+
+    // ---- Transaction extractors ----
+
+    private static List<ResourceError> extractAddPartitionsToTxn(AddPartitionsToTxnResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        // v3 and below: per-topic results
+        response.data().resultsByTopicV3AndBelow().forEach(topic ->
+            topic.resultsByPartition().forEach(p ->
+                maybeAdd(result, p.partitionErrorCode(), topic.name())));
+        // v4+: per-transaction, per-topic results
+        response.data().resultsByTransaction().forEach(txn ->
+            txn.topicResults().forEach(topic ->
+                topic.resultsByPartition().forEach(p ->
+                    maybeAdd(result, p.partitionErrorCode(), topic.name()))));
+        return result;
+    }
+
+    private static List<ResourceError> extractTxnOffsetCommit(TxnOffsetCommitResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().topics().forEach(topic ->
+            topic.partitions().forEach(p ->
+                maybeAdd(result, p.errorCode(), topic.name())));
+        return result;
+    }
+
+    // ---- Config extractors ----
+
+    private static List<ResourceError> extractAlterConfigs(AlterConfigsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().responses().forEach(r ->
+            maybeAdd(result, r.errorCode(), r.resourceName()));
+        return result;
+    }
+
+    private static List<ResourceError> extractDescribeConfigs(DescribeConfigsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().results().forEach(r ->
+            maybeAdd(result, r.errorCode(), r.resourceName()));
+        return result;
+    }
+
+    private static List<ResourceError> extractIncrementalAlterConfigs(IncrementalAlterConfigsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.data().responses().forEach(r ->
+            maybeAdd(result, r.errorCode(), r.resourceName()));
+        return result;
+    }
+
+    // ---- Helpers ----
+
+    private static List<ResourceError> extractSingleError(AbstractResponse response, String resource) {
+        List<ResourceError> result = new ArrayList<>();
+        response.errorCounts().forEach((error, count) ->
+            maybeAdd(result, error.code(), resource));
+        return result;
+    }
+
+    @FunctionalInterface
+    private interface ResourceSupplier {
+        String get();
+    }
+
+    private static List<ResourceError> extractSingleErrorFromRequest(
+            AbstractResponse response, ResourceSupplier resourceSupplier) {
+        List<ResourceError> result = new ArrayList<>();
+        String resource = resourceSupplier.get();
+        response.errorCounts().forEach((error, count) ->
+            maybeAdd(result, error.code(), resource));
+        return result;
+    }
+
+    private static List<ResourceError> extractDefaultErrors(AbstractResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        response.errorCounts().forEach((error, count) ->
+            maybeAdd(result, error.code(), ""));
+        return result;
+    }
+
+    private static void maybeAdd(List<ResourceError> result, short errorCode, String resource) {
+        if (errorCode != 0) {
+            result.add(new ResourceError(errorCode, resource));
+        }
+    }
+
+    private static String doExtractResourceFromRequest(RequestChannel.Request request) {
+        ApiKeys apiKey = request.header().apiKey();
+        switch (apiKey) {
+            case PRODUCE:
+                var produceTopics = request.body(org.apache.kafka.common.requests.ProduceRequest.class).data().topicData();
+                return produceTopics.isEmpty() ? "" : produceTopics.iterator().next().name();
+            case JOIN_GROUP:
+                return request.body(JoinGroupRequest.class).data().groupId();
+            case SYNC_GROUP:
+                return request.body(SyncGroupRequest.class).data().groupId();
+            case HEARTBEAT:
+                return request.body(HeartbeatRequest.class).data().groupId();
+            case LEAVE_GROUP:
+                return request.body(LeaveGroupRequest.class).data().groupId();
+            case OFFSET_COMMIT:
+                return request.body(OffsetCommitRequest.class).data().groupId();
+            case INIT_PRODUCER_ID: {
+                String txnId = request.body(InitProducerIdRequest.class).data().transactionalId();
+                return txnId != null ? txnId : "";
+            }
+            case ADD_OFFSETS_TO_TXN:
+                return request.body(AddOffsetsToTxnRequest.class).data().transactionalId();
+            case END_TXN:
+                return request.body(EndTxnRequest.class).data().transactionalId();
+            case FIND_COORDINATOR: {
+                String key = request.body(FindCoordinatorRequest.class).data().key();
+                return key != null ? key : "";
+            }
+            case CONSUMER_GROUP_HEARTBEAT:
+                return request.body(ConsumerGroupHeartbeatRequest.class).data().groupId();
+            default:
+                return "";
+        }
+    }
+}

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.network
-import kafka.server.{KafkaConfig, RequestLocal}
+import kafka.server.{KafkaConfig, RequestErrorAccumulator, RequestLocal, ResourceErrorExtractor}
 import kafka.utils.Implicits._
 import kafka.utils.{Logging, Pool}
 import org.apache.kafka.common.config.ConfigResource
@@ -187,6 +187,12 @@ object RequestChannel extends Logging {
           throw new ClassCastException(s"Expected request with type ${classTag.runtimeClass}, but found ${r.getClass}")
       }
     }
+
+    // AutoMQ inject start
+    def body[T <: AbstractRequest](clazz: Class[T]): T = {
+      clazz.cast(bodyAndSize.request)
+    }
+    // AutoMQ inject end
 
     def loggableRequest: AbstractRequest = {
 
@@ -392,6 +398,10 @@ class RequestChannel(val queueSize: Int,
   private val multiCallbackQueue = new java.util.ArrayList[ArrayBlockingQueue[BaseRequest]]()
   private var notifiedShutdown = false
 
+  // AutoMQ inject start - request error accumulator
+  @volatile var requestErrorAccumulator: RequestErrorAccumulator = _
+  // AutoMQ inject end
+
   metricsGroup.newGauge(requestQueueSizeMetricName, () => {
     if (multiRequestQueue.size() != 0) {
       multiRequestQueue.stream().mapToInt(q => q.size()).sum()
@@ -456,6 +466,9 @@ class RequestChannel(val queueSize: Int,
     // This case is used when the request handler has encountered an error, but the client
     // does not expect a response (e.g. when produce request has acks set to 0)
     updateErrorMetrics(request.header.apiKey, errorCounts.asScala)
+    // AutoMQ inject start
+    maybeRecordRequestErrorsFromMap(request, errorCounts)
+    // AutoMQ inject end
     sendResponse(new RequestChannel.CloseConnectionResponse(request))
   }
 
@@ -465,6 +478,9 @@ class RequestChannel(val queueSize: Int,
     onComplete: Option[Send => Unit]
   ): Unit = {
     updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala)
+    // AutoMQ inject start
+    maybeRecordRequestErrors(request, response)
+    // AutoMQ inject end
     sendResponse(new RequestChannel.SendResponse(
       request,
       request.buildResponseSend(response),
@@ -567,6 +583,40 @@ class RequestChannel(val queueSize: Int,
   @Deprecated
   def receiveRequest(): RequestChannel.BaseRequest =
     requestQueue.take()
+
+  // AutoMQ inject start
+  private def maybeRecordRequestErrors(
+    request: RequestChannel.Request,
+    response: AbstractResponse
+  ): Unit = {
+    val acc = requestErrorAccumulator
+    if (acc == null) return
+    val errors = ResourceErrorExtractor.extract(request, response)
+    if (errors.isEmpty) return
+    val clientIp = request.context.clientAddress.getHostAddress
+    val clientId = request.header.clientId
+    val apiKey = request.header.apiKey.id
+    errors.forEach { re =>
+      acc.record(apiKey, re.errorCode, re.resource, clientIp, clientId)
+    }
+  }
+
+  private def maybeRecordRequestErrorsFromMap(
+    request: RequestChannel.Request,
+    errorCounts: java.util.Map[Errors, Integer]
+  ): Unit = {
+    val acc = requestErrorAccumulator
+    if (acc == null) return
+    val clientIp = request.context.clientAddress.getHostAddress
+    val clientId = request.header.clientId
+    val apiKey = request.header.apiKey.id
+    val resource = ResourceErrorExtractor.extractResourceFromRequest(request)
+    errorCounts.forEach { (error, _) =>
+      if (RequestErrorAccumulator.isRecordable(error.code))
+        acc.record(apiKey, error.code, resource, clientIp, clientId)
+    }
+  }
+  // AutoMQ inject end
 
   def updateErrorMetrics(apiKey: ApiKeys, errors: collection.Map[Errors, Integer]): Unit = {
     errors.forKeyValue { (error, count) =>

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -24,10 +24,11 @@ import kafka.controller.KafkaController
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.clients.admin.ClusterEventsConfig
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.InvalidTopicException
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TABLE_TOPIC_CONTROL_TOPIC_NAME, TABLE_TOPIC_DATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
+import org.apache.kafka.common.internals.Topic.{CLUSTER_EVENTS_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, TABLE_TOPIC_CONTROL_TOPIC_NAME, TABLE_TOPIC_DATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
 import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreatableTopicConfig, CreatableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
@@ -262,6 +263,15 @@ class DefaultAutoTopicCreationManager(
         new CreatableTopic()
           .setName(topic)
           .setNumPartitions(50)
+          .setReplicationFactor(1)
+          .setConfigs(convertToTopicConfigCollections(configs))
+      }
+      case CLUSTER_EVENTS_TOPIC_NAME => {
+        val configs = new Properties()
+        configs.put(TopicConfig.RETENTION_MS_CONFIG, ClusterEventsConfig.DEFAULT_RETENTION_MS)
+        new CreatableTopic()
+          .setName(topic)
+          .setNumPartitions(ClusterEventsConfig.DEFAULT_PARTITIONS)
           .setReplicationFactor(1)
           .setConfigs(convertToTopicConfigCollections(configs))
       }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -174,6 +174,7 @@ class BrokerServer(
   config.addReconfigurable(clientRackProvider)
 
   var tableManager: TableManager = _
+  var requestErrorAccumulator: RequestErrorAccumulator = _
   // AutoMQ inject end
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
@@ -461,6 +462,22 @@ class BrokerServer(
         socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
         config.numIoThreads, s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
         DataPlaneAcceptor.ThreadPrefix)
+
+      // AutoMQ inject start - cluster event publisher and request error accumulator
+      try {
+        val publisherConfig = new java.util.HashMap[String, Object]()
+        kafka.automq.utils.ClientUtils.clusterClientBaseConfig(config).forEach { (k, v) =>
+          publisherConfig.put(k.toString, v)
+        }
+        config.rack.foreach(rack => publisherConfig.put("client.id", "automq_az=" + rack))
+        org.apache.kafka.clients.admin.ClusterEventPublisher.setup(publisherConfig)
+        requestErrorAccumulator = new RequestErrorAccumulator(config.nodeId, 30000L)
+        socketServer.dataPlaneRequestChannel.requestErrorAccumulator = requestErrorAccumulator
+      } catch {
+        case e: Throwable =>
+          error("Failed to initialize ClusterEventPublisher/RequestErrorAccumulator", e)
+      }
+      // AutoMQ inject end
 
       // Start RemoteLogManager before initializing broker metadata publishers.
       remoteLogManagerOpt.foreach { rlm =>
@@ -796,6 +813,12 @@ class BrokerServer(
 
       if (quotaManagers != null)
         CoreUtils.swallow(quotaManagers.shutdown(), this)
+
+      // AutoMQ inject start - shutdown request error accumulator and cluster event publisher
+      if (requestErrorAccumulator != null)
+        CoreUtils.swallow(requestErrorAccumulator.close(), this)
+      CoreUtils.swallow(org.apache.kafka.clients.admin.ClusterEventPublisher.shutdown(), this)
+      // AutoMQ inject end
 
       if (socketServer != null)
         CoreUtils.swallow(socketServer.shutdown(), this)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1321,10 +1321,10 @@ class KafkaApis(val requestChannel: RequestChannel,
         autoTopicCreationManager.createTopics(nonExistingTopics, controllerMutationQuota, Some(request.context))
       } else {
         // AutoMQ inject start
-        for (tableTopic <- Set(Topic.TABLE_TOPIC_CONTROL_TOPIC_NAME, Topic.TABLE_TOPIC_DATA_TOPIC_NAME)) {
-          if (nonExistingTopics.contains(tableTopic)) {
+        for (autoCreateTopic <- Set(Topic.TABLE_TOPIC_CONTROL_TOPIC_NAME, Topic.TABLE_TOPIC_DATA_TOPIC_NAME, Topic.CLUSTER_EVENTS_TOPIC_NAME)) {
+          if (nonExistingTopics.contains(autoCreateTopic)) {
             val controllerMutationQuota = quotas.controllerMutation.newPermissiveQuotaFor(request)
-            autoTopicCreationManager.createTopics(Set(tableTopic), controllerMutationQuota, Some(request.context))
+            autoTopicCreationManager.createTopics(Set(autoCreateTopic), controllerMutationQuota, Some(request.context))
           }
         }
         // AutoMQ inject end

--- a/core/src/test/java/kafka/server/RequestErrorEventDataTest.java
+++ b/core/src/test/java/kafka/server/RequestErrorEventDataTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import org.apache.kafka.clients.admin.RequestErrorEventData;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RequestErrorEventDataTest {
+
+    @Test
+    void roundTripSerialization() {
+        RequestErrorEventData original = new RequestErrorEventData()
+            .setApiKey(0)
+            .setErrorCode(29)
+            .setResource("my-topic")
+            .setClientIps(List.of("10.0.0.1"))
+            .setClientIds(List.of("producer-1"))
+            .setRps(42.0);
+
+        byte[] bytes = original.toByteArray();
+        assertNotNull(bytes);
+
+        RequestErrorEventData decoded = RequestErrorEventData.fromByteArray(bytes);
+        assertEquals(0, decoded.apiKey());
+        assertEquals(29, decoded.errorCode());
+        assertEquals("my-topic", decoded.resource());
+        assertEquals(List.of("10.0.0.1"), decoded.clientIps());
+        assertEquals(List.of("producer-1"), decoded.clientIds());
+        assertEquals(42.0, decoded.rps(), 0.001);
+    }
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -194,6 +194,7 @@ versions += [
   iceberg: "1.6.1",
   wire: "4.9.1",
   oshi: "6.8.1",
+  cloudevents: "4.0.1",
   // AutoMQ inject end
 
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
@@ -337,4 +338,5 @@ libs += [
   kafkaAvroSerializer: "io.confluent:kafka-avro-serializer:$versions.confluentSchema",
   spotbugsAnnotations: "com.github.spotbugs:spotbugs-annotations:$versions.spotbugs",
   oshi: "com.github.oshi:oshi-core:$versions.oshi",
+  cloudeventsKafka: "io.cloudevents:cloudevents-kafka:$versions.cloudevents",
 ]

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -636,6 +636,10 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"/>
         </Or>
     </Match>
+    <!-- Suppress all warnings for protobuf-generated classes -->
+    <Match>
+        <Package name="~com\.automq\.events"/>
+    </Match>
     <!-- AutoMQ inject end -->
 
     <Match>

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterEventsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterEventsCommand.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ClusterEventTypeRegistry;
+import org.apache.kafka.clients.admin.ClusterEventsReader;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.util.CommandDefaultOptions;
+import org.apache.kafka.server.util.CommandLineUtils;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.cloudevents.CloudEvent;
+import joptsimple.ArgumentAcceptingOptionSpec;
+
+/**
+ * CLI tool for querying the {@code __automq_cluster_events} internal topic.
+ *
+ * <p>When {@code --until} is not specified, runs in tail mode: continuously polls
+ * for new events until Ctrl-C or {@code --max-events} is reached.
+ *
+ * <pre>
+ * kafka-cluster-events.sh --bootstrap-server localhost:9092 \
+ *   --type com.automq.ops.rebalance.summary --since -24h
+ * </pre>
+ */
+public class ClusterEventsCommand {
+
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(2);
+
+    public static void main(String[] args) {
+        Exit.exit(mainNoExit(args, System.out));
+    }
+
+    static int mainNoExit(String[] args, PrintStream out) {
+        ClusterEventsCommandOptions opts = new ClusterEventsCommandOptions(args);
+        try {
+            opts.checkArgs();
+        } catch (Exception e) {
+            out.println("Error: " + e.getMessage());
+            try {
+                opts.parser.printHelpOn(out);
+            } catch (IOException ioe) {
+                // ignore
+            }
+            return 1;
+        }
+
+        Properties props = buildAdminProps(opts, out);
+        if (props == null) return 1;
+
+        try (Admin admin = Admin.create(props);
+             ClusterEventsReader reader = admin.describeClusterEvents(parseSinceMs(opts))) {
+            return pollLoop(reader, out, opts);
+        } catch (Exception e) {
+            out.println("Error: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private static Long parseSinceMs(ClusterEventsCommandOptions opts) {
+        return opts.options.has(opts.sinceOpt)
+            ? parseTimeArg(opts.options.valueOf(opts.sinceOpt)) : null;
+    }
+
+    private static int pollLoop(ClusterEventsReader reader, PrintStream out,
+                                ClusterEventsCommandOptions opts) {
+        EventFilter filter = EventFilter.from(opts);
+        AtomicBoolean running = new AtomicBoolean(true);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> running.set(false)));
+
+        int count = 0;
+        while (running.get() && count < filter.maxEvents) {
+            List<CloudEvent> events = reader.poll(POLL_TIMEOUT);
+            for (CloudEvent event : events) {
+                if (filter.isPastUntil(event)) return 0;
+                if (filter.matches(event)) {
+                    out.println(formatEvent(event));
+                    if (++count >= filter.maxEvents) return 0;
+                }
+            }
+            if (!filter.tailMode && reader.isPolledToEnd()) break;
+        }
+        return 0;
+    }
+
+    private static final class EventFilter {
+        final Long untilMs;
+        final int maxEvents;
+        final String eventType;
+        final Pattern sourceRegex;
+        final Pattern subjectRegex;
+        final boolean tailMode;
+
+        EventFilter(Long untilMs, int maxEvents, String eventType,
+                    Pattern sourceRegex, Pattern subjectRegex) {
+            this.untilMs = untilMs;
+            this.maxEvents = maxEvents;
+            this.eventType = eventType;
+            this.sourceRegex = sourceRegex;
+            this.subjectRegex = subjectRegex;
+            this.tailMode = untilMs == null;
+        }
+
+        static EventFilter from(ClusterEventsCommandOptions opts) {
+            Long untilMs = opts.options.has(opts.untilOpt)
+                ? parseTimeArg(opts.options.valueOf(opts.untilOpt)) : null;
+            int maxEvents = opts.options.has(opts.maxEventsOpt)
+                ? opts.options.valueOf(opts.maxEventsOpt) : Integer.MAX_VALUE;
+            String eventType = opts.options.has(opts.typeOpt)
+                ? opts.options.valueOf(opts.typeOpt) : null;
+            Pattern sourceRegex = opts.options.has(opts.sourceOpt)
+                ? Pattern.compile(opts.options.valueOf(opts.sourceOpt)) : null;
+            Pattern subjectRegex = opts.options.has(opts.subjectOpt)
+                ? Pattern.compile(opts.options.valueOf(opts.subjectOpt)) : null;
+            return new EventFilter(untilMs, maxEvents, eventType, sourceRegex, subjectRegex);
+        }
+
+        boolean isPastUntil(CloudEvent event) {
+            if (untilMs == null) return false;
+            java.time.OffsetDateTime time = event.getTime();
+            return time != null && time.toInstant().toEpochMilli() > untilMs;
+        }
+
+        boolean matches(CloudEvent event) {
+            if (event == null) return false;
+            if (eventType != null && !eventType.equals(event.getType())) return false;
+            if (!matchesPattern(sourceRegex, event.getSource() != null ? event.getSource().toString() : null))
+                return false;
+            return matchesPattern(subjectRegex, event.getSubject());
+        }
+
+        private static boolean matchesPattern(Pattern pattern, String value) {
+            if (pattern == null) return true;
+            return value != null && pattern.matcher(value).find();
+        }
+    }
+
+    private static Properties buildAdminProps(ClusterEventsCommandOptions opts, PrintStream out) {
+        Properties props = new Properties();
+        if (opts.options.has(opts.commandConfigOpt)) {
+            try {
+                props.putAll(Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt)));
+            } catch (IOException e) {
+                out.println("Error loading command config: " + e.getMessage());
+                return null;
+            }
+        }
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt));
+        return props;
+    }
+
+    /**
+     * Parse a time argument. Accepts:
+     * <ul>
+     *   <li>ISO-8601 datetime: {@code 2026-04-07T10:00:00Z}</li>
+     *   <li>Relative: {@code -1h}, {@code -24h}, {@code -7d}</li>
+     * </ul>
+     */
+    static long parseTimeArg(String value) {
+        value = value.trim();
+        Pattern relative = Pattern.compile("^-(\\d+)([hHdD])$");
+        Matcher m = relative.matcher(value);
+        if (m.matches()) {
+            long amount = Long.parseLong(m.group(1));
+            String unit = m.group(2).toLowerCase(java.util.Locale.ROOT);
+            long millis = unit.equals("h") ? amount * 3600_000L : amount * 86400_000L;
+            return System.currentTimeMillis() - millis;
+        }
+        try {
+            return OffsetDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .toInstant().toEpochMilli();
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Cannot parse time value '" + value
+                + "'. Use ISO-8601 (e.g. 2026-04-07T10:00:00Z) or relative (e.g. -1h, -7d).");
+        }
+    }
+
+    private static String formatEvent(CloudEvent event) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("type=").append(event.getType());
+        sb.append(" source=").append(event.getSource());
+        if (event.getSubject() != null)
+            sb.append(" subject=").append(event.getSubject());
+        if (event.getTime() != null)
+            sb.append(" time=").append(event.getTime());
+        ClusterEventTypeRegistry.decode(event).ifPresentOrElse(
+            decoded -> sb.append(" data=").append(decoded),
+            () -> {
+                io.cloudevents.CloudEventData data = event.getData();
+                if (data != null) {
+                    byte[] bytes = data.toBytes();
+                    if (bytes != null)
+                        sb.append(" data=").append(new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
+                }
+            }
+        );
+        return sb.toString();
+    }
+
+    static final class ClusterEventsCommandOptions extends CommandDefaultOptions {
+        final ArgumentAcceptingOptionSpec<String> bootstrapServerOpt;
+        final ArgumentAcceptingOptionSpec<String> commandConfigOpt;
+        final ArgumentAcceptingOptionSpec<String> typeOpt;
+        final ArgumentAcceptingOptionSpec<String> sinceOpt;
+        final ArgumentAcceptingOptionSpec<String> untilOpt;
+        final ArgumentAcceptingOptionSpec<String> sourceOpt;
+        final ArgumentAcceptingOptionSpec<String> subjectOpt;
+        final ArgumentAcceptingOptionSpec<Integer> maxEventsOpt;
+
+        ClusterEventsCommandOptions(String[] args) {
+            super(args);
+            bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The Kafka server to connect to.")
+                .withRequiredArg().describedAs("server").ofType(String.class);
+            commandConfigOpt = parser.accepts("command-config",
+                "Property file containing configs to be passed to Admin Client.")
+                .withRequiredArg().describedAs("config file").ofType(String.class);
+            typeOpt = parser.accepts("type", "Filter by CloudEvent type (e.g. com.automq.ops.rebalance.summary).")
+                .withRequiredArg().ofType(String.class);
+            sinceOpt = parser.accepts("since",
+                "Only show events at or after this time. ISO-8601 or relative (e.g. -1h, -7d).")
+                .withRequiredArg().ofType(String.class);
+            untilOpt = parser.accepts("until",
+                "Only show events at or before this time. ISO-8601 or relative. "
+                + "If not set, runs in tail mode (continuously polls until Ctrl-C).")
+                .withRequiredArg().ofType(String.class);
+            sourceOpt = parser.accepts("source", "Filter by source (regex).")
+                .withRequiredArg().ofType(String.class);
+            subjectOpt = parser.accepts("subject", "Filter by subject (regex).")
+                .withRequiredArg().ofType(String.class);
+            maxEventsOpt = parser.accepts("max-events", "Maximum number of events to return.")
+                .withRequiredArg().ofType(Integer.class);
+            options = parser.parse(args);
+        }
+
+        void checkArgs() {
+            CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt);
+        }
+    }
+}


### PR DESCRIPTION
Introduce a cluster-level event system that publishes structured events to the `__automq_cluster_events` internal topic using CloudEvents + protobuf.

**Core infrastructure:**
- `ClusterEventPublisher`: async, best-effort producer that wraps events as CloudEvents and writes them to the internal topic
- `ClusterEventsReader`: consumer-based reader for retrieving events
- `ClusterEventsCommand`: CLI tool (`kafka-cluster-events.sh`) for reading and displaying cluster events

**RequestErrorEvent pipeline:**
- Detects sustained request error patterns (e.g. auth failures, authorization errors) on the broker and publishes them as events, enabling the control plane to surface risky or misconfigured clients
- Integrated into `RequestChannel` and `KafkaApis` to capture errors on the broker request path
- `ResourceErrorExtractor` parses per-resource error codes from Kafka API responses (Produce, Fetch, Metadata, etc.)
- `RequestErrorAccumulator` aggregates errors in-memory by (apiKey, errorCode, resource) with client IP/ID tracking, then periodically flushes accumulated buckets as `RequestErrorEvent` records