### PR TITLE
fix: handle empty read-committed elastic log fetch

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
@@ -396,6 +396,16 @@ class ElasticLog(val metaStream: MetaStream,
         segment: LogSegment,
         fetchInfo: FetchDataInfo, upperBoundOffsetOpt: Option[Long]): FetchDataInfo = {
         val fetchSize = fetchInfo.records.sizeInBytes
+        // A zero-byte fetch contains no record batches, so there are no aborted
+        // transactions for the consumer to filter. Returning an empty aborted list also
+        // avoids falling back to ElasticLogSegment.fetchUpperBoundOffset, which is not
+        // implemented for elastic segments and is unnecessary for empty fetch results.
+        if (fetchSize == 0) {
+            return new FetchDataInfo(fetchInfo.fetchOffsetMetadata,
+                fetchInfo.records,
+                fetchInfo.firstEntryIncomplete,
+                Optional.of(Collections.emptyList()))
+        }
         val startOffsetPosition = new OffsetPosition(fetchInfo.fetchOffsetMetadata.messageOffset,
             fetchInfo.fetchOffsetMetadata.relativePositionInSegment)
         val upperBoundOffset = upperBoundOffsetOpt match {

--- a/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
+++ b/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
@@ -608,6 +608,17 @@ class ElasticLogTest {
         assertEquals(4L, abortedTxns(1).asInstanceOf[FetchResponseData.AbortedTransaction].firstOffset())
     }
 
+    @Test
+    def testReadCommittedEmptyFetchReturnsEmptyAbortedTransactions(): Unit = {
+        appendRecords(kvsToRecords(Seq(KeyValue("a=", "1"))), initialOffset = 0)
+
+        val fetchDataInfo = log.read(0, 0, minOneMessage = false, log.logEndOffsetMetadata, includeAbortedTxns = true)
+
+        assertEquals(0, fetchDataInfo.records.sizeInBytes)
+        assertTrue(fetchDataInfo.abortedTransactions.isPresent)
+        assertTrue(fetchDataInfo.abortedTransactions.get.isEmpty)
+    }
+
     private def createElasticLogWithActiveSegment(dir: File = logDir,
         config: LogConfig,
         scheduler: Scheduler = mockTime.scheduler,


### PR DESCRIPTION
## Summary
- return an empty aborted transaction list for empty ElasticLog fetch results under read-committed isolation
- avoid calling ElasticLogSegment.fetchUpperBoundOffset for zero-byte fetch results
- add a regression test for maxLength=0 with includeAbortedTxns=true

## Tests
- ./gradlew core:test --tests kafka.log.streamaspect.ElasticLogTest --no-daemon -x checkstyleTest

## Notes
- Running the same targeted test without `-x checkstyleTest` was blocked by an existing untracked file in the working tree: `core/src/test/java/kafka/coordinator/group/GroupCoordinatorPartitionTest.java` violates MethodLength. That file is not part of this PR.