### PR TITLE
feat(zerozone): add async partition snapshot long polling

### DIFF
--- a/core/src/main/java/kafka/automq/partition/snapshot/ConfirmWalDataDelta.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/ConfirmWalDataDelta.java
@@ -83,17 +83,25 @@ public class ConfirmWalDataDelta implements ConfirmWAL.AppendListener {
     static final int STATE_CLOSED = 9;
     static final int MAX_RECORDS_BUFFER_SIZE = 32 * 1024; // 32KiB
     private final ConfirmWAL confirmWAL;
+    private final Runnable onAppendCallback;
 
     private final ConfirmWAL.ListenerHandle listenerHandle;
     final BlockingQueue<RecordExt> records = new LinkedBlockingQueue<>();
     final AtomicInteger size = new AtomicInteger(0);
 
     private RecordOffset lastConfirmOffset = null;
+    private RecordOffset latestAppendOffset = null;
 
     int state = STATE_NOT_SYNC;
 
     public ConfirmWalDataDelta(ConfirmWAL confirmWAL) {
+        this(confirmWAL, () -> {
+        });
+    }
+
+    public ConfirmWalDataDelta(ConfirmWAL confirmWAL, Runnable onAppendCallback) {
         this.confirmWAL = confirmWAL;
+        this.onAppendCallback = onAppendCallback;
         this.listenerHandle = confirmWAL.addAppendListener(this);
     }
 
@@ -120,6 +128,8 @@ public class ConfirmWalDataDelta implements ConfirmWAL.AppendListener {
                         state = STATE_SYNCING;
                     }
                     drainedRecords.forEach(r -> r.record.release());
+                } else if (hasNewEndOffset()) {
+                    newConfirmOffset = latestAppendOffset;
                 }
             } else if (state == STATE_SYNCING) {
                 delta = new ArrayList<>(records.size());
@@ -155,12 +165,17 @@ public class ConfirmWalDataDelta implements ConfirmWAL.AppendListener {
         }
     }
 
