### PR TITLE
fix: harden inter-broker async sender validation

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Time;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,12 +62,21 @@ public class InterBrokerAsyncSender implements AsyncSender {
     public <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(
         Node node, AbstractRequest.Builder<T> requestBuilder
     ) {
+        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
         if (closed) {
-            CompletableFuture<ClientResponse> future = new CompletableFuture<>();
             future.completeExceptionally(new IllegalStateException("InterBrokerAsyncSender is closed"));
             return future;
         }
-        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
+        if (node == null || node.isEmpty()) {
+            future.completeExceptionally(new IllegalArgumentException("Cannot send request to empty node " + node));
+            return future;
+        }
+        try {
+            Objects.requireNonNull(requestBuilder, "requestBuilder must not be null");
+        } catch (RuntimeException e) {
+            future.completeExceptionally(e);
+            return future;
+        }
         inFlightFutures.add(future);
         PendingRequest request = new PendingRequest(node, requestBuilder, future, time.milliseconds());
         pendingRequests.offer(request);
@@ -137,20 +147,25 @@ public class InterBrokerAsyncSender implements AsyncSender {
                 RequestCompletionHandler handler = new RequestCompletionHandler() {
                     @Override
                     public void onComplete(ClientResponse response) {
-                        if (response.authenticationException() != null) {
-                            request.future.completeExceptionally(response.authenticationException());
-                        } else if (response.versionMismatch() != null) {
-                            request.future.completeExceptionally(response.versionMismatch());
-                        } else if (response.wasDisconnected()) {
-                            if (response.wasTimedOut()) {
-                                request.future.completeExceptionally(new TimeoutException("Request timed out"));
+                        try {
+                            if (response.authenticationException() != null) {
+                                request.future.completeExceptionally(response.authenticationException());
+                            } else if (response.versionMismatch() != null) {
+                                request.future.completeExceptionally(response.versionMismatch());
+                            } else if (response.wasDisconnected()) {
+                                if (response.wasTimedOut()) {
+                                    request.future.completeExceptionally(new TimeoutException("Request timed out"));
+                                } else {
+                                    request.future.completeExceptionally(new DisconnectException("Disconnected from " + request.node));
+                                }
                             } else {
-                                request.future.completeExceptionally(new DisconnectException("Disconnected from " + request.node));
+                                request.future.complete(response);
                             }
-                        } else {
-                            request.future.complete(response);
+                        } catch (Throwable t) {
+                            request.future.completeExceptionally(t);
+                        } finally {
+                            inFlightFutures.remove(request.future);
                         }
-                        inFlightFutures.remove(request.future);
                     }
                 };
                 requests.add(new RequestAndCompletionHandler(

--- a/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,6 +51,7 @@ import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -325,6 +327,51 @@ public class InterBrokerAsyncSenderTest {
         ExecutionException exception = assertThrows(ExecutionException.class,
             () -> future.get(100, TimeUnit.MILLISECONDS));
         assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+
+    @Test
+    public void testSendRequestRejectsEmptyNode() {
+        CompletableFuture<ClientResponse> future = sender.sendRequest(Node.noNode(), requestBuilder);
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+        verify(networkClient, never()).wakeup();
+    }
+
+    @Test
+    public void testSendRequestRejectsNullRequestBuilder() {
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, null);
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(NullPointerException.class, exception.getCause());
+        verify(networkClient, never()).wakeup();
+    }
+
+    @Test
+    public void testCompletionHandlerTurnsUnexpectedExceptionIntoFutureFailure() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(true);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        assertDoesNotThrow(() -> handlerCaptor.getValue().onComplete(null));
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(NullPointerException.class, exception.getCause());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject null or empty target nodes before requests enter InterBrokerSendThread
- reject null request builders before enqueueing
- convert unexpected completion-handler exceptions into failed futures and always clean up in-flight state

## Context
Lag collection can accidentally pass Node.noNode() into InterBrokerAsyncSender when metadata lookup returns an empty node. Without validation this reaches NetworkClient.ready() in InterBrokerSendThread and throws IllegalArgumentException, which ShutdownableThread treats as fatal.

This does not modify InterBrokerSendThread. It adds a defensive boundary at InterBrokerAsyncSender so invalid sender inputs fail the returned future instead of crashing the sender thread.

## Tests
- just gradlew :server-common:test --tests org.apache.kafka.server.util.InterBrokerAsyncSenderTest