### PR TITLE
fix: prevent data loss caused by DataBlockIndex.endOffsetDelta int erflow during compaction

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -46,7 +46,6 @@ import com.automq.stream.s3.wal.RecordOffset;
 import com.automq.stream.s3.wal.RecoverResult;
 import com.automq.stream.s3.wal.WriteAheadLog;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
-import com.automq.stream.utils.ExceptionUtil;
 import com.automq.stream.utils.FutureTicker;
 import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.Systems;
@@ -61,18 +60,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -207,236 +201,8 @@ public class S3Storage implements Storage {
         }
     }
 
-    /**
-     * Recover continuous records in each stream from the WAL, and put them into the returned {@link LogCache.LogCacheBlock}.
-     * <p>
-     * It will filter out
-     * <ul>
-     *     <li>the records that are not in the opening streams</li>
-     *     <li>the records that have been committed</li>
-     *     <li>the records that are not continuous, which means, all records after the first discontinuous record</li>
-     * </ul>
-     * <p>
-     * It throws {@link IllegalStateException} if the start offset of the first recovered record mismatches
-     * the end offset of any opening stream, which indicates data loss.
-     * <p>
-     * If there are out of order records (which should never happen or there is a BUG), it will try to re-order them.
-     * <p>
-     * For example, if we recover following records from the WAL in a stream:
-     * <pre>    1, 2, 3, 5, 4, 6, 10, 11</pre>
-     * and the {@link StreamMetadata#endOffset()} of this stream is 3. Then the returned {@link LogCache.LogCacheBlock}
-     * will contain records
-     * <pre>    3, 4, 5, 6</pre>
-     * Here,
-     * <ul>
-     *     <li>The record 1 and 2 are discarded because they have been committed (less than 3, the end offset of the stream)</li>
-     *     <li>The record 10 and 11 are discarded because they are not continuous (10 is not 7, the next offset of 6)</li>
-     *     <li>The record 5 and 4 are reordered because they are out of order, and we handle this bug here</li>
-     * </ul>
-     * <p>
-     * It will return when any of the following conditions is met:
-     * <ul>
-     *     <li>all the records in the WAL have been recovered</li>
-     *     <li>the cache block is full</li>
-     * </ul>
-     * Visible for testing.
-     *
-     * @param it                      WAL recover iterator
-     * @param openingStreamEndOffsets the end offset of each opening stream
-     * @param maxCacheSize            the max size of the returned {@link RecoveryBlockResult#cacheBlock}
-     * @param logger                  logger
-     */
-    static RecoveryBlockResult recoverContinuousRecords(
-        Iterator<RecoverResult> it,
-        Map<Long, Long> openingStreamEndOffsets,
-        long maxCacheSize,
-        Logger logger
-    ) {
-        RecordOffset logEndOffset = null;
-        Map<Long, Long> streamNextOffsets = new HashMap<>();
-        Map<Long, Queue<StreamRecordBatch>> streamDiscontinuousRecords = new HashMap<>();
-        LogCache.LogCacheBlock cacheBlock = new LogCache.LogCacheBlock(maxCacheSize);
-
-        boolean first = true;
-        try {
-            while (it.hasNext() && !cacheBlock.isFull()) {
-                RecoverResult recoverResult = it.next();
-                logEndOffset = recoverResult.recordOffset();
-                if (first) {
-                    LOGGER.info("recover start offset {}", logEndOffset);
-                    first = false;
-                }
-                StreamRecordBatch streamRecordBatch = recoverResult.record();
-                processRecoveredRecord(streamRecordBatch, openingStreamEndOffsets, streamDiscontinuousRecords, cacheBlock, streamNextOffsets, logger);
-            }
-        } catch (Throwable e) {
-            // {@link RuntimeIOException} may be thrown by {@code it.next()}
-            releaseAllRecords(streamDiscontinuousRecords.values());
-            releaseAllRecords(cacheBlock.records().values());
-            throw e;
-        }
-        if (logEndOffset != null) {
-            cacheBlock.lastRecordOffset(logEndOffset);
-        }
-
-        releaseDiscontinuousRecords(streamDiscontinuousRecords, logger);
-        RecoveryBlockResult rst = filterOutInvalidStreams(cacheBlock, openingStreamEndOffsets);
-        return decodeLinkRecord(rst);
-    }
-
-    /**
-     * Processes recovered stream records. Caches continuous ones or queues discontinuous based on offset order.
-     *
-     * @param streamRecordBatch          the recovered record batch to process
-     * @param openingStreamEndOffsets    the end offsets of each opening stream
-     * @param streamDiscontinuousRecords the out-of-order records of each stream (to be filled)
-     * @param cacheBlock                 the cache block (to be filled)
-     * @param streamNextOffsets          the next offsets of each stream (to be updated)
-     * @param logger                     logger
-     */
-    private static void processRecoveredRecord(
-        StreamRecordBatch streamRecordBatch,
-        Map<Long, Long> openingStreamEndOffsets,
-        Map<Long, Queue<StreamRecordBatch>> streamDiscontinuousRecords,
-        LogCache.LogCacheBlock cacheBlock,
-        Map<Long, Long> streamNextOffsets,
-        Logger logger
-    ) {
-        long streamId = streamRecordBatch.getStreamId();
-
-        Long openingStreamEndOffset = openingStreamEndOffsets.get(streamId);
-        if (openingStreamEndOffset == null || openingStreamEndOffset > streamRecordBatch.getBaseOffset()) {
-            // stream is already safe closed, or the record have been committed, skip it
-            streamRecordBatch.release();
-            return;
-        }
-
-        Long expectedNextOffset = streamNextOffsets.get(streamId);
-        Queue<StreamRecordBatch> discontinuousRecords = streamDiscontinuousRecords.get(streamId);
-        boolean isContinuous = expectedNextOffset == null || expectedNextOffset == streamRecordBatch.getBaseOffset();
-        if (!isContinuous) {
-            // unexpected record, put it into discontinuous records queue.
-            if (discontinuousRecords == null) {
-                discontinuousRecords = new PriorityQueue<>(Comparator.comparingLong(StreamRecordBatch::getBaseOffset));
-                streamDiscontinuousRecords.put(streamId, discontinuousRecords);
-            }
-            discontinuousRecords.add(streamRecordBatch);
-            return;
-        }
-        // continuous record, put it into cache, and check if there is any historical discontinuous records can be polled.
-        cacheBlock.put(streamRecordBatch);
-        expectedNextOffset = maybePollDiscontinuousRecords(streamRecordBatch, cacheBlock, discontinuousRecords, logger);
-        streamNextOffsets.put(streamId, expectedNextOffset);
-    }
-
-    private static long maybePollDiscontinuousRecords(
-        StreamRecordBatch streamRecordBatch,
-        LogCache.LogCacheBlock cacheBlock,
-        Queue<StreamRecordBatch> discontinuousRecords,
-        Logger logger
-    ) {
-        long expectedNextOffset = streamRecordBatch.getLastOffset();
-        if (discontinuousRecords == null) {
-            return expectedNextOffset;
-        }
-        // check and poll historical discontinuous records.
-        while (!discontinuousRecords.isEmpty()) {
-            StreamRecordBatch peek = discontinuousRecords.peek();
-            if (peek.getBaseOffset() != expectedNextOffset) {
-                break;
-            }
-            // should never happen, log it.
-            logger.error("[BUG] recover an out of order record, streamId={}, expectedNextOffset={}, record={}", streamRecordBatch.getStreamId(), expectedNextOffset, peek);
-            discontinuousRecords.poll();
-            cacheBlock.put(peek);
-            expectedNextOffset = peek.getLastOffset();
-        }
-        return expectedNextOffset;
-    }
-
-    private static void releaseDiscontinuousRecords(Map<Long, Queue<StreamRecordBatch>> streamDiscontinuousRecords,
-        Logger logger) {
-        streamDiscontinuousRecords.values().stream()
-            .filter(q -> !q.isEmpty())
-            .peek(q -> logger.info("drop discontinuous records, records={}", q))
-            .forEach(S3Storage::releaseRecords);
-    }
-
-    /**
-     * Filter out invalid streams (the recovered start offset mismatches the stream end offset from controller) from the cache block if there are any.
-     */
-    private static RecoveryBlockResult filterOutInvalidStreams(LogCache.LogCacheBlock cacheBlock,
-        Map<Long, Long> openingStreamEndOffsets) {
-        Set<Long> invalidStreams = new HashSet<>();
-        List<RuntimeException> exceptions = new ArrayList<>();
-
-        cacheBlock.records().forEach((streamId, records) -> {
-            if (!records.isEmpty()) {
-                long startOffset = records.get(0).getBaseOffset();
-                long expectedStartOffset = openingStreamEndOffsets.getOrDefault(streamId, startOffset);
-                if (startOffset != expectedStartOffset) {
-                    RuntimeException exception = new IllegalStateException(String.format("[BUG] WAL data may lost, streamId %d endOffset=%d from controller, " +
-                        "but WAL recovered records startOffset=%s", streamId, expectedStartOffset, startOffset));
-                    LOGGER.error("invalid stream records", exception);
-                    invalidStreams.add(streamId);
-                    exceptions.add(exception);
-                }
-            }
-        });
-
-        if (invalidStreams.isEmpty()) {
-            return new RecoveryBlockResult(cacheBlock, null);
-        }
-
-        // Only streams not in invalidStreams should be uploaded and closed,
-        // so re-new a cache block and put only valid records into it, and release all invalid records.
-        LogCache.LogCacheBlock newCacheBlock = new LogCache.LogCacheBlock(1024L * 1024 * 1024);
-        cacheBlock.records().forEach((streamId, records) -> {
-            if (!invalidStreams.contains(streamId)) {
-                records.forEach(newCacheBlock::put);
-            } else {
-                // release invalid records.
-                releaseRecords(records);
-            }
-        });
-        return new RecoveryBlockResult(newCacheBlock, ExceptionUtil.combine(exceptions));
-    }
-
-    private static void releaseAllRecords(Collection<? extends Collection<StreamRecordBatch>> allRecords) {
-        allRecords.forEach(S3Storage::releaseRecords);
-    }
-
     private static void releaseRecords(Collection<StreamRecordBatch> records) {
         records.forEach(StreamRecordBatch::release);
-    }
-
-    private static RecoveryBlockResult decodeLinkRecord(RecoveryBlockResult recoverBlockRst) {
-        LogCache.LogCacheBlock cacheBlock = recoverBlockRst.cacheBlock;
-        int size = 0;
-        for (List<StreamRecordBatch> l : cacheBlock.records().values()) {
-            size += l.size();
-        }
-        List<CompletableFuture<Void>> futures = new ArrayList<>(size);
-        for (Map.Entry<Long, List<StreamRecordBatch>> entry : cacheBlock.records().entrySet()) {
-            List<StreamRecordBatch> records = entry.getValue();
-            for (int i = 0; i < records.size(); i++) {
-                StreamRecordBatch record = records.get(i);
-                if (record.getCount() >= 0) {
-                    continue;
-                }
-                int finalI = i;
-                futures.add(linkRecordDecoder.decode(record, DECODE_LINK_RECORD_INSTANT_ALLOC).thenAccept(r -> {
-                    records.set(finalI, r);
-                }));
-            }
-        }
-        try {
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-            return recoverBlockRst;
-        } catch (Throwable ex) {
-            releaseAllRecords(cacheBlock.records().values());
-            throw new RuntimeException(ex);
-        }
     }
 
     @Override