+    public synchronized boolean hasNewEndOffset() {
+        return latestAppendOffset != null && (lastConfirmOffset == null || latestAppendOffset.compareTo(lastConfirmOffset) > 0);
+    }
+
     @Override
     public synchronized void onAppend(StreamRecordBatch record, RecordOffset recordOffset,
         RecordOffset nextOffset) {
         if (state == STATE_CLOSED) {
             return;
         }
+        latestAppendOffset = nextOffset;
         record.retain();
         records.add(new RecordExt(record, recordOffset, nextOffset));
         if (size.addAndGet(record.encoded().readableBytes()) > MAX_RECORDS_BUFFER_SIZE) {
@@ -171,6 +186,7 @@ public class ConfirmWalDataDelta implements ConfirmWAL.AppendListener {
             records.clear();
             size.set(0);
         }
+        onAppendCallback.run();
     }
 
     record RecordExt(StreamRecordBatch record, RecordOffset recordOffset, RecordOffset nextOffset) {

--- a/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.message.AutomqGetPartitionSnapshotResponseData.To
 import org.apache.kafka.common.message.AutomqGetPartitionSnapshotResponseData.TopicCollection;
 import org.apache.kafka.common.requests.s3.AutomqGetPartitionSnapshotRequest;
 import org.apache.kafka.common.requests.s3.AutomqGetPartitionSnapshotResponse;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
@@ -46,6 +47,9 @@ import org.apache.kafka.storage.internals.log.TimestampOffset;
 
 import com.automq.stream.s3.ConfirmWAL;
 import com.automq.stream.utils.Threads;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,19 +60,27 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.netty.util.concurrent.FastThreadLocal;
 
 public class PartitionSnapshotsManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionSnapshotsManager.class);
     private static final int NOOP_SESSION_ID = 0;
+    static final long LONG_POLL_TIMEOUT_MS = 1000;
     private final Map<Integer, Session> sessions = new HashMap<>();
     private final List<PartitionWithVersion> snapshotVersions = new CopyOnWriteArrayList<>();
     private final Time time;
     private final ConfirmWAL confirmWAL;
+    private final ScheduledExecutorService longPollExecutor = Threads.newSingleThreadScheduledExecutor(
+        ThreadUtils.createThreadFactory("automq-partition-snapshot-long-poll", true), LOGGER, true);
+    private final AtomicBoolean partitionNotificationPending = new AtomicBoolean(false);
 
     public PartitionSnapshotsManager(Time time, AutoMQConfig config, ConfirmWAL confirmWAL,
         Supplier<AutoMQVersion> versionGetter) {
@@ -89,8 +101,9 @@ public class PartitionSnapshotsManager {
     public void onPartitionOpen(Partition partition) {
         PartitionWithVersion partitionWithVersion = new PartitionWithVersion(partition, PartitionSnapshotVersion.create());
         snapshotVersions.add(partitionWithVersion);
-        partition.maybeAddListener(newPartitionListener(partitionWithVersion));
-        partition.addLogEventListener(newLogEventListener(partitionWithVersion));
+        partition.maybeAddListener(newPartitionListener(partitionWithVersion, this::notifySnapshotChanged));
+        partition.addLogEventListener(newLogEventListener(partitionWithVersion, this::notifySnapshotChanged));
+        notifySnapshotChanged();
     }
 
     public void onPartitionClose(Partition partition) {
@@ -98,6 +111,7 @@ public class PartitionSnapshotsManager {
         synchronized (this) {
             sessions.values().forEach(s -> s.onPartitionClose(partition));
         }
+        notifySnapshotChanged();
     }
 
     public CompletableFuture<AutomqGetPartitionSnapshotResponse> handle(AutomqGetPartitionSnapshotRequest request) {
@@ -142,6 +156,32 @@ public class PartitionSnapshotsManager {
         });
     }
 
+    private void notifySnapshotChanged() {
+        if (partitionNotificationPending.compareAndSet(false, true)) {
+            longPollExecutor.execute(this::tryNotifySnapshotChanged);
+        }
+    }
+
+    private void tryNotifySnapshotChanged() {
+        List<Session> sessionsSnapshot;
+        synchronized (this) {
+            partitionNotificationPending.set(false);
+            sessionsSnapshot = new ArrayList<>(sessions.values());
+        }
+        sessionsSnapshot.forEach(Session::tryCompletePendingLongPoll);
+    }
+
+    /*
+     * A session returns partition/WAL deltas immediately when available. Otherwise, the request is parked as a
+     * pending long-poll and is completed by the first later partition/WAL change that produces deltas, or by timeout.
+     *
+     * Partition-change notifications are coalesced at the manager level, while WAL append notifications are
+     * coalesced per session. Both paths enqueue at most one async longPollExecutor wakeup while a prior notification is
+     * pending.
+     *
+     * Session mutable state is serialized by the Session monitor. The manager monitor is only used for the session
+     * map; session wakeups run after the manager lock is released.
+     */
     class Session {
         private static final short ZERO_ZONE_V0_REQUEST_VERSION = (short) 0;
         private static final FastThreadLocal<List<CompletableFuture<Void>>> COMPLETE_CF_LIST_LOCAL = new FastThreadLocal<>() {
@@ -157,14 +197,18 @@ public class PartitionSnapshotsManager {
         private long lastGetSnapshotsTimestamp = time.milliseconds();
         private final Set<CompletableFuture<Void>> inflightCommitCfSet = ConcurrentHashMap.newKeySet();
         private final ConfirmWalDataDelta delta;
+        private final AtomicBoolean walAppendNotificationPending = new AtomicBoolean(false);
+        private PendingLongPoll pendingLongPoll;
 
         public Session(int sessionId) {
             this.sessionId = sessionId;
-            this.delta = new ConfirmWalDataDelta(confirmWAL);
+            this.delta = new ConfirmWalDataDelta(confirmWAL,
+                this::notifyWalAppended);
         }
 
         public synchronized void close() {
             delta.close();
+            completePendingLongPoll();
         }
 
         public synchronized int sessionEpoch() {
@@ -173,42 +217,22 @@ public class PartitionSnapshotsManager {
 
         public synchronized CompletableFuture<AutomqGetPartitionSnapshotResponse> snapshotsDelta(
             AutomqGetPartitionSnapshotRequest request, boolean requestCommit) {
-            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
-            sessionEpoch++;
-            lastGetSnapshotsTimestamp = time.milliseconds();
-            resp.setSessionId(sessionId);
-            resp.setSessionEpoch(sessionEpoch);
-            long finalSessionEpoch = sessionEpoch;
-            CompletableFuture<Void> collectPartitionSnapshotsCf;
-            if (!requestCommit && inflightCommitCfSet.isEmpty()) {
-                collectPartitionSnapshotsCf = collectPartitionSnapshots(request.data().version(), resp);
-            } else {
-                collectPartitionSnapshotsCf = CompletableFuture.completedFuture(null);
+            if (pendingLongPoll != null) {
+                // Same-session requests with the current epoch are retries of the outstanding long-poll request.
+                lastGetSnapshotsTimestamp = time.milliseconds();
+                return pendingLongPoll.future;
             }
-            boolean newSession = finalSessionEpoch == 1;
-            return collectPartitionSnapshotsCf
-                .thenApply(nil -> {
-                    if (request.data().version() > ZERO_ZONE_V0_REQUEST_VERSION) {
-                        if (newSession) {
-                            // return the WAL config in the session first response
-                            resp.setConfirmWalConfig(confirmWAL.uri());
-                        }
-                        delta.handle(request.version(), resp);
+            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
+            if (!requestCommit && inflightCommitCfSet.isEmpty()) {
+                CompletableFuture<Void> collectPartitionSnapshotsCf = collectPartitionSnapshots(request.data().version(), resp);
+                return collectPartitionSnapshotsCf.thenCompose(nil -> {
+                    synchronized (Session.this) {
+                        return maybeLongPollOrComplete(request, resp);
                     }
-                    if (requestCommit) {
-                        // Commit after generating the snapshots.
-                        // Then the snapshot-read partitions could read from snapshot-read cache or block cache.
-                        CompletableFuture<Void> commitCf = newSession ?
-                            // The proxy node's first snapshot-read request needs to commit immediately to ensure the data could be read.
-                            confirmWAL.commit(0, false)
-                            // The proxy node's snapshot-read cache isn't enough to hold the 'uncommitted' data,
-                            // so the proxy node request a commit to ensure the data could be read from block cache.
-                            : confirmWAL.commit(1000, false);
-                        inflightCommitCfSet.add(commitCf);
-                        commitCf.whenComplete((rst, ex) -> inflightCommitCfSet.remove(commitCf));
-                    }
-                    return new AutomqGetPartitionSnapshotResponse(resp);
                 });
+            } else {
+                return completeResponse(request, requestCommit, resp);
+            }
         }
 
         public synchronized void onPartitionClose(Partition partition) {
@@ -217,6 +241,137 @@ public class PartitionSnapshotsManager {
 
         public synchronized boolean expired() {
             return time.milliseconds() - lastGetSnapshotsTimestamp > 60000;
+        }
+
+        private CompletableFuture<AutomqGetPartitionSnapshotResponse> maybeLongPollOrComplete(
+            AutomqGetPartitionSnapshotRequest request,
+            AutomqGetPartitionSnapshotResponseData resp
+        ) {
+            if (hasResponseDeltas(request, resp)) {
+                return completeResponse(request, false, resp);
+            }
+            return createPendingLongPoll(request);
+        }
+
+        private CompletableFuture<AutomqGetPartitionSnapshotResponse> completeResponse(
+            AutomqGetPartitionSnapshotRequest request,
+            boolean requestCommit,
+            AutomqGetPartitionSnapshotResponseData resp
+        ) {
+            cancelPendingLongPoll();
+            sessionEpoch++;
+            lastGetSnapshotsTimestamp = time.milliseconds();
+            resp.setSessionId(sessionId);
+            resp.setSessionEpoch(sessionEpoch);
+            boolean newSession = sessionEpoch == 1;
+            if (request.data().version() > ZERO_ZONE_V0_REQUEST_VERSION) {
+                if (newSession) {
+                    // return the WAL config in the session first response
+                    resp.setConfirmWalConfig(confirmWAL.uri());
+                }
+                delta.handle(request.version(), resp);
+            }
+            if (requestCommit) {
+                // Commit after generating the snapshots.
+                // Then the snapshot-read partitions could read from snapshot-read cache or block cache.
+                CompletableFuture<Void> commitCf = newSession ?
+                    // The proxy node's first snapshot-read request needs to commit immediately to ensure the data could be read.
+                    confirmWAL.commit(0, false)
+                    // The proxy node's snapshot-read cache isn't enough to hold the 'uncommitted' data,
+                    // so the proxy node request a commit to ensure the data could be read from block cache.
+                    : confirmWAL.commit(1000, false);
+                inflightCommitCfSet.add(commitCf);
+                commitCf.whenComplete((rst, ex) -> inflightCommitCfSet.remove(commitCf));
+            }
+            return CompletableFuture.completedFuture(new AutomqGetPartitionSnapshotResponse(resp));
+        }
+
+        private CompletableFuture<AutomqGetPartitionSnapshotResponse> createPendingLongPoll(
+            AutomqGetPartitionSnapshotRequest request
+        ) {
+            CompletableFuture<AutomqGetPartitionSnapshotResponse> future = new CompletableFuture<>();
+            PendingLongPoll pending = new PendingLongPoll(request, future);
+            pending.timeoutTask = longPollExecutor.schedule(
+                () -> {
+                    synchronized (Session.this) {
+                        if (pendingLongPoll == pending) {
+                            completePendingLongPoll();
+                        }
+                    }
+                },
+                LONG_POLL_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS
+            );
+            pendingLongPoll = pending;
+            return future;
+        }
+
+        private synchronized void tryCompletePendingLongPoll() {
+            completePendingLongPoll();
+        }
+
+        private void notifyWalAppended() {
+            if (walAppendNotificationPending.compareAndSet(false, true)) {
+                longPollExecutor.execute(this::tryNotifyWalAppended);
+            }
+        }
+
+        private synchronized void tryNotifyWalAppended() {
+            walAppendNotificationPending.set(false);
+            completePendingLongPoll();
+        }
+
+        private void completePendingLongPoll() {
+            PendingLongPoll pending = pendingLongPoll;
+            if (pending == null) {
+                return;
+            }
+            if (pending.completing) {
+                return;
+            }
+            pending.completing = true;
+            pending.cancelTimeout();
+            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
+            collectPartitionSnapshots(pending.request.data().version(), resp).whenComplete((nil, ex) -> {
+                synchronized (Session.this) {
+                    if (pendingLongPoll == pending) {
+                        finishPendingLongPoll(pending, resp, ex);
+                    }
+                }
+            });
+        }
+
+        private void finishPendingLongPoll(PendingLongPoll pending,
+            AutomqGetPartitionSnapshotResponseData resp,
+            Throwable ex) {
+            pendingLongPoll = null;
+            if (ex != null) {
+                pending.future.completeExceptionally(ex);
+                return;
+            }
+            completeResponse(pending.request, false, resp).whenComplete((response, completeEx) -> {
+                if (completeEx != null) {
+                    pending.future.completeExceptionally(completeEx);
+                } else {
+                    pending.future.complete(response);
+                }
+            });
+        }
+
+        private void cancelPendingLongPoll() {
+            PendingLongPoll pending = pendingLongPoll;
+            if (pending == null) {
+                return;
+            }
+            pendingLongPoll = null;
+            pending.cancelTimeout();
+            pending.future.cancel(false);
+        }
+
+        private boolean hasResponseDeltas(AutomqGetPartitionSnapshotRequest request,
+            AutomqGetPartitionSnapshotResponseData resp) {
+            return hasSnapshotDeltas(resp)
+                || (request.data().version() > ZERO_ZONE_V0_REQUEST_VERSION && delta.hasNewEndOffset());
         }
 
         private CompletableFuture<Void> collectPartitionSnapshots(short funcVersion,
@@ -295,6 +450,10 @@ public class PartitionSnapshotsManager {
 
     }
 
+    static boolean hasSnapshotDeltas(AutomqGetPartitionSnapshotResponseData resp) {
+        return resp.topics() != null && !resp.topics().isEmpty();
+    }
+
     static AutomqGetPartitionSnapshotResponseData.LogOffsetMetadata logOffsetMetadata(LogOffsetMetadata src) {
         if (src == null) {
             return null;
@@ -357,22 +516,46 @@ public class PartitionSnapshotsManager {
         }
     }
 
-    static PartitionListener newPartitionListener(PartitionWithVersion version) {
+    static PartitionListener newPartitionListener(PartitionWithVersion version, Runnable notifySnapshotChanged) {
         return new PartitionListener() {
             @Override
             public void onNewLeaderEpoch(long oldEpoch, long newEpoch) {
                 version.version.incrementRecordsVersion();
+                notifySnapshotChanged.run();
             }
 
             @Override
             public void onNewAppend(TopicPartition partition, long offset) {
                 version.version.incrementRecordsVersion();
+                notifySnapshotChanged.run();
             }
         };
     }
 
-    static LogEventListener newLogEventListener(PartitionWithVersion version) {
-        return (segment, event) -> version.version.incrementSegmentsVersion();
+    static LogEventListener newLogEventListener(PartitionWithVersion version, Runnable notifySnapshotChanged) {
+        return (segment, event) -> {
+            version.version.incrementSegmentsVersion();
+            notifySnapshotChanged.run();
+        };
+    }
+
+    static class PendingLongPoll {
+        final AutomqGetPartitionSnapshotRequest request;
+        final CompletableFuture<AutomqGetPartitionSnapshotResponse> future;
+        ScheduledFuture<?> timeoutTask;
+        boolean completing;
+
+        PendingLongPoll(AutomqGetPartitionSnapshotRequest request,
+            CompletableFuture<AutomqGetPartitionSnapshotResponse> future) {
+            this.request = request;
+            this.future = future;
+        }
+
+        void cancelTimeout() {
+            if (timeoutTask != null) {
+                timeoutTask.cancel(false);
+            }
+        }
     }
 
 }

--- a/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
@@ -46,6 +46,7 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
 import org.apache.kafka.storage.internals.log.TimestampOffset;
 
 import com.automq.stream.s3.ConfirmWAL;
+import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.Threads;
 
 import org.slf4j.Logger;
@@ -222,15 +223,18 @@ public class PartitionSnapshotsManager {
                 lastGetSnapshotsTimestamp = time.milliseconds();
                 return pendingLongPoll.future;
             }
-            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
             if (!requestCommit && inflightCommitCfSet.isEmpty()) {
-                CompletableFuture<Void> collectPartitionSnapshotsCf = collectPartitionSnapshots(request.data().version(), resp);
-                return collectPartitionSnapshotsCf.thenCompose(nil -> {
+                PendingLongPoll pending = new PendingLongPoll(request, new CompletableFuture<>());
+                pendingLongPoll = pending;
+                pending.future.whenComplete((response, ex) -> {
                     synchronized (Session.this) {
-                        return maybeLongPollOrComplete(request, resp);
+                        cleanupPendingLongPoll(pending);
                     }
                 });
+                registerLongPolling(pending);
+                return pending.future;
             } else {
+                AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
                 return completeResponse(request, requestCommit, resp);
             }
         }
@@ -243,14 +247,46 @@ public class PartitionSnapshotsManager {
             return time.milliseconds() - lastGetSnapshotsTimestamp > 60000;
         }
 
-        private CompletableFuture<AutomqGetPartitionSnapshotResponse> maybeLongPollOrComplete(
-            AutomqGetPartitionSnapshotRequest request,
-            AutomqGetPartitionSnapshotResponseData resp
-        ) {
-            if (hasResponseDeltas(request, resp)) {
-                return completeResponse(request, false, resp);
+        private void registerLongPolling(PendingLongPoll pending) {
+            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
+            CompletableFuture<Void> collectPartitionSnapshotsCf = collectPartitionSnapshots(
+                pending.request.data().version(), resp);
+            if (hasResponseDeltas(pending.request, resp)) {
+                collectPartitionSnapshotsCf.whenComplete((nil, ex) -> {
+                    synchronized (Session.this) {
+                        if (pendingLongPoll == pending) {
+                            completePendingResponse(pending, resp, ex);
+                        }
+                    }
+                });
+                return;
             }
-            return createPendingLongPoll(request);
+
+            pending.timeoutTask = longPollExecutor.schedule(
+                () -> {
+                    synchronized (Session.this) {
+                        if (pendingLongPoll == pending) {
+                            completePendingLongPoll();
+                        }
+                    }
+                },
+                LONG_POLL_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS
+            );
+            pending.triggerCf.thenCompose(nil -> {
+                pending.cancelTimeout();
+                AutomqGetPartitionSnapshotResponseData triggeredResp = new AutomqGetPartitionSnapshotResponseData();
+                return collectPartitionSnapshots(pending.request.data().version(), triggeredResp)
+                    .thenApply(ignored -> triggeredResp);
+            }).whenComplete((triggeredResp, ex) -> {
+                synchronized (Session.this) {
+                    if (pendingLongPoll == pending) {
+                        // A partition/WAL trigger is a liveness signal for the parked request: complete the long poll
+                        // even when the collected response is empty because the triggering delta may have been consumed.
+                        completePendingResponse(pending, triggeredResp, ex);
+                    }
+                }
+            });
         }
 
         private CompletableFuture<AutomqGetPartitionSnapshotResponse> completeResponse(
@@ -258,7 +294,6 @@ public class PartitionSnapshotsManager {
             boolean requestCommit,
             AutomqGetPartitionSnapshotResponseData resp
         ) {
-            cancelPendingLongPoll();
             sessionEpoch++;
             lastGetSnapshotsTimestamp = time.milliseconds();
             resp.setSessionId(sessionId);
@@ -286,26 +321,6 @@ public class PartitionSnapshotsManager {
             return CompletableFuture.completedFuture(new AutomqGetPartitionSnapshotResponse(resp));
         }
 
-        private CompletableFuture<AutomqGetPartitionSnapshotResponse> createPendingLongPoll(
-            AutomqGetPartitionSnapshotRequest request
-        ) {
-            CompletableFuture<AutomqGetPartitionSnapshotResponse> future = new CompletableFuture<>();
-            PendingLongPoll pending = new PendingLongPoll(request, future);
-            pending.timeoutTask = longPollExecutor.schedule(
-                () -> {
-                    synchronized (Session.this) {
-                        if (pendingLongPoll == pending) {
-                            completePendingLongPoll();
-                        }
-                    }
-                },
-                LONG_POLL_TIMEOUT_MS,
-                TimeUnit.MILLISECONDS
-            );
-            pendingLongPoll = pending;
-            return future;
-        }
-
         private synchronized void tryCompletePendingLongPoll() {
             completePendingLongPoll();
         }
@@ -326,46 +341,24 @@ public class PartitionSnapshotsManager {
             if (pending == null) {
                 return;
             }
-            if (pending.completing) {
-                return;
-            }
-            pending.completing = true;
-            pending.cancelTimeout();
-            AutomqGetPartitionSnapshotResponseData resp = new AutomqGetPartitionSnapshotResponseData();
-            collectPartitionSnapshots(pending.request.data().version(), resp).whenComplete((nil, ex) -> {
-                synchronized (Session.this) {
-                    if (pendingLongPoll == pending) {
-                        finishPendingLongPoll(pending, resp, ex);
-                    }
-                }
-            });
+            pending.triggerCf.complete(null);
         }
 
-        private void finishPendingLongPoll(PendingLongPoll pending,
-            AutomqGetPartitionSnapshotResponseData resp,
+        private void completePendingResponse(PendingLongPoll pending, AutomqGetPartitionSnapshotResponseData resp,
             Throwable ex) {
-            pendingLongPoll = null;
             if (ex != null) {
                 pending.future.completeExceptionally(ex);
                 return;
             }
-            completeResponse(pending.request, false, resp).whenComplete((response, completeEx) -> {
-                if (completeEx != null) {
-                    pending.future.completeExceptionally(completeEx);
-                } else {
-                    pending.future.complete(response);
-                }
-            });
+            FutureUtil.propagate(completeResponse(pending.request, false, resp), pending.future);
         }
 
-        private void cancelPendingLongPoll() {
-            PendingLongPoll pending = pendingLongPoll;
-            if (pending == null) {
+        private void cleanupPendingLongPoll(PendingLongPoll pending) {
+            if (pendingLongPoll != pending) {
                 return;
             }
             pendingLongPoll = null;
             pending.cancelTimeout();
-            pending.future.cancel(false);
         }
 
         private boolean hasResponseDeltas(AutomqGetPartitionSnapshotRequest request,
@@ -408,7 +401,11 @@ public class PartitionSnapshotsManager {
             resp.setTopics(topics);
             CompletableFuture<Void> retCf = CompletableFuture.allOf(completeCfList.toArray(new CompletableFuture[0]));
             completeCfList.clear();
-            return retCf;
+            return retCf.exceptionally(ex -> {
+                LOGGER.warn("Partition snapshot completion failed, returning collected snapshot delta anyway. sessionId={}",
+                    sessionId, ex);
+                return null;
+            });
         }
 
         private PartitionSnapshot snapshot(short funcVersion, Partition partition,
@@ -542,8 +539,8 @@ public class PartitionSnapshotsManager {
     static class PendingLongPoll {
         final AutomqGetPartitionSnapshotRequest request;
         final CompletableFuture<AutomqGetPartitionSnapshotResponse> future;
+        final CompletableFuture<Void> triggerCf = new CompletableFuture<>();
         ScheduledFuture<?> timeoutTask;
-        boolean completing;
 
         PendingLongPoll(AutomqGetPartitionSnapshotRequest request,
             CompletableFuture<AutomqGetPartitionSnapshotResponse> future) {

--- a/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/PartitionSnapshotsManager.java
@@ -74,7 +74,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 public class PartitionSnapshotsManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(PartitionSnapshotsManager.class);
     private static final int NOOP_SESSION_ID = 0;
-    static final long LONG_POLL_TIMEOUT_MS = 1000;
+    static final long LONG_POLL_TIMEOUT_MS = 100;
     private final Map<Integer, Session> sessions = new HashMap<>();
     private final List<PartitionWithVersion> snapshotVersions = new CopyOnWriteArrayList<>();
     private final Time time;

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory
 import java.util
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{CompletableFuture, ExecutorService, TimeUnit}
-import java.util.function.Supplier
+import java.util.function.{BiConsumer, Supplier}
 import java.util.stream.IntStream
 import java.util.{Collections, Optional}
 import scala.annotation.nowarn
@@ -869,11 +869,17 @@ class ElasticKafkaApis(
 
   override def handleOffsetForLeaderEpochRequest(request: RequestChannel.Request): Unit = {
     val cf = snapshotAwaitReadySupplier.get()
-    offsetForLeaderEpochExecutor.execute(() => {
-      // Await new snapshots to be applied to avoid consumers finding the endOffset jumping back when the snapshot-read partition leader changes.
-      cf.join()
-      super.handleOffsetForLeaderEpochRequest(request)
-    })
+    def handleOffsetForLeaderEpoch(): Unit = super.handleOffsetForLeaderEpochRequest(request)
+    // Await new snapshots to be applied to avoid consumers finding the endOffset jumping back when the snapshot-read partition leader changes.
+    cf.whenCompleteAsync(new BiConsumer[Void, Throwable] {
+      override def accept(nil: Void, ex: Throwable): Unit = {
+        if (ex != null) {
+          handleError(request, ex)
+        } else {
+          handleOffsetForLeaderEpoch()
+        }
+      }
+    }, offsetForLeaderEpochExecutor)
   }
 
   override protected def metadataTopicsInterceptor(clientId: ClientIdMetadata, listenerName: String, topics: util.List[MetadataResponseData.MetadataResponseTopic]): util.List[MetadataResponseData.MetadataResponseTopic] = {

--- a/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
+++ b/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
@@ -90,7 +90,6 @@ public class PartitionSnapshotsManagerTest {
         CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
             request(first.data().sessionId(), first.data().sessionEpoch(), false));
 
-        Thread.sleep(100);
         assertFalse(second.isDone());
 
         AutomqGetPartitionSnapshotResponse timeoutResponse = second.get(2, TimeUnit.SECONDS);
@@ -200,13 +199,14 @@ public class PartitionSnapshotsManagerTest {
     @Test
     public void testTimeoutDoesNotDropInFlightCollectedDeltas() throws Exception {
         AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
-        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
-            request(first.data().sessionId(), first.data().sessionEpoch(), false));
-        assertFalse(pending.isDone());
 
         Uuid topicId = Uuid.randomUuid();
         CompletableFuture<Void> slowSnapshotCf = new CompletableFuture<>();
         manager.onPartitionOpen(partition(topicId, 3, 7, 9, slowSnapshotCf));
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(pending.isDone());
 
         Thread.sleep(PartitionSnapshotsManager.LONG_POLL_TIMEOUT_MS + 100);
         assertFalse(pending.isDone());

--- a/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
+++ b/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
@@ -38,10 +38,12 @@ import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -51,7 +53,6 @@ import scala.Option;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -154,7 +155,7 @@ public class PartitionSnapshotsManagerTest {
     }
 
     @Test
-    public void testAlreadyFailedSnapshotFuturePropagates() throws Exception {
+    public void testAlreadyFailedSnapshotFutureStillCompletesCollectedDelta() throws Exception {
         Uuid topicId = Uuid.randomUuid();
         CompletableFuture<Void> failedSnapshotCf = new CompletableFuture<>();
         failedSnapshotCf.completeExceptionally(new IllegalStateException("snapshot failed"));
@@ -165,7 +166,12 @@ public class PartitionSnapshotsManagerTest {
         CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
             request(first.data().sessionId(), first.data().sessionEpoch(), false));
 
-        assertThrows(ExecutionException.class, () -> second.get(1, TimeUnit.SECONDS));
+        AutomqGetPartitionSnapshotResponse response = second.get(1, TimeUnit.SECONDS);
+        assertEquals(first.data().sessionId(), response.data().sessionId());
+        assertEquals(first.data().sessionEpoch() + 1, response.data().sessionEpoch());
+        assertEquals(1, response.data().topics().size());
+        assertEquals(topicId, response.data().topics().find(topicId).topicId());
+        assertEquals(3, response.data().topics().find(topicId).partitions().get(0).partitionIndex());
     }
 
     @Test
@@ -239,6 +245,66 @@ public class PartitionSnapshotsManagerTest {
         assertEquals(topicId, retryResponse.data().topics().find(topicId).topicId());
     }
 
+    @Test
+    public void testInFlightCollectionCompletesConcurrentPendingRetry() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+
+        Uuid topicId = Uuid.randomUuid();
+        CompletableFuture<Void> slowSnapshotCf = new CompletableFuture<>();
+        manager.onPartitionOpen(partition(topicId, 3, 7, 9, slowSnapshotCf));
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> collecting = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(collecting.isDone());
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> retry = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(retry.isDone());
+
+        slowSnapshotCf.complete(null);
+        AutomqGetPartitionSnapshotResponse collectingResponse = collecting.get(1, TimeUnit.SECONDS);
+        AutomqGetPartitionSnapshotResponse retryResponse = retry.get(1, TimeUnit.SECONDS);
+        assertEquals(collectingResponse.data().sessionId(), retryResponse.data().sessionId());
+        assertEquals(collectingResponse.data().sessionEpoch(), retryResponse.data().sessionEpoch());
+        assertEquals(1, retryResponse.data().topics().size());
+        assertEquals(topicId, retryResponse.data().topics().find(topicId).topicId());
+        assertEquals(3, retryResponse.data().topics().find(topicId).partitions().get(0).partitionIndex());
+    }
+
+    @Test
+    public void testStaleWalNotificationForceCompletesIdleLongPoll() throws Exception {
+        when(confirmWAL.confirmOffset()).thenReturn(DefaultRecordOffset.of(1, 0, 0));
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false, (short) 1, (short) 2))
+            .get(1, TimeUnit.SECONDS);
+
+        CountDownLatch executorBlocked = new CountDownLatch(1);
+        CountDownLatch releaseExecutor = new CountDownLatch(1);
+        longPollExecutor().execute(() -> {
+            executorBlocked.countDown();
+            try {
+                releaseExecutor.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(executorBlocked.await(1, TimeUnit.SECONDS));
+
+        appendWalRecord(0, 0);
+        AutomqGetPartitionSnapshotResponse walResponse = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false, (short) 1, (short) 2))
+            .get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
+            request(walResponse.data().sessionId(), walResponse.data().sessionEpoch(), false, (short) 1, (short) 2));
+        assertFalse(pending.isDone());
+
+        releaseExecutor.countDown();
+
+        AutomqGetPartitionSnapshotResponse response = pending.get(1, TimeUnit.SECONDS);
+        assertEquals(walResponse.data().sessionEpoch() + 1, response.data().sessionEpoch());
+        assertTrue(response.data().topics().isEmpty());
+    }
+
     private static AutomqGetPartitionSnapshotRequest request(int sessionId, int sessionEpoch, boolean requestCommit) {
         return request(sessionId, sessionEpoch, requestCommit, (short) 0, (short) 0);
     }
@@ -263,6 +329,12 @@ public class PartitionSnapshotsManagerTest {
             DefaultRecordOffset.of(1, walOffset + 1, 0)
         );
         record.release();
+    }
+
+    private ScheduledExecutorService longPollExecutor() throws Exception {
+        Field field = PartitionSnapshotsManager.class.getDeclaredField("longPollExecutor");
+        field.setAccessible(true);
+        return (ScheduledExecutorService) field.get(manager);
     }
 
     private static Partition partition(Uuid topicId, int partitionId, int leaderEpoch, long endOffset) {

--- a/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
+++ b/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.partition.snapshot;
+
+import kafka.automq.AutoMQConfig;
+import kafka.cluster.Partition;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.AutomqGetPartitionSnapshotRequestData;
+import org.apache.kafka.common.requests.s3.AutomqGetPartitionSnapshotRequest;
+import org.apache.kafka.common.requests.s3.AutomqGetPartitionSnapshotResponse;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
+import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
+import org.apache.kafka.storage.internals.log.TimestampOffset;
+
+import com.automq.stream.s3.ConfirmWAL;
+import com.automq.stream.s3.model.StreamRecordBatch;
+import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.Unpooled;
+import scala.Function0;
+import scala.Option;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PartitionSnapshotsManagerTest {
+    private MockTime time;
+    private ConfirmWAL confirmWAL;
+    private AtomicReference<ConfirmWAL.AppendListener> appendListener;
+    private PartitionSnapshotsManager manager;
+
+    @BeforeEach
+    public void setup() {
+        time = new MockTime();
+        AutoMQConfig config = mock(AutoMQConfig.class);
+        when(config.zoneRouterChannels()).thenReturn(Optional.empty());
+        confirmWAL = mock(ConfirmWAL.class);
+        appendListener = new AtomicReference<>();
+        when(confirmWAL.addAppendListener(any())).thenAnswer(invocation -> {
+            appendListener.set(invocation.getArgument(0));
+            return (ConfirmWAL.ListenerHandle) () -> {
+            };
+        });
+        when(confirmWAL.commit(anyLong(), eq(false))).thenReturn(CompletableFuture.completedFuture(null));
+        manager = new PartitionSnapshotsManager(time, config, confirmWAL, () -> AutoMQVersion.V3);
+    }
+
+    @Test
+    public void testIdleExistingSessionLongPollsUntilTimeout() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+
+        Thread.sleep(100);
+        assertFalse(second.isDone());
+
+        AutomqGetPartitionSnapshotResponse timeoutResponse = second.get(2, TimeUnit.SECONDS);
+        assertEquals(first.data().sessionId(), timeoutResponse.data().sessionId());
+        assertEquals(first.data().sessionEpoch() + 1, timeoutResponse.data().sessionEpoch());
+        assertTrue(timeoutResponse.data().topics().isEmpty());
+    }
+
+    @Test
+    public void testRequestCommitBypassesLongPoll() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), true));
+
+        assertTrue(second.isDone());
+        AutomqGetPartitionSnapshotResponse response = second.get(1, TimeUnit.SECONDS);
+        assertEquals(first.data().sessionEpoch() + 1, response.data().sessionEpoch());
+    }
+
+    @Test
+    public void testPartitionOpenWakesPendingLongPoll() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+
+        assertFalse(second.isDone());
+
+        Uuid topicId = Uuid.randomUuid();
+        manager.onPartitionOpen(partition(topicId, 3, 7, 9));
+
+        AutomqGetPartitionSnapshotResponse response = second.get(1, TimeUnit.SECONDS);
+        assertEquals(first.data().sessionEpoch() + 1, response.data().sessionEpoch());
+        assertEquals(1, response.data().topics().size());
+        assertEquals(topicId, response.data().topics().find(topicId).topicId());
+        assertEquals(3, response.data().topics().find(topicId).partitions().get(0).partitionIndex());
+    }
+
+    @Test
+    public void testConfirmWalDeltaWakesPendingLongPoll() throws Exception {
+        when(confirmWAL.confirmOffset()).thenReturn(DefaultRecordOffset.of(1, 0, 0));
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false, (short) 1, (short) 2))
+            .get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false, (short) 1, (short) 2));
+        assertFalse(second.isDone());
+        appendWalRecord(0, 0);
+
+        AutomqGetPartitionSnapshotResponse walOffsetResponse = second.get(1, TimeUnit.SECONDS);
+        assertTrue(walOffsetResponse.data().topics().isEmpty());
+        assertEquals(1, DefaultRecordOffset.of(Unpooled.wrappedBuffer(walOffsetResponse.data().confirmWalEndOffset())).offset());
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> third = manager.handle(
+            request(walOffsetResponse.data().sessionId(), walOffsetResponse.data().sessionEpoch(), false, (short) 1, (short) 2));
+        assertFalse(third.isDone());
+        appendWalRecord(1, 1);
+
+        AutomqGetPartitionSnapshotResponse walDeltaResponse = third.get(1, TimeUnit.SECONDS);
+        assertTrue(walDeltaResponse.data().topics().isEmpty());
+        assertTrue(walDeltaResponse.data().confirmWalDeltaData().length > 0);
+    }
+
+    @Test
+    public void testAlreadyFailedSnapshotFuturePropagates() throws Exception {
+        Uuid topicId = Uuid.randomUuid();
+        CompletableFuture<Void> failedSnapshotCf = new CompletableFuture<>();
+        failedSnapshotCf.completeExceptionally(new IllegalStateException("snapshot failed"));
+        manager.onPartitionOpen(partition(topicId, 3, 7, 9, failedSnapshotCf));
+
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> second = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+
+        assertThrows(ExecutionException.class, () -> second.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testConcurrentRequestReusesPendingLongPoll() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(pending.isDone());
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> retry = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), true));
+
+        assertFalse(retry.isDone());
+
+        AutomqGetPartitionSnapshotResponse retryResponse = retry.get(2, TimeUnit.SECONDS);
+        AutomqGetPartitionSnapshotResponse pendingResponse = pending.get(1, TimeUnit.SECONDS);
+        assertEquals(retryResponse.data().sessionId(), pendingResponse.data().sessionId());
+        assertEquals(retryResponse.data().sessionEpoch(), pendingResponse.data().sessionEpoch());
+
+        AutomqGetPartitionSnapshotResponse next = manager.handle(
+            request(retryResponse.data().sessionId(), retryResponse.data().sessionEpoch(), true)).get(1, TimeUnit.SECONDS);
+        assertEquals(retryResponse.data().sessionId(), next.data().sessionId());
+        assertEquals(retryResponse.data().sessionEpoch() + 1, next.data().sessionEpoch());
+    }
+
+    @Test
+    public void testTimeoutDoesNotDropInFlightCollectedDeltas() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(pending.isDone());
+
+        Uuid topicId = Uuid.randomUuid();
+        CompletableFuture<Void> slowSnapshotCf = new CompletableFuture<>();
+        manager.onPartitionOpen(partition(topicId, 3, 7, 9, slowSnapshotCf));
+
+        Thread.sleep(PartitionSnapshotsManager.LONG_POLL_TIMEOUT_MS + 100);
+        assertFalse(pending.isDone());
+
+        slowSnapshotCf.complete(null);
+        AutomqGetPartitionSnapshotResponse response = pending.get(1, TimeUnit.SECONDS);
+        assertEquals(first.data().sessionEpoch() + 1, response.data().sessionEpoch());
+        assertEquals(1, response.data().topics().size());
+        assertEquals(topicId, response.data().topics().find(topicId).topicId());
+        assertEquals(3, response.data().topics().find(topicId).partitions().get(0).partitionIndex());
+    }
+
+    @Test
+    public void testConcurrentRequestReusesCompletingLongPoll() throws Exception {
+        AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false)).get(1, TimeUnit.SECONDS);
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> pending = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), false));
+        assertFalse(pending.isDone());
+
+        Uuid topicId = Uuid.randomUuid();
+        CompletableFuture<Void> slowSnapshotCf = new CompletableFuture<>();
+        manager.onPartitionOpen(partition(topicId, 3, 7, 9, slowSnapshotCf));
+        Thread.sleep(100);
+        assertFalse(pending.isDone());
+
+        CompletableFuture<AutomqGetPartitionSnapshotResponse> retry = manager.handle(
+            request(first.data().sessionId(), first.data().sessionEpoch(), true));
+        assertFalse(retry.isDone());
+
+        slowSnapshotCf.complete(null);
+        AutomqGetPartitionSnapshotResponse retryResponse = retry.get(1, TimeUnit.SECONDS);
+        AutomqGetPartitionSnapshotResponse pendingResponse = pending.get(1, TimeUnit.SECONDS);
+        assertEquals(retryResponse.data().sessionId(), pendingResponse.data().sessionId());
+        assertEquals(retryResponse.data().sessionEpoch(), pendingResponse.data().sessionEpoch());
+        assertEquals(1, retryResponse.data().topics().size());
+        assertEquals(topicId, retryResponse.data().topics().find(topicId).topicId());
+    }
+
+    private static AutomqGetPartitionSnapshotRequest request(int sessionId, int sessionEpoch, boolean requestCommit) {
+        return request(sessionId, sessionEpoch, requestCommit, (short) 0, (short) 0);
+    }
+
+    private static AutomqGetPartitionSnapshotRequest request(int sessionId, int sessionEpoch, boolean requestCommit,
+        short dataVersion, short requestVersion) {
+        return new AutomqGetPartitionSnapshotRequest(
+            new AutomqGetPartitionSnapshotRequestData()
+                .setSessionId(sessionId)
+                .setSessionEpoch(sessionEpoch)
+                .setRequestCommit(requestCommit)
+                .setVersion(dataVersion),
+            requestVersion
+        );
+    }
+
+    private void appendWalRecord(long baseOffset, long walOffset) {
+        StreamRecordBatch record = StreamRecordBatch.of(1, 2, baseOffset, 1, Unpooled.wrappedBuffer(new byte[1]));
+        appendListener.get().onAppend(
+            record,
+            DefaultRecordOffset.of(1, walOffset, 1),
+            DefaultRecordOffset.of(1, walOffset + 1, 0)
+        );
+        record.release();
+    }
+
+    private static Partition partition(Uuid topicId, int partitionId, int leaderEpoch, long endOffset) {
+        return partition(topicId, partitionId, leaderEpoch, endOffset, CompletableFuture.completedFuture(null));
+    }
+
+    private static Partition partition(Uuid topicId, int partitionId, int leaderEpoch, long endOffset,
+        CompletableFuture<Void> completeCf) {
+        Partition partition = mock(Partition.class);
+        when(partition.topicId()).thenReturn(Option.apply(topicId));
+        when(partition.partitionId()).thenReturn(partitionId);
+        when(partition.getLeaderEpoch()).thenReturn(leaderEpoch);
+        when(partition.maybeAddListener(any())).thenReturn(true);
+        doAnswer(invocation -> ((Function0<?>) invocation.getArgument(0)).apply())
+            .when(partition).withReadLock(any());
+        when(partition.snapshot()).thenReturn(new kafka.cluster.PartitionSnapshot(
+            leaderEpoch,
+            null,
+            new LogOffsetMetadata(endOffset),
+            new LogOffsetMetadata(endOffset),
+            Map.of(1L, endOffset),
+            new TimestampOffset(1, endOffset),
+            completeCf
+        ));
+        return partition;
+    }
+}


### PR DESCRIPTION
## Summary
- Simplify partition snapshot long polling so each `PendingLongPoll` owns the client response future, a `triggerCf` wakeup future, and its timeout task.
- Register the pending request before snapshot collection so same-session retries reuse the in-flight future; immediate deltas still wait for partition snapshot completion before responding.
- Complete trigger/timeout wakeups through `triggerCf`, force-complete triggered long polls even when the collected delta is empty, and centralize cleanup in `pending.future.whenComplete`.

## Why
- Saves CPU on snapshot-read clients and brokers by reducing repeated empty snapshot-delta requests while keeping the pending long-poll lifecycle explicit and race-resistant.

## Test Plan
- [x] `./gradlew :core:test --tests kafka.automq.partition.snapshot.PartitionSnapshotsManagerTest`