### PR TITLE
fix(s3stream): reduce CPU overhead in AsyncNetworkBandwidthLimiter when traffic hits limit

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/network/AsyncNetworkBandwidthLimiter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/AsyncNetworkBandwidthLimiter.java
@@ -106,7 +106,7 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
         lock.lock();
         try {
             this.availableTokens.getAndUpdate(old -> Math.min(old + this.tokenSize, this.maxTokens));
-            condition.signalAll();
+            condition.signal();
         } finally {
             lock.unlock();
         }
@@ -157,7 +157,6 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
             try {
                 if (availableTokens.get() <= 0 || !queuedCallbacks.isEmpty()) {
                     queuedCallbacks.offer(new BucketItem(throttleStrategy, size, cf));
-                    condition.signalAll();
                 } else {
                     reduceToken(size);
                     satisfied = true;


### PR DESCRIPTION
## Motivation

Resolves #2052

When network traffic reaches the configured bandwidth limit, `AsyncNetworkBandwidthLimiter` consumes excessive CPU due to wasteful wake-up cycles in its consumer thread. The flame graphs in the issue show this overhead clearly.

## Root Cause

Two problems in the signaling logic create a hot wake-up loop under sustained load:

1. **`consume()` calls `condition.signalAll()` on every enqueue** (even when `availableTokens <= 0`). This wakes the `run()` thread, which acquires the lock, checks `ableToConsume()` (returns `false` since tokens are exhausted), and immediately blocks again. Under sustained traffic at the limit, every incoming request triggers this wasteful cycle: wake -> lock -> check -> sleep -> wake -> lock -> check -> sleep.

2. **`refillToken()` uses `signalAll()` instead of `signal()`**. Only the single `run()` thread ever waits on this condition variable, so `signalAll()` is unnecessary overhead.

## Changes

**`AsyncNetworkBandwidthLimiter.java`** (1 file changed, 1 insertion, 2 deletions):

- **`consume()`**: Removed `condition.signalAll()` after enqueueing a `BucketItem`. The `run()` thread cannot drain the queue without available tokens, so waking it serves no purpose. When tokens *are* available and the queue is empty, `consume()` takes the fast-path and completes the future inline without queuing, so `run()` never needs a signal in that path either.

- **`refillToken()`**: Replaced `signalAll()` with `signal()`. Only one thread (`run()`) waits on this condition, making `signalAll()` unnecessary.

## Verification

All 10 existing tests in `AsyncNetworkBandwidthLimiterTest` pass:

- `testByPassConsume` / `testByPassConsume2`
- `testThrottleConsume` / `testThrottleConsume2` / `testThrottleConsume3` / `testThrottleConsume4` / `testThrottleConsume5`
- `testThrottleConsumeWithPriority` / `testThrottleConsumeWithPriority1`
- `testThrottleConsumeWithLargeChunk`