### PR TITLE
fix: force jaxb-api to 2.3.1 to avoid duplicate versions in release packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,10 @@ allprojects {
           // AutoMQ inject start
           // pin OTel sender versions to prevent version conflicts with Strimzi thirdparty-libs
           libs.opentelemetryExporterSenderJdk,
-          libs.opentelemetryExporterSenderGrpcManagedChannel
+          libs.opentelemetryExporterSenderGrpcManagedChannel,
+          // unify JAXB versions across all modules to avoid duplicate jars in release packaging
+          libs.jaxbApi,
+          libs.jaxbImpl
           // AutoMQ inject end
         )
         // AutoMQ inject start

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -114,6 +114,7 @@ versions += [
   scalaLogging: "3.9.5",
   jaxAnnotation: "1.3.2",
   jaxb: "2.3.1",
+  jaxbRI: "2.3.1", // JAXB Reference Implementation version matching jaxb-api 2.3.1
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
@@ -235,6 +236,7 @@ libs += [
   // AutoMQ inject end
   jaxAnnotationApi: "javax.annotation:javax.annotation-api:$versions.jaxAnnotation",
   jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
+  jaxbImpl: "com.sun.xml.bind:jaxb-impl:$versions.jaxbRI",
   jaxrsApi: "javax.ws.rs:javax.ws.rs-api:$versions.jaxrs",
   javassist: "org.javassist:javassist:$versions.javassist",
   jettyServer: "org.eclipse.jetty:jetty-server:$versions.jetty",


### PR DESCRIPTION
## Problem

Release tarball `libs/` contains both `jaxb-api-2.2.12.jar` and `jaxb-api-2.3.1.jar` because:
- `:core` resolves `jaxb-api` to `2.2.12` (from `jackson-module-jaxb-annotations:2.20.0` transitive dep)
- `:trogdor`/`:connect:runtime`/`:connect:mirror` resolve to `2.3.1` (direct `implementation libs.jaxbApi`)

Each module resolves independently, and `releaseTarGz` copies all runtimeClasspaths into a flat `libs/` directory. `duplicatesStrategy EXCLUDE` only deduplicates same-name files, so both versions coexist.

## Fix

Add `libs.jaxbApi` to the global `configurations.all.resolutionStrategy.force` block, ensuring all modules resolve `jaxb-api` to the declared `2.3.1` version.

## Verification

```
# Before: :core resolves jaxb-api to 2.2.12
# After:
javax.xml.bind:jaxb-api:2.2.12 -> 2.3.1 (forced)
javax.xml.bind:jaxb-api:2.2.11 -> 2.3.1 (forced)
javax.xml.bind:jaxb-api:2.2.2  -> 2.3.1 (forced)

# dependant-libs: only jaxb-api-2.3.1.jar ✅
```