### PR TITLE
docs(devkit): document broker log location (#3355)

### DIFF
--- a/devkit/README.md
+++ b/devkit/README.md
@@ -83,6 +83,17 @@ just logs 0 | head -20          # oldest entries
 just logs 0 | tail -20          # newest entries
 ```
 
+`just logs` only shows container stdout/stderr. Kafka component logs are written
+inside the node container under `/tmp/kafka-logs`, for example
+`/tmp/kafka-logs/server.log`, `controller.log`, `s3-object.log`, and
+`s3stream-threads.log`. Use `just exec` when checking detailed broker logs:
+
+```bash
+just exec 0 grep -R ERROR /tmp/kafka-logs
+just exec 0 grep -R LOGCACHE_VERIFY /tmp/kafka-logs
+just exec 0 tail -200 /tmp/kafka-logs/server.log
+```
+
 ## Topic Operations
 
 ```bash

--- a/devkit/justfile
+++ b/devkit/justfile
@@ -45,7 +45,7 @@ ensure-cluster-id:
 
 # Override to skip or replace the Java build step, e.g.:
 #   DEVKIT_BUILD_CMD="echo skipped" just start-build
-JAVA_BUILD_CMD := env_var_or_default("DEVKIT_BUILD_CMD", "./gradlew :core:build :tools:build :shell:build -x test")
+JAVA_BUILD_CMD := env_var_or_default("DEVKIT_BUILD_CMD", "./gradlew build -x test")
 
 [private]
 build:


### PR DESCRIPTION
## Summary
- Document that `just logs` only shows container stdout/stderr
- Add examples for inspecting detailed broker logs under `/tmp/kafka-logs` with `just exec`
- Use full Gradle build as the default devkit build command