### PR TITLE
build: cherry-pick dependency alignment and packaging fixes from 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,11 +179,16 @@ allprojects {
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
-	  // be explicit about the reload4j version instead of relying on the transitive versions
-	  libs.reload4j,
-	  // pin OTel sender versions to prevent version conflicts with Strimzi thirdparty-libs
-	  libs.opentelemetryExporterSenderJdk,
-	  libs.opentelemetryExporterSenderGrpcManagedChannel
+          // be explicit about the reload4j version instead of relying on the transitive versions
+          libs.reload4j,
+          // AutoMQ inject start
+          // pin OTel sender versions to prevent version conflicts with Strimzi thirdparty-libs
+          libs.opentelemetryExporterSenderJdk,
+          libs.opentelemetryExporterSenderGrpcManagedChannel,
+          // unify JAXB versions across all modules to avoid duplicate jars in release packaging
+          libs.jaxbApi,
+          libs.jaxbImpl
+          // AutoMQ inject end
         )
         // AutoMQ inject start
         // swagger is only used for doc generation and still depends on jackson-yaml compatible with SnakeYAML 1.x.

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,16 @@ allprojects {
     // that are unrelated to the project dependencies, we should not change them
     if (name != "zinc") {
       resolutionStrategy {
+        // AutoMQ inject start
+        eachDependency { details ->
+          if (details.requested.group == 'io.netty' &&
+              details.requested.name != 'netty' &&
+              !details.requested.name.startsWith('netty-tcnative')) {
+            details.useVersion versions.netty
+            details.because('Release packaging must align all Netty modules to a single version')
+          }
+        }
+        // AutoMQ inject end
         force(
           // be explicit about the javassist dependency version instead of relying on the transitive version
           libs.javassist,
@@ -165,6 +175,9 @@ allprojects {
           libs.scalaLibrary,
           libs.scalaReflect,
           libs.jacksonAnnotations,
+          // AutoMQ inject start
+          libs.snakeyaml,
+          // AutoMQ inject end
           // be explicit about the Netty dependency version instead of relying on the version set by
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
@@ -995,7 +1008,7 @@ project(':core') {
     // table topic start
     implementation ("org.apache.avro:avro:${versions.avro}")
     implementation ("org.apache.avro:avro-protobuf:${versions.avro}")
-    implementation('com.google.protobuf:protobuf-java:3.25.5')
+    implementation libs.protobuf
     implementation ("org.apache.iceberg:iceberg-core:${versions.iceberg}")
     implementation ("org.apache.iceberg:iceberg-api:${versions.iceberg}")
     implementation ("org.apache.iceberg:iceberg-data:${versions.iceberg}")
@@ -1005,7 +1018,7 @@ project(':core') {
     implementation ("org.apache.iceberg:iceberg-nessie:${versions.iceberg}")
     implementation ("software.amazon.awssdk:glue:${versions.awsSdk}")
     implementation ("software.amazon.awssdk:s3tables:${versions.awsSdk}")
-    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.0'
+    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.8'
 
     implementation ('org.apache.hadoop:hadoop-common:3.4.1') {
       exclude group: 'org.eclipse.jetty', module: '*'
@@ -1053,7 +1066,7 @@ project(':core') {
     //   Wire Runtime for schema handling
     implementation ("com.squareup.wire:wire-schema:${versions.wire}")
     implementation ("com.squareup.wire:wire-runtime:${versions.wire}")
-    implementation 'com.google.api.grpc:proto-google-common-protos:2.52.0'
+    implementation libs.protoGoogleCommonProtos
     // > Protobuf ext end
 
     // table topic end
@@ -2403,7 +2416,7 @@ project(':automq-metrics') {
     implementation('io.opentelemetry:opentelemetry-sdk:1.40.0')
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha")
     implementation("io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:2.6.0-alpha")
-    implementation('com.google.protobuf:protobuf-java:3.25.5')
+    implementation libs.protobuf
     implementation('org.xerial.snappy:snappy-java:1.1.10.5')
   }
 
@@ -2461,8 +2474,8 @@ project(':tools') {
       exclude group: 'org.apache.kafka', module: 'kafka-clients'
     }
     implementation libs.bucket4j
-    implementation (libs.oshi){
-      exclude group: 'org.slf4j', module: '*'
+    implementation (libs.oshi) {
+      exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     // AutoMQ inject end
 

--- a/build.gradle
+++ b/build.gradle
@@ -175,9 +175,6 @@ allprojects {
           libs.scalaLibrary,
           libs.scalaReflect,
           libs.jacksonAnnotations,
-          // AutoMQ inject start
-          libs.snakeyaml,
-          // AutoMQ inject end
           // be explicit about the Netty dependency version instead of relying on the version set by
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
@@ -188,6 +185,12 @@ allprojects {
 	  libs.opentelemetryExporterSenderJdk,
 	  libs.opentelemetryExporterSenderGrpcManagedChannel
         )
+        // AutoMQ inject start
+        // swagger is only used for doc generation and still depends on jackson-yaml compatible with SnakeYAML 1.x.
+        if (name != "swagger") {
+          force(libs.snakeyaml)
+        }
+        // AutoMQ inject end
       }
     }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -225,6 +225,7 @@ libs += [
   jacksonYaml: "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$versions.jackson",
   // AutoMQ inject start
   snakeyaml: "org.yaml:snakeyaml:$versions.snakeyaml",
+  protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
   protoGoogleCommonProtos: "com.google.api.grpc:proto-google-common-protos:$versions.protoGoogleCommonProtos",
   // AutoMQ inject end
   jaxAnnotationApi: "javax.annotation:javax.annotation-api:$versions.jaxAnnotation",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,6 +112,7 @@ versions += [
   scalaLogging: "3.9.5",
   jaxAnnotation: "1.3.2",
   jaxb: "2.3.1",
+  jaxbRI: "2.3.1", // JAXB Reference Implementation version matching jaxb-api 2.3.1
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
@@ -228,6 +229,7 @@ libs += [
   // AutoMQ inject end
   jaxAnnotationApi: "javax.annotation:javax.annotation-api:$versions.jaxAnnotation",
   jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
+  jaxbImpl: "com.sun.xml.bind:jaxb-impl:$versions.jaxbRI",
   jaxrsApi: "javax.ws.rs:javax.ws.rs-api:$versions.jaxrs",
   javassist: "org.javassist:javassist:$versions.javassist",
   jettyServer: "org.eclipse.jetty:jetty-server:$versions.jetty",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,7 +97,11 @@ versions += [
   gradle: "8.8",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.17.1",
+  // AutoMQ inject start
+  jackson: "2.20.0",
+  // jackson-annotations uses "2.20" instead of "2.20.0"
+  jacksonAnnotationsVersion: "2.20",
+  // AutoMQ inject end
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "9.4.54.v20240208",
@@ -142,6 +146,10 @@ versions += [
   metrics: "2.2.0",
   netty: "4.1.111.Final",
   opentelemetryProto: "1.0.0-alpha",
+  // AutoMQ inject start
+  protobuf: "4.32.1",
+  protoGoogleCommonProtos: "2.40.0",
+  // AutoMQ inject end
   pcollections: "4.0.1",
   reflections: "0.10.2",
   reload4j: "1.2.25",
@@ -155,6 +163,9 @@ versions += [
   scoverage: "2.0.11",
   slf4j: "1.7.36",
   jclOverSlf4j: "1.7.36",
+  // AutoMQ inject start
+  snakeyaml: "2.5",
+  // AutoMQ inject end
   snappy: "1.1.10.5",
   spotbugs: "4.8.0",
   zinc: "1.9.2",
@@ -168,9 +179,8 @@ versions += [
   opentelemetrySDK: "1.40.0",
   opentelemetrySDKAlpha: "1.40.0-alpha",
   opentelemetryInstrument: "2.6.0-alpha",
-  oshi: "6.4.7",
   awsSdk:"2.29.26",
-  bucket4j:"8.5.0",
+  bucket4j:"8.10.1",
   jna:"5.2.0",
   guava:"32.0.1-jre",
   hdrHistogram:"2.1.12",
@@ -202,7 +212,9 @@ libs += [
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
-  jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
+  // AutoMQ inject start
+  jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jacksonAnnotationsVersion",
+  // AutoMQ inject end
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
   jacksonDataformatCsv: "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$versions.jackson",
   jacksonModuleScala: "com.fasterxml.jackson.module:jackson-module-scala_$versions.baseScala:$versions.jackson",
@@ -210,6 +222,10 @@ libs += [
   jacksonAfterburner: "com.fasterxml.jackson.module:jackson-module-afterburner:$versions.jackson",
   jacksonJaxrsJsonProvider: "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$versions.jackson",
   jacksonYaml: "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$versions.jackson",
+  // AutoMQ inject start
+  snakeyaml: "org.yaml:snakeyaml:$versions.snakeyaml",
+  protoGoogleCommonProtos: "com.google.api.grpc:proto-google-common-protos:$versions.protoGoogleCommonProtos",
+  // AutoMQ inject end
   jaxAnnotationApi: "javax.annotation:javax.annotation-api:$versions.jaxAnnotation",
   jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
   jaxrsApi: "javax.ws.rs:javax.ws.rs-api:$versions.jaxrs",
@@ -305,7 +321,6 @@ libs += [
   opentelemetryExporterSenderGrpcManagedChannel: "io.opentelemetry:opentelemetry-exporter-sender-grpc-managed-channel:$versions.opentelemetrySDK",
   grpcNettyShaded: "io.grpc:grpc-netty-shaded:$versions.grpc",
   opentelemetryJmx: "io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:$versions.opentelemetryInstrument",
-  oshi: "com.github.oshi:oshi-core-java11:$versions.oshi",
   bucket4j: "com.bucket4j:bucket4j-core:$versions.bucket4j",
   jna: "net.java.dev.jna:jna:$versions.jna",
   guava: "com.google.guava:guava:$versions.guava",


### PR DESCRIPTION
## Summary
Cherry-pick build-related fixes from the `1.7` branch to `main`.

## Cherry-picked PRs
- #3275 — Align opensource dependency versions (jackson 2.20, protobuf 4.32.1, bucket4j 8.10.1, Netty version alignment, etc.)
- #3308 — Avoid forcing SnakeYAML for swagger doc generation
- #3322 — Force jaxb-api to 2.3.1 to avoid duplicate versions in release packaging

## Conflicts Resolved
- `build.gradle`: The `tools` project dependency layout differs between `main` and `1.7`; kept `main`'s structure and applied version/exclude changes in place.
- `gradle/dependencies.gradle`: Added missing `protobuf`/`protoGoogleCommonProtos` version entries that didn't exist on `main`.
- `build.gradle`: Fixed tab-vs-space indentation inconsistency in the `resolutionStrategy` block.