### PR TITLE
fix: exclude transitive kafka-clients from cloudevents-kafka (#3334)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1721,7 +1721,9 @@ project(':clients') {
     implementation libs.protobuf
 
     // AutoMQ inject start
-    implementation libs.cloudeventsKafka
+    implementation (libs.cloudeventsKafka) {
+      exclude group: 'org.apache.kafka', module: 'kafka-clients'
+    }
     // AutoMQ inject end
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
@@ -2517,7 +2519,9 @@ project(':tools') {
     implementation (libs.oshi) {
       exclude group: 'org.slf4j', module: 'slf4j-api'
     }
-    implementation libs.cloudeventsKafka
+    implementation (libs.cloudeventsKafka) {
+      exclude group: 'org.apache.kafka', module: 'kafka-clients'
+    }
     implementation libs.protobuf
     // AutoMQ inject end
 


### PR DESCRIPTION
## Problem
The `cloudevents-kafka` dependency transitively pulls in `kafka-clients:3.0.0`, which conflicts with the project's own `kafka-clients:3.9.1`. This results in two kafka-clients jars in the release tarball.

## Solution
Exclude `org.apache.kafka:kafka-clients` from `cloudevents-kafka` in both `:clients` and `:tools` projects.

## Verification
After the fix, `./gradlew releaseTarGz` produces a tarball containing only `kafka-clients-3.9.1.jar`.
