### PR TITLE
fix(s3stream): fix double-release race in LogCache.tryMerge (#3307)

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -312,6 +312,8 @@ public class LogCache {
         for (; ; ) {
             LogCacheBlock left;
             LogCacheBlock right;
+            long leftFreeOpsModCount;
+            long rightFreeOpsModCount;
             writeLock.lock();
             try {
                 if (blocks.size() <= MERGE_BLOCK_THRESHOLD || mergeStartIndex + 1 >= blocks.size()) {
@@ -326,6 +328,8 @@ public class LogCache {
                     mergeStartIndex++;
                     continue;
                 }
+                leftFreeOpsModCount = left.freeOpsModCount;
+                rightFreeOpsModCount = right.freeOpsModCount;
             } finally {
                 writeLock.unlock();
             }
@@ -343,6 +347,8 @@ public class LogCache {
                 if (blocks.size() > mergeStartIndex + 1
                     && blocks.get(mergeStartIndex) == left
                     && blocks.get(mergeStartIndex + 1) == right
+                    && left.freeOpsModCount == leftFreeOpsModCount
+                    && right.freeOpsModCount == rightFreeOpsModCount
                 ) {
                     blocks.set(mergeStartIndex, newBlock);
                     blocks.remove(mergeStartIndex + 1);
@@ -428,6 +434,7 @@ public class LogCache {
         private final AtomicLong size = new AtomicLong();
         private final List<FreeListener> freeListeners = new ArrayList<>();
         volatile boolean free;
+        long freeOpsModCount;
         private RecordOffset lastRecordOffset;
 
         public LogCacheBlock(long maxSize, int maxStreamCount) {
@@ -497,6 +504,7 @@ public class LogCache {
 
         public void free() {
             suppress(() -> {
+                freeOpsModCount++;
                 List<StreamRangeBound> streams = new ArrayList<>(map.size());
                 map.forEach((streamId, records) -> {
                     streams.add(new StreamRangeBound(streamId, records.startOffset(), records.endOffset()));
@@ -510,6 +518,7 @@ public class LogCache {
         public void free(long streamId) {
             StreamCache streamCache = map.remove(streamId);
             if (streamCache != null) {
+                freeOpsModCount++;
                 LOG_CACHE_ASYNC_EXECUTOR.execute(() -> suppress(streamCache::free, LOGGER));
             }
         }

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -203,6 +205,91 @@ public class LogCacheTest {
         assertEquals(2L, mergedCache.endOffset());
         assertEquals(0L, mergedCache.records.get(0).getBaseOffset());
         assertEquals(1L, mergedCache.records.get(1).getBaseOffset());
+    }
+
+    /**
+     * Verify that freeOpsModCount is incremented when a stream is removed from a block,
+     * and that tryMerge aborts the swap when the count changes between the two lock acquisitions.
+     */
+    @Test
+    public void testMergeAbortedWhenBlockMutatedDuringMerge() throws ExecutionException, InterruptedException {
+        LogCache logCache = new LogCache(Long.MAX_VALUE, 10_000L);
+        final long streamId1 = 1L;
+        final long streamId2 = 2L;
+
+        // Two blocks, each with two streams so clearStreamRecords can mutate one while merge runs.
+        logCache.put(StreamRecordBatch.of(streamId1, 0L, 0L, 1, TestUtils.random(1)));
+        logCache.put(StreamRecordBatch.of(streamId2, 0L, 0L, 1, TestUtils.random(1)));
+        LogCacheBlock block0 = logCache.archiveCurrentBlock();
+
+        logCache.put(StreamRecordBatch.of(streamId1, 0L, 1L, 1, TestUtils.random(1)));
+        logCache.put(StreamRecordBatch.of(streamId2, 0L, 1L, 1, TestUtils.random(1)));
+        LogCacheBlock block1 = logCache.archiveCurrentBlock();
+
+        assertEquals(0, block0.freeOpsModCount);
+        assertEquals(0, block1.freeOpsModCount);
+
+        // Simulate clearStreamRecords mutating blocks while tryMerge would be running.
+        block0.free = true;
+        block1.free = true;
+        logCache.clearStreamRecords(streamId2);
+
+        assertEquals(1, block0.freeOpsModCount);
+        assertEquals(1, block1.freeOpsModCount);
+
+        // tryMerge should detect the mutation and NOT replace the blocks.
+        int blocksBefore = logCache.blocks.size();
+        logCache.markFree(block0).get();
+        // blocks should not have been merged since freeOpsModCount changed
+        assertEquals(blocksBefore, logCache.blocks.size());
+    }
+
+    /**
+     * Concurrent stress test: markFree (which triggers tryMerge) races with clearStreamRecords.
+     * Without the freeOpsModCount guard this would cause IllegalReferenceCountException.
+     */
+    @Test
+    public void testNoDoubleReleaseUnderConcurrentClearAndMerge() throws Exception {
+        final int iterations = 200;
+        for (int iter = 0; iter < iterations; iter++) {
+            LogCache logCache = new LogCache(Long.MAX_VALUE, 10_000L);
+            final long streamId1 = 1L;
+            final long streamId2 = 2L;
+
+            // Fill enough blocks to exceed MERGE_BLOCK_THRESHOLD so tryMerge actually runs.
+            for (int i = 0; i < LogCache.MERGE_BLOCK_THRESHOLD + 2; i++) {
+                logCache.put(StreamRecordBatch.of(streamId1, 0L, i, 1, TestUtils.random(1)));
+                logCache.put(StreamRecordBatch.of(streamId2, 0L, i, 1, TestUtils.random(1)));
+                LogCacheBlock b = logCache.archiveCurrentBlock();
+                b.free = true;
+            }
+
+            CountDownLatch latch = new CountDownLatch(1);
+
+            // Thread 1: trigger tryMerge via markFree
+            CompletableFuture<Void> mergeFuture = CompletableFuture.runAsync(() -> {
+                try {
+                    latch.await();
+                    logCache.markFree(logCache.blocks.get(0)).get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // Thread 2: concurrently clear streamId2 from all blocks
+            CompletableFuture<Void> clearFuture = CompletableFuture.runAsync(() -> {
+                try {
+                    latch.await();
+                    logCache.clearStreamRecords(streamId2);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            latch.countDown();
+            // Should complete without IllegalReferenceCountException
+            CompletableFuture.allOf(mergeFuture, clearFuture).get();
+        }
     }
 
 }


### PR DESCRIPTION
## Bug

A rare `IllegalReferenceCountException: refCnt: 0, decrement: 1` occurs when `LogCacheBlock.free()` tries to release a `StreamRecordBatch` whose refCnt is already 0.

Root cause: `tryMerge` performs the expensive `mergeBlock` call outside the write lock for performance. During that window, `clearStreamRecords` can acquire the write lock and call `block.free(streamId)`, which removes a `StreamCache` from the block and schedules an async release of all its `StreamRecordBatch` records (refCnt → 0). When `tryMerge` then re-acquires the write lock, it only checks that `left`/`right` are still the same block objects in `blocks` — it does not detect that the blocks were mutated. So the merged `newBlock` (which shares the same record references via `mergeBlock`) replaces `left`/`right` in `blocks`. Later, when `newBlock.free()` is called, it tries to release records that are already at refCnt 0, causing the crash.

## Fix

Add a `freeOpsModCount` field to `LogCacheBlock` that is incremented whenever the block is mutated by a free operation (`free()` or `free(long streamId)`). In `tryMerge`, snapshot both blocks' `freeOpsModCount` inside the same write lock that selects `left` and `right`. After `mergeBlock` completes, re-acquire the write lock and verify the counts are unchanged before committing the swap. If either block was mutated in between, the merge is aborted and `newBlock` is simply discarded — preventing stale record references from entering `blocks` and being double-freed.