### PR TITLE
fix(s3stream): avoid aliasing LogCache merge sources (#3349)

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -413,16 +413,14 @@ public class LogCache {
         synchronized (left) {
             left.size.addAndGet(right.size());
             left.lastRecordOffset = right.lastRecordOffset;
-            left.map.forEach((streamId, leftStreamCache) -> {
-                StreamCache rightStreamCache = right.map.get(streamId);
-                if (rightStreamCache != null) {
+            right.map.forEach((streamId, rightStreamCache) -> {
+                StreamCache leftStreamCache = left.map.get(streamId);
+                if (leftStreamCache == null) {
+                    left.map.put(streamId, new StreamCache(rightStreamCache));
+                } else {
                     leftStreamCache.records.addAll(rightStreamCache.records);
                     leftStreamCache.endOffset(rightStreamCache.endOffset());
-                }
-            });
-            right.map.forEach((streamId, rightStreamCache) -> {
-                if (!left.map.containsKey(streamId)) {
-                    left.map.put(streamId, rightStreamCache);
+                    leftStreamCache.offsetIndexMap.clear();
                 }
             });
         }
@@ -596,6 +594,12 @@ public class LogCache {
 
         public StreamCache() {
             this.records = new ArrayList<>();
+        }
+
+        StreamCache(StreamCache other) {
+            this.records = new ArrayList<>(other.records);
+            this.startOffset = other.startOffset();
+            this.endOffset = other.endOffset();
         }
 
         /**

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
@@ -167,6 +167,23 @@ public class LogCacheTest {
     }
 
     @Test
+    public void testMergeBlockDoesNotAliasSourceStreamCaches() {
+        LogCacheBlock left = new LogCacheBlock(1024L * 1024);
+        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
+
+        LogCacheBlock right = new LogCacheBlock(1024L * 1024);
+        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20)));
+
+        LogCacheBlock merged = new LogCacheBlock(1024L * 1024);
+        LogCache.mergeBlock(merged, left);
+        LogCache.mergeBlock(merged, right);
+
+        assertEquals(1, left.map.get(233L).records.size());
+        assertEquals(11L, right.map.get(233L).records.get(0).getBaseOffset());
+        assertEquals(2, merged.map.get(233L).records.size());
+    }
+
+    @Test
     public void testTryMergeLogic() throws ExecutionException, InterruptedException {
         LogCache logCache = new LogCache(Long.MAX_VALUE, 10_000L);
         final long streamId = 233L;


### PR DESCRIPTION
## Summary
- Fix LogCache merge candidate construction so it copies StreamCache containers instead of aliasing source block StreamCaches.
- Prevent an aborted tryMerge swap from mutating source blocks and leaving duplicate StreamRecordBatch references to be freed twice.
- Add a regression test proving mergeBlock does not alias source StreamCache containers.

## Bug flow
1. tryMerge selects two adjacent free blocks, left and right, then releases the write lock before doing expensive merge work.
2. The previous mergeBlock(newBlock, left) put left's StreamCache object directly into the candidate newBlock when newBlock did not have that stream yet.
3. mergeBlock(newBlock, right) then appended right's records into that same StreamCache object, so candidate construction had already mutated left by alias.
4. If the final guarded swap was aborted because the source blocks changed while the lock was released, left and right stayed in the block list, but left could now contain right's record references.
5. A later free path could release the same StreamRecordBatch through both original blocks, causing the second ByteBuf release to hit refCnt 0 and throw IllegalReferenceCountException.

## Test Plan
- ./gradlew :s3stream:test --tests com.automq.stream.s3.cache.LogCacheTest --tests com.automq.stream.s3.S3StorageTest