@@ -478,32 +244,16 @@ public class S3Storage implements Storage {
         Map<Long, Long> streamEndOffsets = streams.stream().collect(Collectors.toMap(StreamMetadata::streamId, StreamMetadata::endOffset));
         Iterator<RecoverResult> iterator = deltaWAL.recover();
 
-        LogCache.LogCacheBlock cacheBlock;
-        List<RuntimeException> exceptions = new ArrayList<>();
-        do {
-            RecoveryBlockResult result = recoverContinuousRecords(iterator, streamEndOffsets, 1 << 29, logger);
-            cacheBlock = result.cacheBlock;
-            Optional.ofNullable(result.exception).ifPresent(exceptions::add);
-            updateStreamEndOffsets(cacheBlock, streamEndOffsets);
-            uploadRecoveredRecords(objectManager, cacheBlock, logger);
-        }
-        while (cacheBlock.isFull());
+        WALRecovery.recover(iterator, streamEndOffsets, 1 << 29, logger, cacheBlock -> {
+            try {
+                uploadRecoveredRecords(objectManager, cacheBlock, logger);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
 
         deltaWAL.reset().get();
         closeStreams(streamManager, streams, streamEndOffsets, logger);
-
-        // fail it if there is any invalid stream.
-        if (!exceptions.isEmpty()) {
-            throw ExceptionUtil.combine(exceptions);
-        }
-    }
-
-    private static void updateStreamEndOffsets(LogCache.LogCacheBlock cacheBlock, Map<Long, Long> streamEndOffsets) {
-        cacheBlock.records().forEach((streamId, records) -> {
-            if (!records.isEmpty()) {
-                streamEndOffsets.put(streamId, records.get(records.size() - 1).getLastOffset());
-            }
-        });
     }
 
     private void uploadRecoveredRecords(ObjectManager objectManager, LogCache.LogCacheBlock cacheBlock, Logger logger)
@@ -514,7 +264,7 @@ public class S3Storage implements Storage {
                 UploadWriteAheadLogTask task = newUploadWriteAheadLogTask(cacheBlock.records(), objectManager, Long.MAX_VALUE);
                 task.prepare().thenCompose(nil -> task.upload()).thenCompose(nil -> task.commit()).get();
             } finally {
-                releaseAllRecords(cacheBlock.records().values());
+                WALRecovery.releaseAllRecords(cacheBlock.records().values());
             }
         }
     }
@@ -848,14 +598,19 @@ public class S3Storage implements Storage {
     private void handleAppendCallback(WalWriteRequest request) {
         final long startTime = System.nanoTime();
         request.record.retain();
-        boolean full;
+        boolean added;
         synchronized (deltaWALCache) {
             // Because LogCacheBlock will use request.offset to execute WAL#trim after being uploaded,
             // this cache put order should keep consistence with WAL put order.
-            full = deltaWALCache.put(request.record);
+            added = deltaWALCache.put(request.record);
+            if (!added) {
+                // record was not added, archive current block and retry
+                uploadDeltaWAL();
+                added = deltaWALCache.put(request.record);
+            }
             deltaWALCache.setLastRecordOffset(request.offset);
         }
-        if (full) {
+        if (!added) {
             // cache block is full, trigger WAL upload.
             uploadDeltaWAL();
         }
@@ -1085,26 +840,6 @@ public class S3Storage implements Storage {
 
         public DeltaWALUploadTaskContext(LogCache.LogCacheBlock cache) {
             this.cache = cache;
-        }
-    }
-
-    /**
-     * Recover result of {@link #recoverContinuousRecords(Iterator, Map, long, Logger)}
-     */
-    static class RecoveryBlockResult {
-        /**
-         * Recovered records. All invalid streams have been filtered out.
-         */
-        final LogCache.LogCacheBlock cacheBlock;
-
-        /**
-         * Any exception occurred during recovery. It is null if no exception occurred.
-         */
-        final RuntimeException exception;
-
-        public RecoveryBlockResult(LogCache.LogCacheBlock cacheBlock, RuntimeException exception) {
-            this.cacheBlock = cacheBlock;
-            this.exception = exception;
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/WALRecovery.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/WALRecovery.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3;
+
+import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.s3.cache.LogCache;
+import com.automq.stream.s3.model.StreamRecordBatch;
+import com.automq.stream.s3.wal.RecordOffset;
+import com.automq.stream.s3.wal.RecoverResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
+
+/**
+ * WAL recovery logic: reads records from the WAL iterator, groups them into
+ * {@link LogCache.LogCacheBlock}s, filters invalid streams, decodes link records,
+ * and passes each block to a handler for upload.
+ */
+public class WALRecovery {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WALRecovery.class);
+    private static final ByteBufSeqAlloc DECODE_LINK_RECORD_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 1);
+
+    /**
+     * Recover records from the WAL iterator, putting them into {@link LogCache.LogCacheBlock}s.
+     * <p>
+     * It will filter out
+     * <ul>
+     *     <li>the records that are not in the opening streams</li>
+     *     <li>the records that have been committed</li>
+     *     <li>discontinuous records (gap between expected and actual offset), with a warning log</li>
+     * </ul>
+     * <p>
+     * For example, if we recover following records from the WAL in a stream:
+     * <pre>    1, 2, 3, 4, 5, 6</pre>
+     * and the {@link com.automq.stream.s3.metadata.StreamMetadata#endOffset()} of this stream is 3.
+     * Then the returned {@link LogCache.LogCacheBlock} will contain records
+     * <pre>    3, 4, 5, 6</pre>
+     * Here,
+     * <ul>
+     *     <li>The record 1 and 2 are discarded because they have been committed (less than 3, the end offset of the stream)</li>
+     * </ul>
+     * <p>
+     * Records are processed in blocks. When a block is full (size threshold or offset overflow),
+     * it is passed to the {@code blockHandler} for upload, and a new block is started.
+     *
+     * @param it                      WAL recover iterator
+     * @param openingStreamEndOffsets the end offset of each opening stream
+     * @param maxCacheSize            the max size of each {@link LogCache.LogCacheBlock}
+     * @param logger                  logger
+     * @param blockHandler            called for each block to upload and release records
+     */
+    public static void recover(
+        Iterator<RecoverResult> it,
+        Map<Long, Long> openingStreamEndOffsets,
+        long maxCacheSize,
+        Logger logger,
+        BlockHandler blockHandler
+    ) {
+        boolean first = true;
+        RecoverResult pending = null;
+        while (pending != null || it.hasNext()) {
+            LogCache.LogCacheBlock cacheBlock = new LogCache.LogCacheBlock(maxCacheSize);
+            RecordOffset blockLastOffset = null;
+            try {
+                if (pending != null) {
+                    cacheBlock.put(pending.record());
+                    openingStreamEndOffsets.put(pending.record().getStreamId(), pending.record().getLastOffset());
+                    blockLastOffset = pending.recordOffset();
+                    pending = null;
+                }
+                while (it.hasNext() && !cacheBlock.isFull()) {
+                    RecoverResult recoverResult = it.next();
+                    if (first) {
+                        logger.info("recover start offset {}", recoverResult.recordOffset());
+                        first = false;
+                    }
+                    if (!processRecord(recoverResult.record(), openingStreamEndOffsets, cacheBlock, logger)) {
+                        pending = recoverResult;
+                    } else {
+                        blockLastOffset = recoverResult.recordOffset();
+                    }
+                }
+            } catch (Throwable e) {
+                releaseAllRecords(cacheBlock.records().values());
+                if (pending != null) {
+                    pending.record().release();
+                }
+                throw e;
+            }
+            if (blockLastOffset != null) {
+                cacheBlock.lastRecordOffset(blockLastOffset);
+            }
+            decodeLinkRecords(cacheBlock);
+            blockHandler.handle(cacheBlock);
+        }
+    }
+
+    /**
+     * @return true if the record was added or dropped, false if the block is full/overflow and the record was NOT added
+     */
+    private static boolean processRecord(
+        StreamRecordBatch streamRecordBatch,
+        Map<Long, Long> openingStreamEndOffsets,
+        LogCache.LogCacheBlock cacheBlock,
+        Logger logger
+    ) {
+        long streamId = streamRecordBatch.getStreamId();
+
+        Long expectedNextOffset = openingStreamEndOffsets.get(streamId);
+        if (expectedNextOffset == null) {
+            // stream is already safe closed, skip it
+            streamRecordBatch.release();
+            return true;
+        }
+        if (expectedNextOffset > streamRecordBatch.getBaseOffset()) {
+            // the record has been committed, skip it
+            streamRecordBatch.release();
+            return true;
+        }
+        if (expectedNextOffset < streamRecordBatch.getBaseOffset()) {
+            // discontinuous record, drop it
+            logger.warn("[BUG] dropping discontinuous WAL record: streamId={}, expectedOffset={}, actualOffset={}",
+                streamId, expectedNextOffset, streamRecordBatch.getBaseOffset());
+            streamRecordBatch.release();
+            return true;
+        }
+
+        if (!cacheBlock.put(streamRecordBatch)) {
+            return false;
+        }
+        openingStreamEndOffsets.put(streamId, streamRecordBatch.getLastOffset());
+        return true;
+    }
+
+    private static void decodeLinkRecords(LogCache.LogCacheBlock cacheBlock) {
+        int size = 0;
+        for (List<StreamRecordBatch> l : cacheBlock.records().values()) {
+            size += l.size();
+        }
+        List<CompletableFuture<Void>> futures = new ArrayList<>(size);
+        for (Map.Entry<Long, List<StreamRecordBatch>> entry : cacheBlock.records().entrySet()) {
+            List<StreamRecordBatch> records = entry.getValue();
+            for (int i = 0; i < records.size(); i++) {
+                StreamRecordBatch record = records.get(i);
+                if (record.getCount() >= 0) {
+                    continue;
+                }
+                int finalI = i;
+                futures.add(S3Storage.getLinkRecordDecoder().decode(record, DECODE_LINK_RECORD_INSTANT_ALLOC).thenAccept(r -> {
+                    records.set(finalI, r);
+                }));
+            }
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        } catch (Throwable ex) {
+            releaseAllRecords(cacheBlock.records().values());
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static void releaseAllRecords(Collection<? extends Collection<StreamRecordBatch>> allRecords) {
+        allRecords.forEach(WALRecovery::releaseRecords);
+    }
+
+    private static void releaseRecords(Collection<StreamRecordBatch> records) {
+        records.forEach(StreamRecordBatch::release);
+    }
+
+    @FunctionalInterface
+    public interface BlockHandler {
+        void handle(LogCache.LogCacheBlock cacheBlock);
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -99,20 +99,24 @@ public class LogCache {
     /**
      * Put a record batch into the cache.
      * record batched in the same stream should be put in order.
+     *
+     * @return true if the record was successfully added, false if the block is full (caller should archive and retry)
      */
     public boolean put(StreamRecordBatch recordBatch) {
         long startTime = System.nanoTime();
         tryRealFree();
-        size.addAndGet(recordBatch.occupiedSize());
         readLock.lock();
-        boolean full;
+        boolean added;
         try {
-            full = activeBlock.put(recordBatch);
+            added = activeBlock.put(recordBatch);
         } finally {
             readLock.unlock();
         }
+        if (added) {
+            size.addAndGet(recordBatch.occupiedSize());
+        }
         StorageOperationStats.getInstance().appendLogCacheStats.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
-        return full;
+        return added;
     }
 
     public List<StreamRecordBatch> get(long streamId, long startOffset, long endOffset, int maxBytes) {
@@ -433,6 +437,7 @@ public class LogCache {
         private final long createdTimestamp = System.currentTimeMillis();
         private final AtomicLong size = new AtomicLong();
         private final List<FreeListener> freeListeners = new ArrayList<>();
+        private volatile boolean overflow;
         volatile boolean free;
         long freeOpsModCount;
         private RecordOffset lastRecordOffset;
@@ -452,19 +457,23 @@ public class LogCache {
         }
 
         public boolean isFull() {
-            return size.get() >= maxSize || map.size() >= maxStreamCount;
+            return overflow || size.get() >= maxSize || map.size() >= maxStreamCount;
         }
 
+        /**
+         * @return true if the record was successfully added, false if the block is full or would overflow
+         */
         public boolean put(StreamRecordBatch recordBatch) {
-            map.compute(recordBatch.getStreamId(), (id, cache) -> {
-                if (cache == null) {
-                    cache = new StreamCache();
-                }
-                cache.add(recordBatch);
-                return cache;
-            });
+            if (isFull()) {
+                return false;
+            }
+            StreamCache cache = map.computeIfAbsent(recordBatch.getStreamId(), id -> new StreamCache());
+            if (!cache.add(recordBatch)) {
+                overflow = true;
+                return false;
+            }
             size.addAndGet(recordBatch.occupiedSize());
-            return isFull();
+            return true;
         }
 
         public List<StreamRecordBatch> get(Long streamId, long startOffset, long endOffset, int maxBytes) {
@@ -589,17 +598,25 @@ public class LogCache {
             this.records = new ArrayList<>();
         }
 
-        synchronized void add(StreamRecordBatch recordBatch) {
+        /**
+         * @return true if the record was successfully added, false if it would cause offset overflow
+         */
+        synchronized boolean add(StreamRecordBatch recordBatch) {
             if (recordBatch.getBaseOffset() != endOffset && endOffset != NOOP_OFFSET) {
                 RuntimeException ex = new IllegalArgumentException(String.format("streamId=%s record batch base offset mismatch, expect %s, actual %s",
                     recordBatch.getStreamId(), endOffset, recordBatch.getBaseOffset()));
                 LOGGER.error("[FATAL]", ex);
+            }
+            long effectiveStartOffset = startOffset == NOOP_OFFSET ? recordBatch.getBaseOffset() : startOffset;
+            if (recordBatch.getLastOffset() - effectiveStartOffset > Integer.MAX_VALUE) {
+                return false;
             }
             records.add(recordBatch);
             if (startOffset == NOOP_OFFSET) {
                 startOffset = recordBatch.getBaseOffset();
             }
             endOffset = recordBatch.getLastOffset();
+            return true;
         }
 
         synchronized List<StreamRecordBatch> get(long startOffset, long endOffset, int maxBytes) {

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
@@ -119,11 +119,12 @@ public class SnapshotReadCache {
                 // Copy the record to the SeqAlloc to reduce fragmentation.
                 StreamRecordBatch copy = StreamRecordBatch.parse(batch.encoded(), true, ENCODE_ALLOC);
                 batch.release();
-                if (cache.put(copy)) {
-                    // the block is full
+                if (!cache.put(copy)) {
+                    // record was not added, archive current block and retry
                     LogCache.LogCacheBlock cacheBlock = cache.archiveCurrentBlock();
                     cacheBlock.addFreeListener(cacheFreeListener);
                     cache.markFree(cacheBlock);
+                    cache.put(copy);
                 }
                 expectedNextOffset.set(copy.getLastOffset());
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -490,6 +490,7 @@ public class StreamObjectCompactor {
         // TODO: switch to include/exclude composite object
         List<List<S3ObjectMetadata>> objectGroups = new LinkedList<>();
         long groupSize = 0;
+        long groupStartOffset = -1L;
         long groupNextOffset = -1L;
         List<S3ObjectMetadata> group = new LinkedList<>();
         int partCount = 0;
@@ -503,6 +504,7 @@ public class StreamObjectCompactor {
                 continue;
             }
             if (groupNextOffset == -1L) {
+                groupStartOffset = object.startOffset();
                 groupNextOffset = object.startOffset();
             }
             // group the objects when the object's range is continuous
@@ -512,10 +514,16 @@ public class StreamObjectCompactor {
                 // object count in a group is larger than MAX_OBJECT_GROUP_COUNT
                 || group.size() >= MAX_OBJECT_GROUP_COUNT
                 || partCount + objectPartCount > Writer.MAX_PART_COUNT
+                // the group offset delta would exceed int32
+                || object.endOffset() - groupStartOffset > Integer.MAX_VALUE
             ) {
-                objectGroups.add(group);
+                if (!group.isEmpty()) {
+                    objectGroups.add(group);
+                }
                 group = new LinkedList<>();
                 groupSize = 0;
+                groupStartOffset = object.startOffset();
+                partCount = 0;
             }
             group.add(object);
             groupSize += object.objectSize();

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -33,8 +33,6 @@ import com.automq.stream.s3.objects.StreamObject;
 import com.automq.stream.s3.operator.MemoryObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.streams.StreamManager;
-import com.automq.stream.s3.wal.RecordOffset;
-import com.automq.stream.s3.wal.RecoverResult;
 import com.automq.stream.s3.wal.WriteAheadLog;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
 import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
@@ -49,10 +47,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -61,10 +56,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.automq.stream.s3.TestUtils.random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -184,117 +175,6 @@ public class S3StorageTest {
     }
 
     @Test
-    public void testRecoverContinuousRecords() {
-        List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(newRecord(233L, 10L)),
-            new TestRecoverResult(newRecord(233L, 11L)),
-            new TestRecoverResult(newRecord(233L, 12L)),
-            new TestRecoverResult(newRecord(233L, 15L)),
-            new TestRecoverResult(newRecord(234L, 20L))
-        );
-        Iterator<RecoverResult> iterator = recoverResults.iterator();
-
-        Map<Long, Long> streamEndOffsets = Map.of(233L, 11L);
-        S3Storage.RecoveryBlockResult result = S3Storage.recoverContinuousRecords(iterator, streamEndOffsets, 1 << 30, LOGGER);
-        LogCache.LogCacheBlock cacheBlock = result.cacheBlock;
-        assertNull(result.exception);
-        // ignore closed stream and noncontinuous records.
-        assertEquals(1, cacheBlock.records().size());
-        List<StreamRecordBatch> streamRecords = cacheBlock.records().get(233L);
-        assertEquals(2, streamRecords.size());
-        assertEquals(11L, streamRecords.get(0).getBaseOffset());
-        assertEquals(12L, streamRecords.get(1).getBaseOffset());
-    }
-
-    @Test
-    public void testRecoverDataLoss() {
-        List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(newRecord(233L, 10L)),
-            new TestRecoverResult(newRecord(233L, 11L)),
-            new TestRecoverResult(newRecord(233L, 12L))
-        );
-        Iterator<RecoverResult> iterator = recoverResults.iterator();
-
-        // simulate data loss
-        Map<Long, Long> streamEndOffsets = Map.of(233L, 5L);
-        S3Storage.RecoveryBlockResult result = S3Storage.recoverContinuousRecords(iterator, streamEndOffsets, 1 << 30, LOGGER);
-        assertNotNull(result.exception);
-        LogCache.LogCacheBlock cacheBlock = result.cacheBlock;
-        assertEquals(0, cacheBlock.records().size());
-    }
-
-    @Test
-    public void testRecoverOutOfOrderRecords() {
-        List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(newRecord(42L, 9L)),
-            new TestRecoverResult(newRecord(42L, 10L)),
-            new TestRecoverResult(newRecord(42L, 13L)),
-            new TestRecoverResult(newRecord(42L, 11L)),
-            new TestRecoverResult(newRecord(42L, 12L)),
-            new TestRecoverResult(newRecord(42L, 14L)),
-            new TestRecoverResult(newRecord(42L, 20L))
-        );
-
-        Map<Long, Long> streamEndOffsets = Map.of(42L, 10L);
-        S3Storage.RecoveryBlockResult result = S3Storage.recoverContinuousRecords(recoverResults.iterator(), streamEndOffsets, 1 << 30, LOGGER);
-        LogCache.LogCacheBlock cacheBlock = result.cacheBlock;
-        assertNull(result.exception);
-        // ignore closed stream and noncontinuous records.
-        assertEquals(1, cacheBlock.records().size());
-        List<StreamRecordBatch> streamRecords = cacheBlock.records().get(42L);
-        assertEquals(5, streamRecords.size());
-        assertEquals(10L, streamRecords.get(0).getBaseOffset());
-        assertEquals(11L, streamRecords.get(1).getBaseOffset());
-        assertEquals(12L, streamRecords.get(2).getBaseOffset());
-        assertEquals(13L, streamRecords.get(3).getBaseOffset());
-        assertEquals(14L, streamRecords.get(4).getBaseOffset());
-    }
-
-    @Test
-    public void testSegmentedRecovery() {
-        List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(newRecord(42L, 10L)),
-            new TestRecoverResult(newRecord(42L, 11L)),
-            new TestRecoverResult(newRecord(42L, 12L)),
-            new TestRecoverResult(newRecord(42L, 13L)),
-            new TestRecoverResult(newRecord(42L, 14L)),
-            new TestRecoverResult(newRecord(42L, 20L))
-        );
-        Iterator<RecoverResult> iterator = recoverResults.iterator();
-
-        Map<Long, Long> streamEndOffsets = new HashMap<>();
-        S3Storage.RecoveryBlockResult result;
-        List<StreamRecordBatch> streamRecords;
-        final long maxCacheSize = 200L;
-
-        streamEndOffsets.put(42L, 10L);
-        result = S3Storage.recoverContinuousRecords(iterator, streamEndOffsets, maxCacheSize, LOGGER);
-        assertNull(result.exception);
-        assertTrue(result.cacheBlock.isFull());
-        streamRecords = result.cacheBlock.records().get(42L);
-        assertEquals(2, streamRecords.size());
-        assertEquals(10L, streamRecords.get(0).getBaseOffset());
-        assertEquals(11L, streamRecords.get(1).getBaseOffset());
-
-        streamEndOffsets.put(42L, 12L);
-        result = S3Storage.recoverContinuousRecords(iterator, streamEndOffsets, maxCacheSize, LOGGER);
-        assertNull(result.exception);
-        assertTrue(result.cacheBlock.isFull());
-        streamRecords = result.cacheBlock.records().get(42L);
-        assertEquals(2, streamRecords.size());
-        assertEquals(12L, streamRecords.get(0).getBaseOffset());
-        assertEquals(13L, streamRecords.get(1).getBaseOffset());
-
-        streamEndOffsets.put(42L, 14L);
-        result = S3Storage.recoverContinuousRecords(iterator, streamEndOffsets, maxCacheSize, LOGGER);
-        assertNull(result.exception);
-        assertFalse(result.cacheBlock.isFull());
-        streamRecords = result.cacheBlock.records().get(42L);
-        assertEquals(1, streamRecords.size());
-        assertEquals(14L, streamRecords.get(0).getBaseOffset());
-    }
-
-    @Test
     public void testWALOverCapacity() throws OverCapacityException {
         storage.append(newRecord(233L, 10L));
         storage.append(newRecord(233L, 11L));
@@ -317,21 +197,4 @@ public class S3StorageTest {
         assertEquals(12L, range.getEndOffset());
     }
 
-    static class TestRecoverResult implements RecoverResult {
-        private final StreamRecordBatch record;
-
-        public TestRecoverResult(StreamRecordBatch record) {
-            this.record = record;
-        }
-
-        @Override
-        public StreamRecordBatch record() {
-            return record;
-        }
-
-        @Override
-        public RecordOffset recordOffset() {
-            return DefaultRecordOffset.of(0, 0, 0);
-        }
-    }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3;
+
+import com.automq.stream.s3.cache.LogCache;
+import com.automq.stream.s3.model.StreamRecordBatch;
+import com.automq.stream.s3.wal.RecordOffset;
+import com.automq.stream.s3.wal.RecoverResult;
+import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.automq.stream.s3.TestUtils.random;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("S3Unit")
+public class WALRecoveryTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WALRecoveryTest.class);
+
+    private static StreamRecordBatch newRecord(long streamId, long offset) {
+        return StreamRecordBatch.of(streamId, 0, offset, 1, random(1));
+    }
+
+    @Test
+    public void testRecoverContinuousRecords() {
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(newRecord(233L, 10L)),
+            new TestRecoverResult(newRecord(233L, 11L)),
+            new TestRecoverResult(newRecord(233L, 12L)),
+            new TestRecoverResult(newRecord(233L, 15L)),
+            new TestRecoverResult(newRecord(234L, 20L))
+        );
+
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(233L, 11L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 1 << 30, LOGGER, results::add);
+        assertEquals(1, results.size());
+        LogCache.LogCacheBlock cacheBlock = results.get(0);
+        // ignore closed stream (234), drop discontinuous record (15).
+        assertEquals(1, cacheBlock.records().size());
+        List<StreamRecordBatch> streamRecords = cacheBlock.records().get(233L);
+        assertEquals(2, streamRecords.size());
+        assertEquals(11L, streamRecords.get(0).getBaseOffset());
+        assertEquals(12L, streamRecords.get(1).getBaseOffset());
+    }
+
+    @Test
+    public void testRecoverDataLoss() {
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(newRecord(233L, 10L)),
+            new TestRecoverResult(newRecord(233L, 11L)),
+            new TestRecoverResult(newRecord(233L, 12L))
+        );
+
+        // simulate data loss: stream endOffset=5 but first WAL record starts at 10
+        // all records are dropped as discontinuous
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(233L, 5L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 1 << 30, LOGGER, results::add);
+        assertEquals(1, results.size());
+        assertEquals(0, results.get(0).records().size());
+    }
+
+    @Test
+    public void testRecoverOutOfOrderRecords() {
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(newRecord(42L, 9L)),
+            new TestRecoverResult(newRecord(42L, 10L)),
+            new TestRecoverResult(newRecord(42L, 13L)),
+            new TestRecoverResult(newRecord(42L, 11L)),
+            new TestRecoverResult(newRecord(42L, 12L)),
+            new TestRecoverResult(newRecord(42L, 14L)),
+            new TestRecoverResult(newRecord(42L, 20L))
+        );
+
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 10L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 1 << 30, LOGGER, results::add);
+        assertEquals(1, results.size());
+        LogCache.LogCacheBlock cacheBlock = results.get(0);
+        // Discontinuous records (13, 14, 20) are dropped; only continuous records from endOffset are kept.
+        assertEquals(1, cacheBlock.records().size());
+        List<StreamRecordBatch> streamRecords = cacheBlock.records().get(42L);
+        assertEquals(3, streamRecords.size());
+        assertEquals(10L, streamRecords.get(0).getBaseOffset());
+        assertEquals(11L, streamRecords.get(1).getBaseOffset());
+        assertEquals(12L, streamRecords.get(2).getBaseOffset());
+    }
+
+    @Test
+    public void testSegmentedRecovery() {
+        // Each record occupies ~145 bytes (1 byte payload + 144 overhead).
+        // With maxCacheSize=200, a block becomes full after 2 records (290 bytes >= 200).
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(newRecord(42L, 10L)),
+            new TestRecoverResult(newRecord(42L, 11L)),
+            new TestRecoverResult(newRecord(42L, 12L)),
+            new TestRecoverResult(newRecord(42L, 13L)),
+            new TestRecoverResult(newRecord(42L, 14L))
+        );
+
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 10L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 200L, LOGGER, results::add);
+        assertEquals(3, results.size());
+
+        // block 0: [10, 11] — full
+        assertTrue(results.get(0).isFull());
+        assertEquals(List.of(10L, 11L),
+            results.get(0).records().get(42L).stream().map(StreamRecordBatch::getBaseOffset).collect(Collectors.toList()));
+
+        // block 1: [12, 13] — full
+        assertTrue(results.get(1).isFull());
+        assertEquals(List.of(12L, 13L),
+            results.get(1).records().get(42L).stream().map(StreamRecordBatch::getBaseOffset).collect(Collectors.toList()));
+
+        // block 2: [14] — not full
+        assertFalse(results.get(2).isFull());
+        assertEquals(List.of(14L),
+            results.get(2).records().get(42L).stream().map(StreamRecordBatch::getBaseOffset).collect(Collectors.toList()));
+
+        // streamEndOffsets should be updated to the last recovered offset
+        assertEquals(15L, streamEndOffsets.get(42L));
+    }
+
+    /**
+     * When offset delta overflow forces a block split, records after the split must still be recovered.
+     */
+    @Test
+    public void testSegmentedRecoveryPendingRecordUpdatesOffset() {
+        // Offset delta overflow forces a block split after the first record.
+        // All three records must be recovered across the resulting blocks.
+        long bigCount = Integer.MAX_VALUE;
+        long secondOffset = bigCount;
+        long thirdOffset = secondOffset + 1;
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1))),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1))),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, thirdOffset, 1, random(1)))
+        );
+
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 0L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 1L << 30, LOGGER, results::add);
+
+        // Should produce 2 blocks (overflow forces split)
+        assertTrue(results.size() >= 2, "Expected multiple blocks but got " + results.size());
+
+        // Collect all recovered base offsets
+        List<Long> allOffsets = new ArrayList<>();
+        for (LogCache.LogCacheBlock block : results) {
+            List<StreamRecordBatch> records = block.records().get(42L);
+            if (records != null) {
+                records.forEach(r -> allOffsets.add(r.getBaseOffset()));
+            }
+        }
+        // All 3 records must be present
+        assertEquals(List.of(0L, secondOffset, thirdOffset), allOffsets);
+    }
+
+    /**
+     * Each block's lastRecordOffset must reflect the last record actually added to that block.
+     */
+    @Test
+    public void testSegmentedRecoveryLastRecordOffset() {
+        long bigCount = Integer.MAX_VALUE;
+        long secondOffset = bigCount;
+        List<RecoverResult> recoverResults = List.of(
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1)),
+                DefaultRecordOffset.of(0, 100, 0)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1)),
+                DefaultRecordOffset.of(0, 200, 0)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset + 1, 1, random(1)),
+                DefaultRecordOffset.of(0, 300, 0))
+        );
+
+        Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 0L));
+        List<LogCache.LogCacheBlock> results = new ArrayList<>();
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 1L << 30, LOGGER, results::add);
+        assertTrue(results.size() >= 2, "Expected multiple blocks but got " + results.size());
+
+        // The first block's lastRecordOffset must be the WAL offset of the last record added to it.
+        LogCache.LogCacheBlock firstBlock = results.get(0);
+        assertEquals(DefaultRecordOffset.of(0, 100, 0), firstBlock.lastRecordOffset());
+    }
+
+    static class TestRecoverResult implements RecoverResult {
+        private final StreamRecordBatch record;
+        private final RecordOffset offset;
+
+        public TestRecoverResult(StreamRecordBatch record) {
+            this(record, DefaultRecordOffset.of(0, 0, 0));
+        }
+
+        public TestRecoverResult(StreamRecordBatch record, RecordOffset offset) {
+            this.record = record;
+            this.offset = offset;
+        }
+
+        @Override
+        public StreamRecordBatch record() {
+            return record;
+        }
+
+        @Override
+        public RecordOffset recordOffset() {
+            return offset;
+        }
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -186,6 +186,33 @@ class StreamObjectCompactorTest {
         assertFalse(doCleanupWhenMajorV1Compaction);
     }
 
+    /**
+     * group0 must not emit empty groups when a single object's offset delta exceeds Integer.MAX_VALUE.
+     */
+    @Test
+    public void testGroup0_singleObjectExceedsIntMax() {
+        long hugeEnd = Integer.MAX_VALUE + 100L;
+        S3ObjectMetadata bigObject = new S3ObjectMetadata(
+            1, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, 0, hugeEnd)),
+            System.currentTimeMillis(), System.currentTimeMillis(), 100, 1);
+        S3ObjectMetadata normalObject = new S3ObjectMetadata(
+            2, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, hugeEnd, hugeEnd + 10)),
+            System.currentTimeMillis(), System.currentTimeMillis(), 100, 2);
+
+        List<List<S3ObjectMetadata>> groups = group0(
+            List.of(bigObject, normalObject), Long.MAX_VALUE, obj -> true);
+
+        // No group should be empty
+        for (List<S3ObjectMetadata> g : groups) {
+            assertFalse(g.isEmpty());
+        }
+        // Both objects must appear in some group
+        long totalObjects = groups.stream().mapToLong(List::size).sum();
+        assertEquals(2, totalObjects);
+    }
+
     @Test
     public void testCompact() throws ExecutionException, InterruptedException {
         List<S3ObjectMetadata> objects = prepareData();


### PR DESCRIPTION
Bug Description:
DataBlockIndex.endOffsetDelta is stored as a 4-byte signed int (max 2^31-1). When a LogCacheBlock accumulates records for a single stream where endOffset - startOffset exceeds Integer.MAX_VALUE, the WAL upload writes a DataBlockIndex with an overflowed (negative) endOffsetDelta. This causes DataBlockIndex.endOffset() to return a value less than startOffset.

During compaction, filterInvalidStreamDataBlocks checks block.getEndOffset() <= stream.startOffset(). The corrupted endOffset satisfies this condition, so the block is removed. The object still has blocks for other streams, so it gets included in the compaction plan and deleted from S3. The affected stream's data is permanently lost.

This primarily affects compact topics (e.g. __consumer_offsets) where log cleaning produces .cleaned segments with sparse offset ranges. The DeltaWALUploadTask batches multiple such segments into a single object, creating a combined offset delta that crosses the int overflow threshold.

How it is fixed:
1. LogCache overflow prevention: LogCacheBlock.put() returns false when the block is full or when adding a record would cause a stream's offset delta to overflow Integer.MAX_VALUE. A new 'overflow' flag is tracked in LogCacheBlock and included in isFull(). StreamCache.add() checks the delta before accepting a record.

2. Callers handle the put() semantic (true=added, false=not added):
- S3Storage.handleAppendCallback: archives the current block and retries
   - SnapshotReadCache: archives the current block and retries
- WAL recovery path: saves rejected records as pending for the next block

3. StreamObjectCompactor.group0(): adds an offset delta guard that splits object groups when endOffset - startOffset would exceed Integer.MAX_VALUE.

4. WAL recovery refactored into standalone WALRecovery class:
   - Removed discontinuous record handling (WAL records are ordered)
   - Recovery loop with BlockHandler processes blocks incrementally
   - Pending record mechanism ensures no records are lost across blocks

Files changed:
- NEW: WALRecovery.java - extracted WAL recovery logic from S3Storage
- LogCache.java - overflow flag in LogCacheBlock, delta check in StreamCache
- S3Storage.java - handle put() returning false, use WALRecovery
- SnapshotReadCache.java - handle put() returning false
- StreamObjectCompactor.java - offset delta guard in group0()
- S3StorageTest.java - updated recovery tests for new semantics
