### PR TITLE
Add Connect startup failure log

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -53,6 +53,8 @@ import java.util.Properties;
  */
 public abstract class AbstractConnectCli<H extends Herder, T extends WorkerConfig> {
 
+    static final String STARTUP_FAILURE_LOG_PREFIX = "AUTOMQ_CONNECT_STARTUP_FAILURE";
+
     private static Logger getLogger() {
         return LoggerFactory.getLogger(AbstractConnectCli.class);
     }
@@ -122,6 +124,7 @@ public abstract class AbstractConnectCli<H extends Herder, T extends WorkerConfi
             connect.awaitStop();
 
         } catch (Throwable t) {
+            logStartupFailure("run", t);
             getLogger().error("Stopping due to error", t);
             Exit.exit(2);
         }
@@ -165,12 +168,47 @@ public abstract class AbstractConnectCli<H extends Herder, T extends WorkerConfi
         try {
             connect.start();
         } catch (Exception e) {
+            logStartupFailure("connect.start", e);
             getLogger().error("Failed to start Connect", e);
             connect.stop();
             Exit.exit(3);
         }
 
         return connect;
+    }
+
+    static void logStartupFailure(String stage, Throwable failure) {
+        String errorClass = failure == null ? "unknown" : failure.getClass().getName();
+        String message = failure == null ? "" : failure.getMessage();
+        getLogger().error("{} {{\"stage\":\"{}\",\"errorClass\":\"{}\",\"message\":\"{}\"}}",
+            STARTUP_FAILURE_LOG_PREFIX, jsonEscape(stage), jsonEscape(errorClass), jsonEscape(message));
+    }
+
+    private static String jsonEscape(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder(value.length() + 16);
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (ch < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
     }
 
     private void initializeTelemetry(Map<String, String> workerProps) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/cli/ConnectStandaloneTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/cli/ConnectStandaloneTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.cli;
 
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.connect.runtime.rest.entities.CreateConnectorRequest;
 import org.apache.kafka.test.TestUtils;
 
@@ -28,12 +29,14 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConnectStandaloneTest {
 
@@ -125,5 +128,19 @@ public class ConnectStandaloneTest {
         CreateConnectorRequest parsedRequest = connectStandalone.parseConnectorConfigurationFile(connectorConfigurationFile.getAbsolutePath());
         CreateConnectorRequest expectedRequest = new CreateConnectorRequest(CONNECTOR_NAME, CONNECTOR_CONFIG, null);
         assertEquals(expectedRequest, parsedRequest);
+    }
+
+    @Test
+    public void testStartupFailureLogIsStructured() {
+        try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(AbstractConnectCli.class)) {
+            AbstractConnectCli.logStartupFailure("connect.start", new IllegalStateException("bad \"plugin\"\npath"));
+
+            List<String> messages = logCaptureAppender.getMessages();
+            assertTrue(messages.stream().anyMatch(message ->
+                message.contains(AbstractConnectCli.STARTUP_FAILURE_LOG_PREFIX)
+                    && message.contains("\"stage\":\"connect.start\"")
+                    && message.contains("\"errorClass\":\"java.lang.IllegalStateException\"")
+                    && message.contains("\"message\":\"bad \\\"plugin\\\"\\npath\"")));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a structured `AUTOMQ_CONNECT_STARTUP_FAILURE` log when Connect startup fails
- include startup stage, error class, and escaped error message for CMP parsing
- add test coverage for the structured log format

## Test
- `./gradlew :connect:runtime:test --tests org.apache.kafka.connect.cli.ConnectStandaloneTest`