### PR TITLE
refactor: encapsulate KVImage/KVDelta map access to enforce KVKey type safety

### DIFF
--- a/core/src/main/java/kafka/automq/failover/FailoverListener.java
+++ b/core/src/main/java/kafka/automq/failover/FailoverListener.java
@@ -21,7 +21,7 @@ package kafka.automq.failover;
 
 import kafka.automq.utils.JsonUtils;
 
-import org.apache.kafka.image.KVDelta;
+import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.loader.LoaderManifest;
@@ -76,8 +76,7 @@ public class FailoverListener implements MetadataPublisher, AutoCloseable {
      */
     private Optional<FailoverContext[]> getContexts(MetadataDelta delta) {
         return Optional.ofNullable(delta.kvDelta())
-            .map(KVDelta::changedKV)
-            .map(kv -> kv.get(FailoverConstants.FAILOVER_KEY))
+            .map(kvDelta -> kvDelta.getChangedKV(KVKey.of(FailoverConstants.FAILOVER_KEY)))
             .map(this::decodeContexts);
     }
     

--- a/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
+++ b/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
@@ -126,7 +126,7 @@ public class DefaultRouterChannelProvider implements RouterChannelProvider {
         if (delta.kvDelta() == null) {
             return;
         }
-        ByteBuffer value = delta.kvDelta().changedKV().get(KVKey.of(RouterChannelEpoch.ROUTER_CHANNEL_EPOCH_KEY));
+        ByteBuffer value = delta.kvDelta().getChangedKV(KVKey.of(RouterChannelEpoch.ROUTER_CHANNEL_EPOCH_KEY));
         if (value == null) {
             return;
         }

--- a/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
@@ -89,7 +89,11 @@ public final class KVDelta {
         return new KVImage(newKVs, registry);
     }
 
-    public Map<KVKey, ByteBuffer> changedKV() {
+    public ByteBuffer getChangedKV(KVKey kvKey) {
+        return changedKV.get(kvKey);
+    }
+
+    Map<KVKey, ByteBuffer> changedKV() {
         return changedKV;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/KVImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/KVImage.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
@@ -57,7 +58,16 @@ public final class KVImage extends AbstractReferenceCounted {
         return registryRef.inLock(() -> this.kv.get(kvKey, registryRef.epoch()));
     }
 
-    public Map<KVKey, ByteBuffer> kvs() {
+    public void forEach(BiConsumer<KVKey, ByteBuffer> action) {
+        if (kv == null || registryRef == RegistryRef.NOOP) {
+            return;
+        }
+        registryRef.inLock(() -> {
+            kv.entrySet(registryRef.epoch()).forEach(e -> action.accept(e.getKey(), e.getValue()));
+        });
+    }
+
+    Map<KVKey, ByteBuffer> kvs() {
         if (kv == null || registryRef == RegistryRef.NOOP) {
             return Collections.emptyMap();
         }

--- a/metadata/src/main/java/org/apache/kafka/image/node/automq/KVImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/automq/KVImageNode.java
@@ -45,7 +45,7 @@ public class KVImageNode implements MetadataNode {
     public Collection<String> childNames() {
         // Return the set of namespace node names
         Map<String, Object> namespaces = new HashMap<>();
-        kvImage.kvs().forEach((k, v) -> namespaces.put(nodeName(k.namespace()), null));
+        kvImage.forEach((k, v) -> namespaces.put(nodeName(k.namespace()), null));
         return namespaces.keySet();
     }
 
@@ -54,7 +54,7 @@ public class KVImageNode implements MetadataNode {
         // name is a namespace node name; return a sub-node for that namespace
         String namespace = name.equals(DEFAULT_NAMESPACE) ? null : name;
         Map<String, ByteBuffer> entries = new HashMap<>();
-        kvImage.kvs().forEach((k, v) -> {
+        kvImage.forEach((k, v) -> {
             if (Objects.equals(k.namespace(), namespace)) {
                 entries.put(k.key(), v);
             }


### PR DESCRIPTION
## Motivation

After the KV key type changed from `String` to `KVKey`, callers that still pass a raw `String` to `Map<KVKey, ByteBuffer>.get(Object)` compile without error but silently return `null` at runtime (since `String.equals(KVKey)` is always `false`).

This was already causing a bug in `FailoverListener`, where failover context changes were never detected. This bug is caused by https://github.com/AutoMQ/automq/pull/3306

## Changes

- **KVImage**: make `kvs()` package-private; add `public forEach(BiConsumer<KVKey, ByteBuffer>)` for safe iteration
- **KVDelta**: make `changedKV()` package-private; add `public getChangedKV(KVKey)` for type-safe lookup
- **FailoverListener**: fix bug — was passing `String` to `Map<KVKey,...>.get()`, now uses `getChangedKV(KVKey.of(...))`
- **DefaultRouterChannelProvider**: migrate to `getChangedKV()`
- **KVImageNode**: migrate to `forEach()`

By hiding the raw `Map`, callers are forced to go through typed APIs, preventing this class of bug at compile time.
