### PR TITLE
fix: pick async sender prerequisites and validation to main

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -240,6 +240,13 @@ public enum ApiKeys {
         return ID_TO_TYPE.containsKey(id);
     }
 
+    /**
+     * Extension APIs use apiKey IDs in [10000, 19999], reserved for enterprise features.
+     */
+    public static boolean isExtensionApi(ApiKeys apiKey) {
+        return apiKey.id >= 10000 && apiKey.id <= 19999;
+    }
+
     public short latestVersion() {
         return messageType.highestSupportedVersion(true);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -421,8 +421,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case READ_SHARE_GROUP_STATE_SUMMARY:
                 return ReadShareGroupStateSummaryRequest.parse(buffer, apiVersion);
             default:
-                throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
-                        "code should be updated to do so.", apiKey));
+                return RequestResponseExtensions.parseRequest(apiKey, apiVersion, buffer);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -358,8 +358,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case READ_SHARE_GROUP_STATE_SUMMARY:
                 return ReadShareGroupStateSummaryResponse.parse(responseBuffer, version);
             default:
-                throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
-                        "code should be updated to do so.", apiKey));
+                return RequestResponseExtensions.parseResponse(apiKey, version, responseBuffer);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestResponseExtensionProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestResponseExtensionProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import java.nio.ByteBuffer;
+
+public interface RequestResponseExtensionProvider {
+    AbstractRequest parseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer);
+
+    AbstractResponse parseResponse(ApiKeys apiKey, short version, ByteBuffer buffer);
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestResponseExtensions.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestResponseExtensions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import java.nio.ByteBuffer;
+import java.util.ServiceLoader;
+
+public class RequestResponseExtensions {
+    private static final RequestResponseExtensionProvider PROVIDER;
+
+    static {
+        RequestResponseExtensionProvider loaded = null;
+        for (RequestResponseExtensionProvider provider : ServiceLoader.load(RequestResponseExtensionProvider.class)) {
+            if (loaded != null) {
+                throw new IllegalStateException("Only one RequestResponseExtensionProvider is supported.");
+            }
+            loaded = provider;
+        }
+        PROVIDER = loaded;
+    }
+
+    public static AbstractRequest parseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer) {
+        if (PROVIDER == null) {
+            throw new AssertionError(String.format(
+                "ApiKey %s is not handled and no extension provider is registered.", apiKey));
+        }
+        return PROVIDER.parseRequest(apiKey, apiVersion, buffer);
+    }
+
+    public static AbstractResponse parseResponse(ApiKeys apiKey, short version, ByteBuffer buffer) {
+        if (PROVIDER == null) {
+            throw new AssertionError(String.format(
+                "ApiKey %s is not handled and no extension provider is registered.", apiKey));
+        }
+        return PROVIDER.parseResponse(apiKey, version, buffer);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -46,6 +46,12 @@ public class ApiKeysTest {
     }
 
     @Test
+    public void testIsExtensionApi() {
+        assertFalse(ApiKeys.isExtensionApi(ApiKeys.FETCH));
+        assertFalse(ApiKeys.isExtensionApi(ApiKeys.DESCRIBE_TOPIC_PARTITIONS));
+    }
+
+    @Test
     public void testAlterPartitionIsClusterAction() {
         assertTrue(ApiKeys.ALTER_PARTITION.clusterAction);
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -292,6 +292,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -338,6 +339,30 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 // This class performs tests requests and responses for all API keys
 public class RequestResponseTest {
+    private static final Set<ApiKeys> STREAM_AND_ENTERPRISE_APIS_NOT_COVERED_BY_GENERIC_SERIALIZATION = EnumSet.of(
+        ApiKeys.CREATE_STREAMS,
+        ApiKeys.OPEN_STREAMS,
+        ApiKeys.CLOSE_STREAMS,
+        ApiKeys.DELETE_STREAMS,
+        ApiKeys.TRIM_STREAMS,
+        ApiKeys.PREPARE_S3_OBJECT,
+        ApiKeys.COMMIT_STREAM_SET_OBJECT,
+        ApiKeys.COMMIT_STREAM_OBJECT,
+        ApiKeys.DESCRIBE_STREAMS,
+        ApiKeys.GET_OPENING_STREAMS,
+        ApiKeys.GET_KVS,
+        ApiKeys.PUT_KVS,
+        ApiKeys.DELETE_KVS,
+        ApiKeys.GET_NEXT_NODE_ID,
+        ApiKeys.AUTOMQ_REGISTER_NODE,
+        ApiKeys.AUTOMQ_GET_NODES,
+        ApiKeys.AUTOMQ_ZONE_ROUTER,
+        ApiKeys.AUTOMQ_UPDATE_GROUP,
+        ApiKeys.AUTOMQ_GET_PARTITION_SNAPSHOT,
+        ApiKeys.UPDATE_LICENSE,
+        ApiKeys.DESCRIBE_LICENSE,
+        ApiKeys.EXPORT_CLUSTER_MANIFEST
+    );
 
     // Exception includes a message that we verify is not included in error responses
     private final UnknownServerException unknownServerException = new UnknownServerException("secret");
@@ -354,6 +379,7 @@ public class RequestResponseTest {
 
         for (ApiKeys apikey : ApiKeys.values()) {
             for (short version : apikey.allVersions()) {
+                if (STREAM_AND_ENTERPRISE_APIS_NOT_COVERED_BY_GENERIC_SERIALIZATION.contains(apikey)) continue;
                 if (toSkip.containsKey(apikey) && toSkip.get(apikey).contains(version)) continue;
                 AbstractRequest request = getRequest(apikey, version);
                 checkRequest(request);
@@ -4003,6 +4029,26 @@ public class RequestResponseTest {
                                 .setStartOffset(0)
                                 .setStateEpoch(0)))));
         return new ReadShareGroupStateSummaryResponse(data);
+    }
+
+    @Test
+    public void testRequestResponseExtensionsUsesRequestProvider() {
+        RequestAndSize requestAndSize = new RequestAndSize(RequestResponseExtensions.parseRequest(
+            ApiKeys.FETCH,
+            (short) 0,
+            ByteBuffer.allocate(0)
+        ), 0);
+        assertTrue(requestAndSize.request instanceof TestRequestResponseExtensionProvider.TestEnterpriseRequest);
+    }
+
+    @Test
+    public void testRequestResponseExtensionsUsesResponseProvider() {
+        AbstractResponse response = RequestResponseExtensions.parseResponse(
+            ApiKeys.FETCH,
+            (short) 0,
+            ByteBuffer.allocate(0)
+        );
+        assertTrue(response instanceof TestRequestResponseExtensionProvider.TestEnterpriseResponse);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/TestRequestResponseExtensionProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TestRequestResponseExtensionProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class TestRequestResponseExtensionProvider implements RequestResponseExtensionProvider {
+    @Override
+    public AbstractRequest parseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer) {
+        return new TestEnterpriseRequest(apiVersion);
+    }
+
+    @Override
+    public AbstractResponse parseResponse(ApiKeys apiKey, short version, ByteBuffer buffer) {
+        return new TestEnterpriseResponse();
+    }
+
+    static final class TestEnterpriseRequest extends AbstractRequest {
+        private final ApiVersionsRequestData data = new ApiVersionsRequestData();
+
+        TestEnterpriseRequest(short version) {
+            super(ApiKeys.FETCH, version);
+        }
+
+        @Override
+        public ApiVersionsRequestData data() {
+            return data;
+        }
+
+        @Override
+        public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+            return new TestEnterpriseResponse();
+        }
+    }
+
+    static final class TestEnterpriseResponse extends AbstractResponse {
+        private final ApiVersionsResponseData data = new ApiVersionsResponseData();
+
+        TestEnterpriseResponse() {
+            super(ApiKeys.FETCH);
+        }
+
+        @Override
+        public ApiVersionsResponseData data() {
+            return data;
+        }
+
+        @Override
+        public int throttleTimeMs() {
+            return 0;
+        }
+
+        @Override
+        public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+            // no-op for tests
+        }
+
+        @Override
+        public Map<Errors, Integer> errorCounts() {
+            return errorCounts(Errors.NONE);
+        }
+    }
+}

--- a/clients/src/test/resources/META-INF/services/org.apache.kafka.common.requests.RequestResponseExtensionProvider
+++ b/clients/src/test/resources/META-INF/services/org.apache.kafka.common.requests.RequestResponseExtensionProvider
@@ -1,0 +1,1 @@
+org.apache.kafka.common.requests.TestRequestResponseExtensionProvider

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -155,6 +155,10 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   def highestOffsetInRemoteStorage(): Long = _highestOffsetInRemoteStorage
 
+  // AutoMQ inject start
+  @volatile private var _latestAppendState: Option[LatestAppendState] = None
+  // AutoMQ inject end
+
   locally {
     def updateLocalLogStartOffset(offset: Long): Unit = {
       _localLogStartOffset = offset
@@ -908,6 +912,11 @@ class UnifiedLog(@volatile var logStartOffset: Long,
               // ProducerStateManager will not be updated and the last stable offset will not advance
               // if the append to the transaction index fails.
               localLog.append(appendInfo.lastOffset, appendInfo.maxTimestamp, appendInfo.shallowOffsetOfMaxTimestamp, validRecords)
+              // AutoMQ inject start
+              if (appendInfo.maxTimestamp >= 0 && appendInfo.lastOffset >= 0) {
+                _latestAppendState = Some(LatestAppendState(appendInfo.lastOffset, appendInfo.maxTimestamp))
+              }
+              // AutoMQ inject end
               updateHighWatermarkWithLogEndOffset()
 
               // update the producer state
@@ -1643,6 +1652,16 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   def logEndOffsetMetadata: LogOffsetMetadata = localLog.logEndOffsetMetadata
 
   /**
+   * The latest append-time sparse sample from the most recent successful append.
+   *
+   * maxTimestampOffset is sourced from LogAppendInfo.lastOffset.
+   * maxTimestamp is sourced from LogAppendInfo.maxTimestamp.
+   */
+  // AutoMQ inject start
+  def latestAppendState: Option[LatestAppendState] = _latestAppendState
+  // AutoMQ inject end
+
+  /**
    * Roll the log over to a new empty log segment if necessary.
    * The segment will be rolled if one of the following conditions met:
    * 1. The logSegment is full
@@ -1838,6 +1857,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
             leaderEpochCache.foreach(_.truncateFromEndAsyncFlush(targetOffset))
             logStartOffset = math.min(targetOffset, logStartOffset)
             rebuildProducerState(targetOffset, producerStateManager)
+            // AutoMQ inject start
+            _latestAppendState = None
+            // AutoMQ inject end
             if (highWatermark >= localLog.logEndOffset)
               updateHighWatermark(localLog.logEndOffsetMetadata)
           }
@@ -1864,6 +1886,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
         logStartOffset = logStartOffsetOpt.getOrElse(newOffset)
         if (remoteLogEnabled()) _localLogStartOffset = newOffset
         rebuildProducerState(newOffset, producerStateManager)
+        // AutoMQ inject start
+        _latestAppendState = None
+        // AutoMQ inject end
         updateHighWatermark(localLog.logEndOffsetMetadata)
       }
     }
@@ -1988,6 +2013,10 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 }
 
 object UnifiedLog extends Logging {
+  // AutoMQ inject start
+  case class LatestAppendState(maxTimestampOffset: Long, maxTimestamp: Long)
+  // AutoMQ inject end
+
   val LogFileSuffix: String = LogFileUtils.LOG_FILE_SUFFIX
 
   val IndexFileSuffix: String = LogFileUtils.INDEX_FILE_SUFFIX

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -33,7 +33,7 @@ import kafka.log.streamaspect.ElasticLogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher}
-import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager, PartitionLifecycleListener}
+import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager, FetchListener, PartitionLifecycleListener}
 import kafka.utils.CoreUtils
 import org.apache.kafka.clients.admin.ClusterEventPublisher
 import org.apache.kafka.common.config.ConfigException
@@ -430,13 +430,25 @@ class BrokerServer(
       // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
       // for Math.max(1, shardNum * sessionIdRange) <= sessionId < (shardNum + 1) * sessionIdRange
       val sessionIdRange = Int.MaxValue / NumFetchSessionCacheShards
+      // AutoMQ inject start
+      val fetchListener = Option(newFetchListener()).getOrElse(FetchListener.NOOP)
+      val sessionRemovalListener = new FetchSessionCacheShard.SessionRemovalListener {
+        override def onRemove(sessionId: Int, partitions: FetchSession.CACHE_MAP): Unit = {
+          fetchListener.onSessionClosedBatch(sessionId, partitions)
+        }
+      }
+      // AutoMQ inject end
       val fetchSessionCacheShards = (0 until NumFetchSessionCacheShards)
         .map(shardNum => new FetchSessionCacheShard(
           config.maxIncrementalFetchSessionCacheSlots / NumFetchSessionCacheShards,
           KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
           sessionIdRange,
-          shardNum
+          shardNum,
+          // AutoMQ inject start
+          sessionRemovalListener
+          // AutoMQ inject end
         ))
+
       val fetchManager = new FetchManager(Time.SYSTEM, new FetchSessionCache(fetchSessionCacheShards))
 
       // Create the request processor objects.
@@ -462,6 +474,7 @@ class BrokerServer(
         tokenManager = tokenManager,
         apiVersionManager = apiVersionManager,
         clientMetricsManager = Some(clientMetricsManager))
+      dataPlaneRequestProcessor.asInstanceOf[ElasticKafkaApis].setEnterpriseFacade(newEnterpriseBrokerFacade())
 
       dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.nodeId,
         socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
@@ -596,7 +609,9 @@ class BrokerServer(
       }
       ElasticLogManager.init(config, clusterId, this)
       trafficInterceptor = newTrafficInterceptor()
-      dataPlaneRequestProcessor.asInstanceOf[ElasticKafkaApis].setTrafficInterceptor(trafficInterceptor)
+      val elasticKafkaApis = dataPlaneRequestProcessor.asInstanceOf[ElasticKafkaApis]
+      elasticKafkaApis.setTrafficInterceptor(trafficInterceptor)
+      elasticKafkaApis.setFetchListener(fetchListener)
       replicaManager.setTrafficInterceptor(trafficInterceptor)
       replicaManager.setS3StreamContext(com.automq.stream.Context.instance())
 
@@ -893,6 +908,16 @@ class BrokerServer(
     }
     trafficInterceptor
   }
+
+  // AutoMQ inject start
+  protected def newFetchListener(): FetchListener = {
+    FetchListener.NOOP
+  }
+
+  protected def newEnterpriseBrokerFacade(): AnyRef = {
+    null
+  }
+  // AutoMQ inject end
 
   protected def newPartitionLifecycleListeners(): util.List[PartitionLifecycleListener] = {
     val list = new util.ArrayList[PartitionLifecycleListener]()

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -612,6 +612,13 @@ case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Compara
   // AutoMQ inject end
 }
 
+// AutoMQ inject start
+object FetchSessionCacheShard {
+  trait SessionRemovalListener {
+    def onRemove(sessionId: Int, partitions: FetchSession.CACHE_MAP): Unit
+  }
+}
+// AutoMQ inject end
 
 /**
   * Caches fetch sessions.
@@ -631,7 +638,11 @@ case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Compara
 class FetchSessionCacheShard(private val maxEntries: Int,
                              private val evictionMs: Long,
                              val sessionIdRange: Int = Int.MaxValue,
-                             private val shardNum: Int = 0) extends Logging {
+                             private val shardNum: Int = 0,
+                             // AutoMQ inject start
+                             private val sessionRemovalListener: FetchSessionCacheShard.SessionRemovalListener = null
+                             // AutoMQ inject end
+                             ) extends Logging {
 
   this.logIdent = s"[Shard $shardNum] "
 
@@ -798,9 +809,20 @@ class FetchSessionCacheShard(private val maxEntries: Int,
     val removeResult = sessions.remove(session.id)
     if (removeResult.isDefined) {
       numPartitions = numPartitions - session.cachedSize
+      // AutoMQ inject start
+      notifySessionRemoved(session.id, session.partitionMap)
+      // AutoMQ inject end
     }
     removeResult
   }
+
+  // AutoMQ inject start
+  private def notifySessionRemoved(sessionId: Int, partitions: FetchSession.CACHE_MAP): Unit = {
+    if (sessionRemovalListener != null) {
+      sessionRemovalListener.onRemove(sessionId, partitions)
+    }
+  }
+  // AutoMQ inject end
 
   /**
     * Update a session's position in the lastUsed and evictable trees.

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticControllerApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticControllerApis.scala
@@ -59,6 +59,7 @@ class ElasticControllerApis(
         case ApiKeys.AUTOMQ_GET_NODES => handleGetNodes(request)
         case ApiKeys.GET_NEXT_NODE_ID => handleGetNextNodeId(request)
         case ApiKeys.DESCRIBE_STREAMS => handleDescribeStreams(request)
+        case apiKey if ApiKeys.isExtensionApi(apiKey) => handleExtensionRequest(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -86,7 +87,6 @@ class ElasticControllerApis(
         request.apiLocalCompleteTimeNanos = time.nanoseconds
       }
     }
-
   }
 
   override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
@@ -111,6 +111,7 @@ class ElasticControllerApis(
            | ApiKeys.GET_NEXT_NODE_ID
            | ApiKeys.DESCRIBE_STREAMS
       => handleExtensionRequest(request, requestLocal)
+      case apiKey if ApiKeys.isExtensionApi(apiKey) => handleExtensionRequest(request, requestLocal)
       case _ => super.handle(request, requestLocal)
     }
   }

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -12,6 +12,7 @@ import kafka.metrics.KafkaMetricsUtil
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server._
+import kafka.server.streamaspect.extension.{BrokerExtensionHandleDispatcher, BrokerExtensionContext}
 import kafka.server.metadata.ConfigRepository
 import kafka.server.streamaspect.ElasticKafkaApis.{LAST_RECORD_TIMESTAMP, PRODUCE_ACK_TIME_HIST, PRODUCE_CALLBACK_TIME_HIST, PRODUCE_TIME_HIST}
 import kafka.utils.Implicits.MapExtensionMethods
@@ -91,6 +92,14 @@ class ElasticKafkaApis(
 
   private var trafficInterceptor: TrafficInterceptor = new NoopTrafficInterceptor(this, metadataCache)
   private var snapshotAwaitReadySupplier: Supplier[CompletableFuture[Void]] = () => CompletableFuture.completedFuture(null)
+  private val brokerExtensionContext: BrokerExtensionContext = new ElasticBrokerExtensionContext
+  private val brokerExtensionHandleDispatcher: BrokerExtensionHandleDispatcher =
+    createBrokerExtensionHandleDispatcher(brokerExtensionContext)
+
+  protected def createBrokerExtensionHandleDispatcher(context: BrokerExtensionContext): BrokerExtensionHandleDispatcher =
+    BrokerExtensionHandleDispatcher.load(context)
+
+  protected def isExtensionApi(apiKey: ApiKeys): Boolean = ApiKeys.isExtensionApi(apiKey)
 
   /**
    * Generate a map of topic -> [(partitionId, epochId)] based on provided topicsRequestData.
@@ -182,6 +191,12 @@ class ElasticKafkaApis(
         case ApiKeys.UPDATE_LICENSE => forwardToControllerOrFail(request)
         case ApiKeys.DESCRIBE_LICENSE => forwardToControllerOrFail(request)
         case ApiKeys.EXPORT_CLUSTER_MANIFEST => forwardToControllerOrFail(request)
+        case apiKey if isExtensionApi(apiKey) =>
+          brokerExtensionHandleDispatcher.handle(request, requestLocal) match {
+            case BrokerExtensionHandleDispatcher.Handled =>
+            case BrokerExtensionHandleDispatcher.NotHandled =>
+              throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
+          }
 
         case _ =>
           throw new IllegalStateException("Message conversion info is recorded only for Produce/Fetch requests")
@@ -215,6 +230,7 @@ class ElasticKafkaApis(
            | ApiKeys.UPDATE_LICENSE
            | ApiKeys.DESCRIBE_LICENSE
            | ApiKeys.EXPORT_CLUSTER_MANIFEST => handleExtensionRequest(request, requestLocal)
+      case apiKey if isExtensionApi(apiKey) => handleExtensionRequest(request, requestLocal)
       case _ => super.handle(request, requestLocal)
     }
   }
@@ -873,6 +889,29 @@ class ElasticKafkaApis(
 
   def setSnapshotAwaitReadyProvider(supplier: Supplier[CompletableFuture[Void]]): Unit = {
     this.snapshotAwaitReadySupplier = supplier
+  }
+
+  private final class ElasticBrokerExtensionContext extends BrokerExtensionContext {
+    override def forwardToControllerOrFail(request: RequestChannel.Request): Unit =
+      ElasticKafkaApis.this.forwardToControllerOrFail(request)
+
+    override def maybeForward(request: RequestChannel.Request,
+      handler: RequestChannel.Request => Unit,
+      responseCallback: Option[AbstractResponse] => Unit): Unit =
+      metadataSupport.maybeForward(request, handler, responseCallback)
+
+    override def sendForwardedResponse(request: RequestChannel.Request, response: AbstractResponse): Unit =
+      requestHelper.sendForwardedResponse(request, response)
+
+    override def sendResponseMaybeThrottle(request: RequestChannel.Request,
+      responseBuilder: Int => AbstractResponse): Unit =
+      requestHelper.sendResponseMaybeThrottle(request, responseBuilder)
+
+    override def handleError(request: RequestChannel.Request, t: Throwable): Unit =
+      requestHelper.handleError(request, t)
+
+    override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit =
+      ElasticKafkaApis.this.handleInvalidVersionsDuringForwarding(request)
   }
 
 }

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.s3.{AutomqGetPartitionSnapshotRequest, AutomqUpdateGroupRequest, AutomqUpdateGroupResponse, AutomqZoneRouterRequest}
-import org.apache.kafka.common.requests.{AbstractResponse, DeleteTopicsRequest, DeleteTopicsResponse, FetchRequest, FetchResponse, ProduceRequest, ProduceResponse, RequestUtils}
+import org.apache.kafka.common.requests.{AbstractResponse, DeleteTopicsRequest, DeleteTopicsResponse, FetchMetadata => JFetchMetadata, FetchRequest, FetchResponse, ProduceRequest, ProduceResponse, RequestUtils}
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, TOPIC, TRANSACTIONAL_ID}
 import org.apache.kafka.common.utils.Time
@@ -92,6 +92,7 @@ class ElasticKafkaApis(
 
   private var trafficInterceptor: TrafficInterceptor = new NoopTrafficInterceptor(this, metadataCache)
   private var snapshotAwaitReadySupplier: Supplier[CompletableFuture[Void]] = () => CompletableFuture.completedFuture(null)
+  @volatile private var enterpriseFacadeRef: AnyRef = null
   private val brokerExtensionContext: BrokerExtensionContext = new ElasticBrokerExtensionContext
   private val brokerExtensionHandleDispatcher: BrokerExtensionHandleDispatcher =
     createBrokerExtensionHandleDispatcher(brokerExtensionContext)
@@ -100,6 +101,7 @@ class ElasticKafkaApis(
     BrokerExtensionHandleDispatcher.load(context)
 
   protected def isExtensionApi(apiKey: ApiKeys): Boolean = ApiKeys.isExtensionApi(apiKey)
+  @volatile private var fetchListener: FetchListener = FetchListener.NOOP
 
   /**
    * Generate a map of topic -> [(partitionId, epochId)] based on provided topicsRequestData.
@@ -639,6 +641,11 @@ class ElasticKafkaApis(
       }
     }
 
+    val requestSessionId = fetchRequest.metadata.sessionId
+    val requestFetchOffsets = interesting.map { case (tp, partitionData) =>
+      tp -> partitionData.fetchOffset
+    }.toMap
+
     // the callback for process a fetch response, invoked before throttling
     def processResponseCallback(responsePartitionData: Seq[(TopicIdPartition, FetchPartitionData)]): Unit = {
       val partitions = new util.LinkedHashMap[TopicIdPartition, FetchResponseData.PartitionData]
@@ -646,6 +653,12 @@ class ElasticKafkaApis(
       val nodeEndpoints = new mutable.HashMap[Int, Node]
       val clientIdMetadata = ClientIdMetadata.of(request.header.clientId(), request.context.clientAddress, request.context.connectionId)
       responsePartitionData.foreach { case (tp, data) =>
+        notifyFetchListener(
+          tp,
+          if (requestSessionId == JFetchMetadata.INVALID_SESSION_ID) FetchListener.NONE_SESSION_ID else requestSessionId,
+          requestFetchOffsets.getOrElse(tp, -1L),
+          data.records
+        )
         val abortedTransactions = data.abortedTransactions.orElse(null)
         val lastStableOffset: Long = data.lastStableOffset.orElse(FetchResponse.INVALID_LAST_STABLE_OFFSET)
         if (data.isReassignmentFetch) reassigningPartitions.add(tp)
@@ -891,6 +904,44 @@ class ElasticKafkaApis(
     this.snapshotAwaitReadySupplier = supplier
   }
 
+  def setFetchListener(fetchListener: FetchListener): Unit = {
+    this.fetchListener = if (fetchListener == null) FetchListener.NOOP else fetchListener
+  }
+
+  def setEnterpriseFacade(enterpriseFacade: AnyRef): Unit = {
+    this.enterpriseFacadeRef = enterpriseFacade
+  }
+
+  private[streamaspect] def enterpriseFacade(): AnyRef = {
+    enterpriseFacadeRef
+  }
+
+  private def notifyFetchListener(topicIdPartition: TopicIdPartition,
+                                  sessionId: Int,
+                                  fetchOffset: Long,
+                                  records: Records): Unit = {
+    if (fetchListener eq FetchListener.NOOP) return
+    val (reportedOffset, timestamp) = extractFetchOffsetAndTimestamp(fetchOffset, records)
+    fetchListener.onFetch(topicIdPartition, sessionId, reportedOffset, timestamp)
+  }
+
+  private def extractFetchOffsetAndTimestamp(defaultOffset: Long, records: Records): (Long, Long) = {
+    if (records == null) {
+      (defaultOffset, RecordBatch.NO_TIMESTAMP)
+    } else {
+      val batches = records.batches().iterator()
+      if (!batches.hasNext) {
+        (defaultOffset, RecordBatch.NO_TIMESTAMP)
+      } else {
+        var lastBatch = batches.next()
+        while (batches.hasNext) {
+          lastBatch = batches.next()
+        }
+        (lastBatch.lastOffset(), lastBatch.maxTimestamp())
+      }
+    }
+  }
+
   private final class ElasticBrokerExtensionContext extends BrokerExtensionContext {
     override def forwardToControllerOrFail(request: RequestChannel.Request): Unit =
       ElasticKafkaApis.this.forwardToControllerOrFail(request)
@@ -912,6 +963,15 @@ class ElasticKafkaApis(
 
     override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit =
       ElasticKafkaApis.this.handleInvalidVersionsDuringForwarding(request)
+
+    override def getTopicName(topicId: Uuid): Optional[String] =
+      OptionConverters.toJava(metadataCache.getTopicName(topicId))
+
+    override def getPartition(topicPartition: TopicPartition): HostedPartition =
+      replicaManager.getPartition(topicPartition)
+
+    override def enterpriseFacade(): AnyRef =
+      ElasticKafkaApis.this.enterpriseFacade()
   }
 
 }

--- a/core/src/main/scala/kafka/server/streamaspect/FetchListener.java
+++ b/core/src/main/scala/kafka/server/streamaspect/FetchListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.streamaspect;
+
+import kafka.server.CachedPartition;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.requests.FetchMetadata;
+import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
+
+/**
+ * All callbacks are invoked on the request-handler I/O path; implementations must not block.
+ */
+public interface FetchListener {
+    int NONE_SESSION_ID = FetchMetadata.INVALID_SESSION_ID;
+    FetchListener NOOP = new FetchListener() {
+        @Override
+        public void onFetch(TopicIdPartition topicIdPartition, int sessionId, long fetchOffset, long timestamp) {
+        }
+
+        @Override
+        public void onSessionClosed(TopicIdPartition topicIdPartition, int sessionId) {
+        }
+    };
+
+    /**
+     * Reports one fetched partition result.
+     * <p>
+     * For now, {@code fetchOffset} and {@code timestamp} are derived from the last batch in returned records:
+     * {@code lastBatch.lastOffset()} and {@code lastBatch.maxTimestamp()}.
+     */
+    void onFetch(TopicIdPartition topicIdPartition, int sessionId, long fetchOffset, long timestamp);
+
+    void onSessionClosed(TopicIdPartition topicIdPartition, int sessionId);
+
+    default void onSessionClosedBatch(int sessionId, ImplicitLinkedHashCollection<CachedPartition> partitions) {
+        for (CachedPartition partition : partitions) {
+            onSessionClosed(
+                new TopicIdPartition(
+                    partition.topicId(),
+                    new TopicPartition(partition.topic(), partition.partition())),
+                sessionId);
+        }
+    }
+}

--- a/core/src/main/scala/kafka/server/streamaspect/extension/BrokerExtensionHandle.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/extension/BrokerExtensionHandle.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.streamaspect.extension
+
+import kafka.network.RequestChannel
+import kafka.server.RequestLocal
+
+import org.apache.kafka.common.requests.AbstractResponse
+
+import java.util.ServiceLoader
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
+/**
+ * Broker-side extension SPI.
+ *
+ * Implementations are created by [[BrokerExtensionHandleProvider]], initialized with
+ * [[BrokerExtensionContext]], and invoked by [[BrokerExtensionHandleDispatcher]].
+ */
+trait BrokerExtensionHandle {
+  def init(ops: BrokerExtensionContext): Unit = {
+  }
+
+  def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit
+}
+
+trait BrokerExtensionHandleProvider {
+  def create(): BrokerExtensionHandle
+}
+
+trait BrokerExtensionContext {
+  def forwardToControllerOrFail(request: RequestChannel.Request): Unit
+
+  def maybeForward(request: RequestChannel.Request,
+    handler: RequestChannel.Request => Unit,
+    responseCallback: Option[AbstractResponse] => Unit): Unit
+
+  def sendForwardedResponse(request: RequestChannel.Request, response: AbstractResponse): Unit
+
+  def sendResponseMaybeThrottle(request: RequestChannel.Request,
+    responseBuilder: Int => AbstractResponse): Unit
+
+  def handleError(request: RequestChannel.Request, t: Throwable): Unit
+
+  def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit
+}
+
+trait BrokerExtensionHandleDispatcher {
+  import BrokerExtensionHandleDispatcher.Result
+
+  def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Result
+}
+
+object BrokerExtensionHandleDispatcher {
+  sealed trait Result
+  case object Handled extends Result
+  case object NotHandled extends Result
+
+  def load(
+    context: BrokerExtensionContext,
+    loader: ServiceLoader[BrokerExtensionHandleProvider] = ServiceLoader.load(classOf[BrokerExtensionHandleProvider])
+  ): BrokerExtensionHandleDispatcher = {
+    loadFromProviders(context, loader.iterator().asScala.toSeq)
+  }
+
+  def loadFromProviders(
+    context: BrokerExtensionContext,
+    providers: Iterable[BrokerExtensionHandleProvider]
+  ): BrokerExtensionHandleDispatcher = {
+    val loadedProviders = providers.toSeq
+    if (loadedProviders.size > 1) {
+      val providerNames = loadedProviders.map(_.getClass.getName).mkString(", ")
+      throw new IllegalStateException(
+        s"Only one BrokerExtensionHandleProvider is supported, found ${loadedProviders.size}: ${providerNames}")
+    }
+
+    loadedProviders.headOption match {
+      case Some(provider) =>
+        val handle = provider.create()
+        handle.init(context)
+        (request: RequestChannel.Request, requestLocal: RequestLocal) => {
+          handle.handle(request, requestLocal)
+          Handled
+        }
+      case None =>
+        (_: RequestChannel.Request, _: RequestLocal) => NotHandled
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/streamaspect/extension/BrokerExtensionHandle.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/extension/BrokerExtensionHandle.scala
@@ -20,10 +20,12 @@
 package kafka.server.streamaspect.extension
 
 import kafka.network.RequestChannel
-import kafka.server.RequestLocal
+import kafka.server.{HostedPartition, RequestLocal}
 
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.requests.AbstractResponse
 
+import java.util.Optional
 import java.util.ServiceLoader
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
@@ -60,6 +62,12 @@ trait BrokerExtensionContext {
   def handleError(request: RequestChannel.Request, t: Throwable): Unit
 
   def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit
+
+  def getTopicName(topicId: Uuid): Optional[String]
+
+  def getPartition(topicPartition: TopicPartition): HostedPartition
+
+  def enterpriseFacade(): AnyRef
 }
 
 trait BrokerExtensionHandleDispatcher {

--- a/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
@@ -1990,6 +1990,32 @@ class FetchSessionTest {
       assertEquals(cacheShards(shardNum % numShards), cache.getNextCacheShard)
     }
   }
+
+  // AutoMQ inject start
+  @Test
+  def testFetchSessionCacheShardNotifiesRemovalListeners(): Unit = {
+    var removedSessionId = -1
+    var removedPartitionCount = -1
+    val cacheShard = new FetchSessionCacheShard(2, 1000, Int.MaxValue, 0, new FetchSessionCacheShard.SessionRemovalListener {
+      override def onRemove(sessionId: Int, partitions: FetchSession.CACHE_MAP): Unit = {
+        removedSessionId = sessionId
+        removedPartitionCount = partitions.size
+      }
+    })
+    val createdSessionId = cacheShard.maybeCreateSession(
+      now = 0,
+      privileged = false,
+      size = 3,
+      usesTopicIds = true,
+      createPartitions = () => dummyCreate(3)
+    )
+    assertTrue(createdSessionId > 0)
+
+    cacheShard.remove(createdSessionId)
+    assertEquals(createdSessionId, removedSessionId)
+    assertEquals(3, removedPartitionCount)
+  }
+  // AutoMQ inject end
 }
 
 object FetchSessionTest {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -25,7 +25,7 @@ import kafka.log.UnifiedLog
 import kafka.network.{RequestChannel, RequestMetrics}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache, MockConfigRepository, ZkMetadataCache}
-import kafka.server.streamaspect.BrokerQuotaManager
+import kafka.server.streamaspect.{BrokerQuotaManager, ElasticKafkaApis, FetchListener}
 import kafka.utils.{CoreUtils, Log4jController, Logging, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
@@ -87,6 +87,7 @@ import org.apache.kafka.server.metrics.ClientMetricsTestUtils
 import org.apache.kafka.server.util.{FutureUtils, MockTime}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchParams, FetchPartitionData, LogConfig}
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
@@ -155,7 +156,11 @@ class KafkaApisTest extends Logging {
                       enableForwarding: Boolean = false,
                       configRepository: ConfigRepository = new MockConfigRepository(),
                       raftSupport: Boolean = false,
-                      overrideProperties: Map[String, String] = Map.empty): KafkaApis = {
+                      overrideProperties: Map[String, String] = Map.empty,
+                      // AutoMQ inject start
+                      fetchListener: FetchListener = null
+                      // AutoMQ inject end
+                     ): KafkaApis = {
     val properties = if (raftSupport) {
       val properties = TestUtils.createBrokerConfig(brokerId, "")
       properties.put(KRaftConfigs.NODE_ID_CONFIG, brokerId.toString)
@@ -4407,6 +4412,166 @@ class KafkaApisTest extends Logging {
     assertEquals(2, node.nodeId)
     assertEquals("broker2", node.host)
   }
+
+  // AutoMQ inject start
+  @Test
+  def testElasticFetchListenerUsesNoneSessionIdForSessionlessFetch(): Unit = {
+    val topicId = Uuid.randomUuid()
+    val tidp = new TopicIdPartition(topicId, new TopicPartition("foo", 0))
+    val tp = tidp.topicPartition
+    addTopicToMetadataCache(tp.topic, numPartitions = 1, topicId = topicId)
+    when(replicaManager.getLogConfig(ArgumentMatchers.eq(tp))).thenReturn(None)
+
+    val listener = mock(classOf[FetchListener])
+    kafkaApis = createKafkaApis(fetchListener = listener)
+    assumeTrue(kafkaApis.isInstanceOf[ElasticKafkaApis])
+    when(replicaManager.fetchMessages(
+      any[FetchParams],
+      any[Seq[(TopicIdPartition, FetchRequest.PartitionData)]],
+      any[ReplicaQuota],
+      any[Seq[(TopicIdPartition, FetchPartitionData)] => Unit]()
+    )).thenAnswer(invocation => {
+      val callback = invocation.getArgument(3).asInstanceOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit]
+      callback(Seq(tidp -> new FetchPartitionData(
+        Errors.NONE,
+        3,
+        0,
+        MemoryRecords.EMPTY,
+        Optional.empty(),
+        OptionalLong.empty(),
+        Optional.empty(),
+        OptionalInt.empty(),
+        false
+      )))
+    })
+
+    val fetchData = Map(tidp -> new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())).asJava
+    val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())).asJava
+    val fetchMetadata = new JFetchMetadata(0, 0)
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
+      fetchMetadata, fetchData, true, false)
+    when(fetchManager.newContext(
+      any[Short],
+      any[JFetchMetadata],
+      any[Boolean],
+      any[util.Map[TopicIdPartition, FetchRequest.PartitionData]],
+      any[util.List[TopicIdPartition]],
+      any[util.Map[Uuid, String]])).thenReturn(fetchContext)
+
+    when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
+      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+
+    val fetchRequest = new FetchRequest.Builder(16, 16, -1, -1, 100, 0, fetchDataBuilder)
+      .metadata(fetchMetadata)
+      .build()
+    val request = buildRequest(fetchRequest)
+    kafkaApis.handleFetchRequest(request)
+    verifyNoThrottling[FetchResponse](request)
+
+    verify(listener, timeout(1000)).onFetch(
+      ArgumentMatchers.eq(tidp),
+      ArgumentMatchers.eq(JFetchMetadata.INVALID_SESSION_ID),
+      ArgumentMatchers.eq(0L),
+      ArgumentMatchers.eq(RecordBatch.NO_TIMESTAMP)
+    )
+  }
+
+  @Test
+  def testElasticFetchListenerReportsLastBatchOffsetAndTimestamp(): Unit = {
+    val topicId = Uuid.randomUuid()
+    val tidp = new TopicIdPartition(topicId, new TopicPartition("foo", 0))
+    val tp = tidp.topicPartition
+    addTopicToMetadataCache(tp.topic, numPartitions = 1, topicId = topicId)
+    when(replicaManager.getLogConfig(ArgumentMatchers.eq(tp))).thenReturn(None)
+
+    val listener = mock(classOf[FetchListener])
+    kafkaApis = createKafkaApis(fetchListener = listener)
+    assumeTrue(kafkaApis.isInstanceOf[ElasticKafkaApis])
+    val records = MemoryRecords.withRecords(
+      10L,
+      Compression.NONE,
+      new SimpleRecord(1111L, "k1".getBytes(StandardCharsets.UTF_8), "v1".getBytes(StandardCharsets.UTF_8))
+    )
+    when(replicaManager.fetchMessages(
+      any[FetchParams],
+      any[Seq[(TopicIdPartition, FetchRequest.PartitionData)]],
+      any[ReplicaQuota],
+      any[Seq[(TopicIdPartition, FetchPartitionData)] => Unit]()
+    )).thenAnswer(invocation => {
+      val callback = invocation.getArgument(3).asInstanceOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit]
+      callback(Seq(tidp -> new FetchPartitionData(
+        Errors.NONE,
+        3,
+        0,
+        records,
+        Optional.empty(),
+        OptionalLong.empty(),
+        Optional.empty(),
+        OptionalInt.empty(),
+        false
+      )))
+    })
+
+    val fetchData = Map(tidp -> new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())).asJava
+    val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())).asJava
+    val fetchMetadata = new JFetchMetadata(0, 0)
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
+      fetchMetadata, fetchData, true, false)
+    when(fetchManager.newContext(
+      any[Short],
+      any[JFetchMetadata],
+      any[Boolean],
+      any[util.Map[TopicIdPartition, FetchRequest.PartitionData]],
+      any[util.List[TopicIdPartition]],
+      any[util.Map[Uuid, String]])).thenReturn(fetchContext)
+
+    when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
+      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+
+    val fetchRequest = new FetchRequest.Builder(16, 16, -1, -1, 100, 0, fetchDataBuilder)
+      .metadata(fetchMetadata)
+      .build()
+    val request = buildRequest(fetchRequest)
+    kafkaApis.handleFetchRequest(request)
+    verifyNoThrottling[FetchResponse](request)
+
+    verify(listener, timeout(1000)).onFetch(
+      ArgumentMatchers.eq(tidp),
+      ArgumentMatchers.eq(JFetchMetadata.INVALID_SESSION_ID),
+      ArgumentMatchers.eq(10L),
+      ArgumentMatchers.eq(1111L)
+    )
+  }
+
+  @Test
+  def testElasticFetchListenerNotifiesSessionClosedForEachPartition(): Unit = {
+    val listener = mock(classOf[FetchListener])
+    val cacheShard = new FetchSessionCacheShard(10, 1000, Int.MaxValue, 0, new FetchSessionCacheShard.SessionRemovalListener {
+      override def onRemove(sessionId: Int, partitions: FetchSession.CACHE_MAP): Unit = {
+        partitions.forEach { partition =>
+          listener.onSessionClosed(
+            new TopicIdPartition(partition.topicId, new TopicPartition(partition.topic, partition.partition)),
+            sessionId
+          )
+        }
+      }
+    })
+    val topicId0 = Uuid.randomUuid()
+    val topicId1 = Uuid.randomUuid()
+    val sessionId = cacheShard.maybeCreateSession(0, privileged = false, size = 2, usesTopicIds = true, () => {
+      val partitions = new FetchSession.CACHE_MAP(2)
+      partitions.add(new CachedPartition("foo", topicId0, 0))
+      partitions.add(new CachedPartition("foo", topicId1, 1))
+      partitions
+    })
+    assertTrue(sessionId > 0)
+
+    cacheShard.remove(sessionId)
+
+    verify(listener).onSessionClosed(new TopicIdPartition(topicId0, new TopicPartition("foo", 0)), sessionId)
+    verify(listener).onSessionClosed(new TopicIdPartition(topicId1, new TopicPartition("foo", 1)), sessionId)
+  }
+  // AutoMQ inject end
 
   @ParameterizedTest
   @ApiKeyVersionsSource(apiKey = ApiKeys.JOIN_GROUP)

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticControllerApisTest.scala
@@ -1,21 +1,77 @@
 package unit.kafka.server.streamaspect
 
+import kafka.network.RequestChannel
 import kafka.server.streamaspect.ElasticControllerApis
-import kafka.server.{ControllerApisTest, KafkaConfig, SimpleApiVersionManager}
+import kafka.server.{ControllerApisTest, KafkaConfig, RequestLocal, SimpleApiVersionManager}
+import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
+import org.apache.kafka.common.message.{UpdateLicenseRequestData, UpdateLicenseResponseData}
+import org.apache.kafka.common.network.{ClientInformation, ListenerName}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors, MessageUtil}
+import org.apache.kafka.common.requests.s3.{UpdateLicenseRequest, UpdateLicenseResponse}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.controller.Controller
+import org.apache.kafka.controller.ControllerRequestContext
 import org.apache.kafka.image.publisher.ControllerRegistrationsPublisher
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion}
 import org.apache.kafka.server.config.KRaftConfigs
-import org.junit.jupiter.api.{Tag, Timeout}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{Tag, Test, Timeout}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.mockito.Mockito.{mock, verify, when}
 
+import java.net.InetAddress
 import java.util.Properties
+import java.util.concurrent.CompletableFuture
 
 @Timeout(60)
 @Tag("S3Unit")
 class ElasticControllerApisTest extends ControllerApisTest {
+
+  @Test
+  def shouldDelegateUpdateLicenseToControllerExtension(): Unit = {
+    val controller = mock(classOf[Controller])
+    val extensionResponse = new UpdateLicenseResponseData()
+      .setErrorCode(Errors.NONE.code)
+      .setErrorMessage("")
+      .setThrottleTimeMs(0)
+    when(controller.handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.UPDATE_LICENSE),
+      ArgumentMatchers.any()))
+      .thenReturn(CompletableFuture.completedFuture(new UpdateLicenseResponse(extensionResponse)))
+
+    controllerApis = createControllerApis(None, controller)
+    val request = buildRequest(new UpdateLicenseRequest.Builder(new UpdateLicenseRequestData()).build(ApiKeys.UPDATE_LICENSE.latestVersion))
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[UpdateLicenseResponse](request)
+    assertEquals(Errors.NONE.code, response.data.errorCode)
+    verify(controller).handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.UPDATE_LICENSE),
+      ArgumentMatchers.any())
+  }
+
+  @Test
+  def shouldMapNullControllerExtensionResponseToUnsupportedVersion(): Unit = {
+    val controller = mock(classOf[Controller])
+    when(controller.handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.UPDATE_LICENSE),
+      ArgumentMatchers.any()))
+      .thenReturn(CompletableFuture.completedFuture(null))
+
+    controllerApis = createControllerApis(None, controller)
+    val request = buildRequest(new UpdateLicenseRequest.Builder(new UpdateLicenseRequestData()).build(ApiKeys.UPDATE_LICENSE.latestVersion))
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[UpdateLicenseResponse](request)
+    assertEquals(Errors.UNSUPPORTED_VERSION.code, response.data.errorCode)
+  }
 
   override def createControllerApis(authorizer: Option[Authorizer],
     controller: Controller,
@@ -43,5 +99,47 @@ class ElasticControllerApisTest extends ControllerApisTest {
         () => FinalizedFeatures.fromKRaftVersion(MetadataVersion.latestTesting())),
       metadataCache
     )
+  }
+
+  private def buildRequest(
+    request: AbstractRequest,
+    listenerName: ListenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+  ): RequestChannel.Request = {
+    val buffer = request.serializeWithHeader(new RequestHeader(request.apiKey, request.version, clientID, 0))
+    val header = RequestHeader.parse(buffer)
+    val context = new RequestContext(
+      header,
+      "1",
+      InetAddress.getLocalHost,
+      KafkaPrincipal.ANONYMOUS,
+      listenerName,
+      SecurityProtocol.PLAINTEXT,
+      ClientInformation.EMPTY,
+      false
+    )
+    new RequestChannel.Request(
+      processor = 1,
+      context = context,
+      startTimeNanos = 0,
+      MemoryPool.NONE,
+      buffer,
+      requestChannelMetrics
+    )
+  }
+
+  private def captureResponse[T <: AbstractResponse](request: RequestChannel.Request): T = {
+    val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
+    verify(requestChannel).sendResponse(
+      ArgumentMatchers.eq(request),
+      capturedResponse.capture(),
+      ArgumentMatchers.any()
+    )
+    val response = capturedResponse.getValue
+    val buffer = MessageUtil.toByteBuffer(response.data, request.context.header.apiVersion)
+    AbstractResponse.parseResponse(
+      request.context.header.apiKey,
+      buffer,
+      request.context.header.apiVersion,
+    ).asInstanceOf[T]
   }
 }

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
@@ -1,20 +1,31 @@
 package unit.kafka.server.streamaspect
 
 import com.google.common.util.concurrent.MoreExecutors
+import kafka.network.RequestChannel
 import kafka.server._
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache, MockConfigRepository, ZkMetadataCache}
+import kafka.server.streamaspect.extension.{BrokerExtensionHandleDispatcher, BrokerExtensionContext}
 import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager}
 import kafka.utils.TestUtils
+import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
-import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.message.{FetchRequestData, UpdateLicenseRequestData}
+import org.apache.kafka.common.network.{ClientInformation, ListenerName}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors, MessageUtil}
+import org.apache.kafka.common.requests.s3.UpdateLicenseRequest
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, FetchRequest, FetchResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion}
 import org.apache.kafka.server.config.KRaftConfigs
-import org.junit.jupiter.api.{Tag, Timeout}
-import org.mockito.Mockito.mock
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
+import org.junit.jupiter.api.{Tag, Test, Timeout}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.mockito.Mockito.{mock, never, verify}
 
-import java.util.Collections
+import java.net.InetAddress
+import java.util.{Collections, Optional}
 import scala.collection.Map
 import scala.jdk.CollectionConverters.SetHasAsScala
 
@@ -22,6 +33,65 @@ import scala.jdk.CollectionConverters.SetHasAsScala
 @Tag("S3Unit")
 class ElasticKafkaApisTest extends KafkaApisTest {
   override protected val replicaManager: ElasticReplicaManager = mock(classOf[ElasticReplicaManager])
+  private var extensionApiMatcherOverride: Option[ApiKeys => Boolean] = None
+  private var brokerDispatcherFactoryOverride: Option[BrokerExtensionContext => BrokerExtensionHandleDispatcher] = None
+
+  @Test
+  def shouldDelegateExtensionApiToBrokerDispatcher(): Unit = {
+    var handledByDispatcher = false
+    withExtensionHooks(
+      _ == ApiKeys.FETCH,
+      _ => (_: RequestChannel.Request, _: RequestLocal) => {
+        handledByDispatcher = true
+        BrokerExtensionHandleDispatcher.Handled
+      }) {
+      kafkaApis = createKafkaApis()
+      val request = buildRequest(new FetchRequest(new FetchRequestData(), ApiKeys.FETCH.latestVersion))
+      kafkaApis.handle(request, RequestLocal.NoCaching)
+
+      assertTrue(handledByDispatcher)
+      verify(requestChannel, never()).sendResponse(
+        ArgumentMatchers.eq(request),
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any())
+    }
+  }
+
+  @Test
+  def shouldReturnUnsupportedWhenExtensionApiIsNotHandled(): Unit = {
+    withExtensionHooks(
+      _ == ApiKeys.FETCH,
+      _ => (_: RequestChannel.Request, _: RequestLocal) => BrokerExtensionHandleDispatcher.NotHandled) {
+      kafkaApis = createKafkaApis()
+      val request = buildRequest(new FetchRequest(new FetchRequestData(), ApiKeys.FETCH.latestVersion))
+      kafkaApis.handle(request, RequestLocal.NoCaching)
+
+      val response = captureResponse[FetchResponse](request)
+      assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, response.data.errorCode)
+      assertNotNull(response)
+    }
+  }
+
+  @Test
+  def shouldKeepExplicitUpdateLicenseRouteAheadOfDispatcher(): Unit = {
+    var handledByDispatcher = false
+    withExtensionHooks(
+      _ => true,
+      _ => (_: RequestChannel.Request, _: RequestLocal) => {
+        handledByDispatcher = true
+        BrokerExtensionHandleDispatcher.Handled
+      }) {
+      kafkaApis = createKafkaApis()
+      val request = buildRequest(new UpdateLicenseRequest.Builder(new UpdateLicenseRequestData()).build(ApiKeys.UPDATE_LICENSE.latestVersion))
+      kafkaApis.handle(request, RequestLocal.NoCaching)
+
+      assertTrue(!handledByDispatcher)
+      verify(requestChannel).sendResponse(
+        ArgumentMatchers.eq(request),
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any())
+    }
+  }
 
   override def createKafkaApis(interBrokerProtocolVersion: MetadataVersion = MetadataVersion.latestTesting,
     authorizer: Option[Authorizer] = None,
@@ -102,6 +172,73 @@ class ElasticKafkaApisTest extends KafkaApisTest {
       apiVersionManager = apiVersionManager,
       clientMetricsManager = clientMetricsManagerOpt,
       MoreExecutors.newDirectExecutorService(),
-      MoreExecutors.newDirectExecutorService())
+      MoreExecutors.newDirectExecutorService()) {
+      override protected def isExtensionApi(apiKey: ApiKeys): Boolean =
+        extensionApiMatcherOverride.map(_(apiKey)).getOrElse(super.isExtensionApi(apiKey))
+
+      override protected def createBrokerExtensionHandleDispatcher(ops: BrokerExtensionContext): BrokerExtensionHandleDispatcher =
+        brokerDispatcherFactoryOverride.map(_(ops)).getOrElse(super.createBrokerExtensionHandleDispatcher(ops))
+    }
+  }
+
+  private def withExtensionHooks[T](
+    extensionApiMatcher: ApiKeys => Boolean,
+    dispatcherFactory: BrokerExtensionContext => BrokerExtensionHandleDispatcher
+  )(block: => T): T = {
+    extensionApiMatcherOverride = Some(extensionApiMatcher)
+    brokerDispatcherFactoryOverride = Some(dispatcherFactory)
+    try block
+    finally {
+      extensionApiMatcherOverride = None
+      brokerDispatcherFactoryOverride = None
+    }
+  }
+
+  private def buildRequest(
+    request: AbstractRequest,
+    listenerName: ListenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+  ): RequestChannel.Request = {
+    val buffer = request.serializeWithHeader(new RequestHeader(request.apiKey, request.version, clientId, 0))
+    val header = RequestHeader.parse(buffer)
+    val context = new RequestContext(
+      header,
+      "1",
+      InetAddress.getLocalHost,
+      Optional.empty(),
+      new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"),
+      listenerName,
+      SecurityProtocol.SSL,
+      ClientInformation.EMPTY,
+      false,
+      Optional.of(kafkaPrincipalSerde)
+    )
+    new RequestChannel.Request(
+      processor = 1,
+      context = context,
+      startTimeNanos = 0,
+      MemoryPool.NONE,
+      buffer,
+      requestChannelMetrics,
+      envelope = None
+    )
+  }
+
+  private def captureResponse[T <: AbstractResponse](request: RequestChannel.Request): T = {
+    val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
+    verify(requestChannel).sendResponse(
+      ArgumentMatchers.eq(request),
+      capturedResponse.capture(),
+      ArgumentMatchers.any()
+    )
+    val response = capturedResponse.getValue
+    val buffer = MessageUtil.toByteBuffer(
+      response.data,
+      request.context.header.apiVersion
+    )
+    AbstractResponse.parseResponse(
+      request.context.header.apiKey,
+      buffer,
+      request.context.header.apiVersion,
+    ).asInstanceOf[T]
   }
 }

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
@@ -5,7 +5,7 @@ import kafka.network.RequestChannel
 import kafka.server._
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache, MockConfigRepository, ZkMetadataCache}
 import kafka.server.streamaspect.extension.{BrokerExtensionHandleDispatcher, BrokerExtensionContext}
-import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager}
+import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager, FetchListener}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -14,15 +14,16 @@ import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, MessageUtil}
 import org.apache.kafka.common.requests.s3.UpdateLicenseRequest
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, FetchRequest, FetchResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion}
 import org.apache.kafka.server.config.KRaftConfigs
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertSame, assertTrue}
 import org.junit.jupiter.api.{Tag, Test, Timeout}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.mockito.Mockito.{mock, never, verify}
+import org.mockito.Mockito.{doReturn, mock, never, spy, verify, when}
 
 import java.net.InetAddress
 import java.util.{Collections, Optional}
@@ -93,12 +94,61 @@ class ElasticKafkaApisTest extends KafkaApisTest {
     }
   }
 
+  @Test
+  def shouldExposeMetadataAndPartitionViaExtensionContext(): Unit = {
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition("test-topic", 0)
+    val partition = mock(classOf[kafka.cluster.Partition])
+    var capturedContext: BrokerExtensionContext = null
+
+    val zkCache = MetadataCache.zkMetadataCache(brokerId, MetadataVersion.latestTesting())
+    metadataCache = spy(zkCache)
+    doReturn(Some("test-topic")).when(metadataCache).getTopicName(topicId)
+    when(replicaManager.getPartition(tp)).thenReturn(HostedPartition.Online(partition))
+
+    withExtensionHooks(
+      _ == ApiKeys.FETCH,
+      ops => {
+        capturedContext = ops
+        (_: RequestChannel.Request, _: RequestLocal) => BrokerExtensionHandleDispatcher.Handled
+      }) {
+      kafkaApis = createKafkaApis()
+      val request = buildRequest(new FetchRequest(new FetchRequestData(), ApiKeys.FETCH.latestVersion))
+      kafkaApis.handle(request, RequestLocal.NoCaching)
+    }
+
+    assertEquals(Optional.of("test-topic"), capturedContext.getTopicName(topicId))
+    assertEquals(HostedPartition.Online(partition), capturedContext.getPartition(tp))
+  }
+
+  @Test
+  def shouldExposeEnterpriseFacadeViaExtensionContext(): Unit = {
+    val facade = new Object()
+    var capturedContext: BrokerExtensionContext = null
+
+    withExtensionHooks(
+      _ == ApiKeys.FETCH,
+      ops => {
+        capturedContext = ops
+        (_: RequestChannel.Request, _: RequestLocal) => BrokerExtensionHandleDispatcher.Handled
+      }) {
+      val elasticKafkaApis = createKafkaApis()
+      kafkaApis = elasticKafkaApis
+      elasticKafkaApis.setEnterpriseFacade(facade)
+      val request = buildRequest(new FetchRequest(new FetchRequestData(), ApiKeys.FETCH.latestVersion))
+      kafkaApis.handle(request, RequestLocal.NoCaching)
+    }
+
+    assertSame(facade, capturedContext.enterpriseFacade())
+  }
+
   override def createKafkaApis(interBrokerProtocolVersion: MetadataVersion = MetadataVersion.latestTesting,
     authorizer: Option[Authorizer] = None,
     enableForwarding: Boolean = false,
     configRepository: ConfigRepository = new MockConfigRepository(),
     raftSupport: Boolean = false,
-    overrideProperties: Map[String, String] = Map.empty): ElasticKafkaApis = {
+    overrideProperties: Map[String, String] = Map.empty,
+    fetchListener: FetchListener = null): ElasticKafkaApis = {
     val properties = if (raftSupport) {
       val properties = TestUtils.createBrokerConfig(brokerId, "")
       properties.put(KRaftConfigs.NODE_ID_CONFIG, brokerId.toString)
@@ -150,7 +200,7 @@ class ElasticKafkaApisTest extends KafkaApisTest {
 
     val clientMetricsManagerOpt = if (raftSupport) Some(clientMetricsManager) else None
 
-    new ElasticKafkaApis(
+    val kafkaApis = new ElasticKafkaApis(
       requestChannel = requestChannel,
       metadataSupport = metadataSupport,
       replicaManager = replicaManager,
@@ -179,6 +229,8 @@ class ElasticKafkaApisTest extends KafkaApisTest {
       override protected def createBrokerExtensionHandleDispatcher(ops: BrokerExtensionContext): BrokerExtensionHandleDispatcher =
         brokerDispatcherFactoryOverride.map(_(ops)).getOrElse(super.createBrokerExtensionHandleDispatcher(ops))
     }
+    kafkaApis.setFetchListener(fetchListener)
+    kafkaApis
   }
 
   private def withExtensionHooks[T](

--- a/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleContractsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleContractsTest.scala
@@ -20,10 +20,13 @@
 package unit.kafka.server.streamaspect.extension
 
 import kafka.network.RequestChannel
-import kafka.server.RequestLocal
+import kafka.server.{HostedPartition, RequestLocal}
 import kafka.server.streamaspect.extension.{BrokerExtensionHandle, BrokerExtensionHandleProvider, BrokerExtensionContext}
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+
+import java.util.Optional
 
 class BrokerExtensionHandleContractsTest {
 
@@ -49,6 +52,9 @@ class BrokerExtensionHandleContractsTest {
         responseBuilder: Int => org.apache.kafka.common.requests.AbstractResponse): Unit = ()
       override def handleError(request: RequestChannel.Request, t: Throwable): Unit = ()
       override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit = ()
+      override def getTopicName(topicId: Uuid): Optional[String] = Optional.empty()
+      override def getPartition(topicPartition: TopicPartition): HostedPartition = HostedPartition.None
+      override def enterpriseFacade(): AnyRef = null
     })
     assert(initialized)
   }

--- a/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleContractsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleContractsTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.server.streamaspect.extension
+
+import kafka.network.RequestChannel
+import kafka.server.RequestLocal
+import kafka.server.streamaspect.extension.{BrokerExtensionHandle, BrokerExtensionHandleProvider, BrokerExtensionContext}
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class BrokerExtensionHandleContractsTest {
+
+  @Test
+  def shouldSupportDefaultInitHook(): Unit = {
+    var initialized = false
+    val handle = new BrokerExtensionHandle {
+      override def init(ops: BrokerExtensionContext): Unit = {
+        initialized = true
+      }
+
+      override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
+      }
+    }
+
+    handle.init(new BrokerExtensionContext {
+      override def forwardToControllerOrFail(request: RequestChannel.Request): Unit = ()
+      override def maybeForward(request: RequestChannel.Request, handler: RequestChannel.Request => Unit,
+        cb: Option[org.apache.kafka.common.requests.AbstractResponse] => Unit): Unit = ()
+      override def sendForwardedResponse(request: RequestChannel.Request,
+        response: org.apache.kafka.common.requests.AbstractResponse): Unit = ()
+      override def sendResponseMaybeThrottle(request: RequestChannel.Request,
+        responseBuilder: Int => org.apache.kafka.common.requests.AbstractResponse): Unit = ()
+      override def handleError(request: RequestChannel.Request, t: Throwable): Unit = ()
+      override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit = ()
+    })
+    assert(initialized)
+  }
+
+  @Test
+  def shouldAllowProviderToCreateHandle(): Unit = {
+    val provider = new BrokerExtensionHandleProvider {
+      override def create(): BrokerExtensionHandle = new BrokerExtensionHandle {
+        override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = ()
+      }
+    }
+
+    assertNotNull(provider.create())
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleDispatcherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleDispatcherTest.scala
@@ -20,11 +20,14 @@
 package unit.kafka.server.streamaspect.extension
 
 import kafka.network.RequestChannel
-import kafka.server.RequestLocal
+import kafka.server.{HostedPartition, RequestLocal}
 import kafka.server.streamaspect.extension.BrokerExtensionHandleDispatcher.{Handled, NotHandled}
 import kafka.server.streamaspect.extension.{BrokerExtensionHandle, BrokerExtensionHandleDispatcher, BrokerExtensionHandleProvider, BrokerExtensionContext}
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
+
+import java.util.Optional
 
 class BrokerExtensionHandleDispatcherTest {
 
@@ -88,5 +91,11 @@ class BrokerExtensionHandleDispatcherTest {
     override def handleError(request: RequestChannel.Request, t: Throwable): Unit = ()
 
     override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit = ()
+
+    override def getTopicName(topicId: Uuid): Optional[String] = Optional.empty()
+
+    override def getPartition(topicPartition: TopicPartition): HostedPartition = HostedPartition.None
+
+    override def enterpriseFacade(): AnyRef = null
   }
 }

--- a/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleDispatcherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/extension/BrokerExtensionHandleDispatcherTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.server.streamaspect.extension
+
+import kafka.network.RequestChannel
+import kafka.server.RequestLocal
+import kafka.server.streamaspect.extension.BrokerExtensionHandleDispatcher.{Handled, NotHandled}
+import kafka.server.streamaspect.extension.{BrokerExtensionHandle, BrokerExtensionHandleDispatcher, BrokerExtensionHandleProvider, BrokerExtensionContext}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
+
+class BrokerExtensionHandleDispatcherTest {
+
+  @Test
+  def shouldReturnNotHandledWithoutProvider(): Unit = {
+    val dispatcher = BrokerExtensionHandleDispatcher.loadFromProviders(noopOps, Seq.empty)
+    assertEquals(NotHandled, dispatcher.handle(null, null))
+  }
+
+  @Test
+  def shouldInvokeProviderHandle(): Unit = {
+    var initialized = false
+    var handled = false
+
+    val provider = new BrokerExtensionHandleProvider {
+      override def create(): BrokerExtensionHandle = new BrokerExtensionHandle {
+        override def init(ops: BrokerExtensionContext): Unit = {
+          initialized = true
+        }
+
+        override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
+          handled = true
+        }
+      }
+    }
+
+    val dispatcher = BrokerExtensionHandleDispatcher.loadFromProviders(noopOps, Seq(provider))
+    assertEquals(Handled, dispatcher.handle(null, null))
+    assertTrue(initialized)
+    assertTrue(handled)
+  }
+
+  @Test
+  def shouldRejectMultipleProviders(): Unit = {
+    val providerOne = simpleProvider
+    val providerTwo = simpleProvider
+
+    assertThrows(classOf[IllegalStateException], () =>
+      BrokerExtensionHandleDispatcher.loadFromProviders(noopOps, Seq(providerOne, providerTwo)))
+  }
+
+  private def simpleProvider: BrokerExtensionHandleProvider = new BrokerExtensionHandleProvider {
+    override def create(): BrokerExtensionHandle = new BrokerExtensionHandle {
+      override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = ()
+    }
+  }
+
+  private def noopOps: BrokerExtensionContext = new BrokerExtensionContext {
+    override def forwardToControllerOrFail(request: RequestChannel.Request): Unit = ()
+
+    override def maybeForward(request: RequestChannel.Request,
+      handler: RequestChannel.Request => Unit,
+      responseCallback: Option[org.apache.kafka.common.requests.AbstractResponse] => Unit): Unit = ()
+
+    override def sendForwardedResponse(request: RequestChannel.Request,
+      response: org.apache.kafka.common.requests.AbstractResponse): Unit = ()
+
+    override def sendResponseMaybeThrottle(request: RequestChannel.Request,
+      responseBuilder: Int => org.apache.kafka.common.requests.AbstractResponse): Unit = ()
+
+    override def handleError(request: RequestChannel.Request, t: Throwable): Unit = ()
+
+    override def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit = ()
+  }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/AsyncSender.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/AsyncSender.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.requests.AbstractRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface AsyncSender extends AutoCloseable {
+
+    <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(
+        Node node,
+        AbstractRequest.Builder<T> requestBuilder
+    );
+
+    @Override
+    void close();
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.RequestCompletionHandler;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class InterBrokerAsyncSender implements AsyncSender {
+
+    private final SendThread sendThread;
+    private final ConcurrentLinkedQueue<PendingRequest> pendingRequests = new ConcurrentLinkedQueue<>();
+    private final Set<CompletableFuture<ClientResponse>> inFlightFutures = ConcurrentHashMap.newKeySet();
+    private final Time time;
+    private final int requestTimeoutMs;
+    private volatile boolean closed = false;
+
+    // Package-private: tests use this to avoid starting the thread
+    InterBrokerAsyncSender(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
+        this.time = time;
+        this.requestTimeoutMs = requestTimeoutMs;
+        this.sendThread = new SendThread(name, networkClient, requestTimeoutMs, time);
+    }
+
+    public static InterBrokerAsyncSender create(String name, KafkaClient networkClient,
+                                                 int requestTimeoutMs, Time time) {
+        InterBrokerAsyncSender sender = new InterBrokerAsyncSender(name, networkClient, requestTimeoutMs, time);
+        sender.sendThread.start();
+        return sender;
+    }
+
+    @Override
+    public <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(
+        Node node, AbstractRequest.Builder<T> requestBuilder
+    ) {
+        if (closed) {
+            CompletableFuture<ClientResponse> future = new CompletableFuture<>();
+            future.completeExceptionally(new IllegalStateException("InterBrokerAsyncSender is closed"));
+            return future;
+        }
+        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
+        inFlightFutures.add(future);
+        PendingRequest request = new PendingRequest(node, requestBuilder, future, time.milliseconds());
+        pendingRequests.offer(request);
+        sendThread.wakeup();
+        return future;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        sendThread.wakeup();
+
+        if (!inFlightFutures.isEmpty()) {
+            try {
+                CompletableFuture.allOf(inFlightFutures.toArray(new CompletableFuture[0]))
+                    .get(requestTimeoutMs, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException | java.util.concurrent.TimeoutException e) {
+                // request failed or drain timed out — proceed to force shutdown
+            }
+        }
+
+        try {
+            sendThread.shutdown();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        PendingRequest pending;
+        while ((pending = pendingRequests.poll()) != null) {
+            pending.future.completeExceptionally(
+                new IllegalStateException("InterBrokerAsyncSender is closed"));
+        }
+    }
+
+    void pollOnce(long maxTimeoutMs) {
+        sendThread.pollOnce(maxTimeoutMs);
+    }
+
+    private static class PendingRequest {
+        final Node node;
+        final AbstractRequest.Builder<?> requestBuilder;
+        final CompletableFuture<ClientResponse> future;
+        final long creationTimeMs;
+
+        PendingRequest(Node node, AbstractRequest.Builder<?> requestBuilder, 
+                      CompletableFuture<ClientResponse> future, long creationTimeMs) {
+            this.node = node;
+            this.requestBuilder = requestBuilder;
+            this.future = future;
+            this.creationTimeMs = creationTimeMs;
+        }
+    }
+
+    private class SendThread extends InterBrokerSendThread {
+
+        SendThread(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
+            super(name, networkClient, requestTimeoutMs, time);
+        }
+
+        @Override
+        public Collection<RequestAndCompletionHandler> generateRequests() {
+            Collection<RequestAndCompletionHandler> requests = new ArrayList<>();
+            PendingRequest pending;
+            while ((pending = pendingRequests.poll()) != null) {
+                final PendingRequest request = pending;
+                RequestCompletionHandler handler = new RequestCompletionHandler() {
+                    @Override
+                    public void onComplete(ClientResponse response) {
+                        if (response.authenticationException() != null) {
+                            request.future.completeExceptionally(response.authenticationException());
+                        } else if (response.versionMismatch() != null) {
+                            request.future.completeExceptionally(response.versionMismatch());
+                        } else if (response.wasDisconnected()) {
+                            if (response.wasTimedOut()) {
+                                request.future.completeExceptionally(new TimeoutException("Request timed out"));
+                            } else {
+                                request.future.completeExceptionally(new DisconnectException("Disconnected from " + request.node));
+                            }
+                        } else {
+                            request.future.complete(response);
+                        }
+                        inFlightFutures.remove(request.future);
+                    }
+                };
+                requests.add(new RequestAndCompletionHandler(
+                    request.creationTimeMs,
+                    request.node,
+                    request.requestBuilder,
+                    handler
+                ));
+            }
+            return requests;
+        }
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/InterBrokerAsyncSender.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Time;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,12 +62,21 @@ public class InterBrokerAsyncSender implements AsyncSender {
     public <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(
         Node node, AbstractRequest.Builder<T> requestBuilder
     ) {
+        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
         if (closed) {
-            CompletableFuture<ClientResponse> future = new CompletableFuture<>();
             future.completeExceptionally(new IllegalStateException("InterBrokerAsyncSender is closed"));
             return future;
         }
-        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
+        if (node == null || node.isEmpty()) {
+            future.completeExceptionally(new IllegalArgumentException("Cannot send request to empty node " + node));
+            return future;
+        }
+        try {
+            Objects.requireNonNull(requestBuilder, "requestBuilder must not be null");
+        } catch (RuntimeException e) {
+            future.completeExceptionally(e);
+            return future;
+        }
         inFlightFutures.add(future);
         PendingRequest request = new PendingRequest(node, requestBuilder, future, time.milliseconds());
         pendingRequests.offer(request);
@@ -137,20 +147,25 @@ public class InterBrokerAsyncSender implements AsyncSender {
                 RequestCompletionHandler handler = new RequestCompletionHandler() {
                     @Override
                     public void onComplete(ClientResponse response) {
-                        if (response.authenticationException() != null) {
-                            request.future.completeExceptionally(response.authenticationException());
-                        } else if (response.versionMismatch() != null) {
-                            request.future.completeExceptionally(response.versionMismatch());
-                        } else if (response.wasDisconnected()) {
-                            if (response.wasTimedOut()) {
-                                request.future.completeExceptionally(new TimeoutException("Request timed out"));
+                        try {
+                            if (response.authenticationException() != null) {
+                                request.future.completeExceptionally(response.authenticationException());
+                            } else if (response.versionMismatch() != null) {
+                                request.future.completeExceptionally(response.versionMismatch());
+                            } else if (response.wasDisconnected()) {
+                                if (response.wasTimedOut()) {
+                                    request.future.completeExceptionally(new TimeoutException("Request timed out"));
+                                } else {
+                                    request.future.completeExceptionally(new DisconnectException("Disconnected from " + request.node));
+                                }
                             } else {
-                                request.future.completeExceptionally(new DisconnectException("Disconnected from " + request.node));
+                                request.future.complete(response);
                             }
-                        } else {
-                            request.future.complete(response);
+                        } catch (Throwable t) {
+                            request.future.completeExceptionally(t);
+                        } finally {
+                            inFlightFutures.remove(request.future);
                         }
-                        inFlightFutures.remove(request.future);
                     }
                 };
                 requests.add(new RequestAndCompletionHandler(

--- a/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.RequestCompletionHandler;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InterBrokerAsyncSenderTest {
+
+    private MockTime time;
+    private KafkaClient networkClient;
+    private InterBrokerAsyncSender sender;
+    private Node node;
+    private AbstractRequest.Builder<?> requestBuilder;
+    private int requestTimeoutMs;
+
+    @BeforeEach
+    public void setUp() {
+        time = new MockTime();
+        networkClient = mock(KafkaClient.class);
+        requestTimeoutMs = 1000;
+        sender = new InterBrokerAsyncSender("test-sender", networkClient, requestTimeoutMs, time);
+        node = new Node(1, "localhost", 9092);
+        requestBuilder = new StubRequestBuilder();
+    }
+
+    @Test
+    public void testSendRequestSuccess() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        ClientResponse response = mock(ClientResponse.class);
+        when(response.responseBody()).thenReturn(mock(AbstractResponse.class));
+        
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+        
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(true);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        // Simulate successful response
+        handlerCaptor.getValue().onComplete(response);
+
+        ClientResponse result = future.get(100, TimeUnit.MILLISECONDS);
+        assertEquals(response, result);
+        assertNotNull(result.responseBody());
+    }
+
+    @Test
+    public void testSendRequestNodeNotReadyThenReady() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        ClientResponse response = mock(ClientResponse.class);
+        when(response.responseBody()).thenReturn(mock(AbstractResponse.class));
+        
+        AbstractRequest.Builder<?> mockBuilder = mock(AbstractRequest.Builder.class);
+        when(mockBuilder.latestAllowedVersion()).thenReturn((short) 1);
+        doReturn(mockBuilder).when(clientRequest).requestBuilder();
+        when(clientRequest.makeHeader(anyShort())).thenReturn(mock(RequestHeader.class));
+        when(clientRequest.callback()).thenReturn(mock(RequestCompletionHandler.class));
+        
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+        
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        
+        // First call: node not ready
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(false).thenReturn(true);
+        when(networkClient.connectionDelay(node, time.milliseconds())).thenReturn(0L);
+        when(networkClient.connectionFailed(node)).thenReturn(false);
+        when(networkClient.authenticationException(node)).thenReturn(null);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        
+        // First poll - node not ready
+        sender.pollOnce(100);
+        
+        // Second poll - node ready
+        sender.pollOnce(100);
+
+        // Simulate successful response
+        handlerCaptor.getValue().onComplete(response);
+
+        ClientResponse result = future.get(100, TimeUnit.MILLISECONDS);
+        assertEquals(response, result);
+    }
+
+    @Test
+    public void testSendRequestConnectionFailed() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        
+        AbstractRequest.Builder<?> mockBuilder = mock(AbstractRequest.Builder.class);
+        when(mockBuilder.latestAllowedVersion()).thenReturn((short) 1);
+        doReturn(mockBuilder).when(clientRequest).requestBuilder();
+        when(clientRequest.makeHeader(anyShort())).thenReturn(mock(RequestHeader.class));
+        
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+        
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        
+        // Make the mock ClientRequest return the captured handler
+        when(clientRequest.callback()).thenAnswer(invocation -> handlerCaptor.getValue());
+        
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(false);
+        when(networkClient.connectionDelay(node, time.milliseconds())).thenReturn(0L);
+        when(networkClient.connectionFailed(node)).thenReturn(true);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, 
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(DisconnectException.class, exception.getCause());
+    }
+
+    @Test
+    public void testSendRequestAuthenticationFailed() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        AuthenticationException authException = new AuthenticationException("Auth failed");
+        
+        AbstractRequest.Builder<?> mockBuilder = mock(AbstractRequest.Builder.class);
+        when(mockBuilder.latestAllowedVersion()).thenReturn((short) 1);
+        doReturn(mockBuilder).when(clientRequest).requestBuilder();
+        when(clientRequest.makeHeader(anyShort())).thenReturn(mock(RequestHeader.class));
+        
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+        
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        
+        // Make the mock ClientRequest return the captured handler
+        when(clientRequest.callback()).thenAnswer(invocation -> handlerCaptor.getValue());
+        
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(false);
+        when(networkClient.connectionDelay(node, time.milliseconds())).thenReturn(0L);
+        when(networkClient.connectionFailed(node)).thenReturn(true);
+        when(networkClient.authenticationException(node)).thenReturn(authException);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, 
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertEquals(authException, exception.getCause());
+    }
+
+    @Test
+    public void testSendRequestTimeout() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        
+        AbstractRequest.Builder<?> mockBuilder = mock(AbstractRequest.Builder.class);
+        when(mockBuilder.latestAllowedVersion()).thenReturn((short) 1);
+        doReturn(mockBuilder).when(clientRequest).requestBuilder();
+        when(clientRequest.makeHeader(anyShort())).thenReturn(mock(RequestHeader.class));
+        when(clientRequest.createdTimeMs()).thenReturn(time.milliseconds());
+        when(clientRequest.requestTimeoutMs()).thenReturn(requestTimeoutMs);
+        
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+        
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        
+        // Make the mock ClientRequest return the captured handler
+        when(clientRequest.callback()).thenAnswer(invocation -> handlerCaptor.getValue());
+        
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(false);
+        when(networkClient.connectionDelay(node, time.milliseconds())).thenReturn(0L);
+        when(networkClient.connectionFailed(node)).thenReturn(false);
+        when(networkClient.authenticationException(node)).thenReturn(null);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        
+        // Advance time beyond timeout
+        time.sleep(requestTimeoutMs + 1);
+        sender.pollOnce(100);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, 
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(DisconnectException.class, exception.getCause());
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        sender.close();
+        verify(networkClient).close();
+    }
+
+    @Test
+    public void testCloseWaitsForInFlightRequests() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        ClientResponse response = mock(ClientResponse.class);
+        when(response.responseBody()).thenReturn(mock(AbstractResponse.class));
+
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(true);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        // Close in a separate thread — it should block waiting for the in-flight request
+        AtomicReference<Thread> closeThread = new AtomicReference<>();
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        CountDownLatch closeDone = new CountDownLatch(1);
+        closeThread.set(new Thread(() -> {
+            closeStarted.countDown();
+            sender.close();
+            closeDone.countDown();
+        }));
+        closeThread.get().start();
+        assertTrue(closeStarted.await(1, TimeUnit.SECONDS));
+
+        // close should still be blocking
+        Thread.sleep(50);
+        assertEquals(1, closeDone.getCount());
+
+        // Complete the in-flight request
+        handlerCaptor.getValue().onComplete(response);
+
+        // Now close should finish
+        assertTrue(closeDone.await(1, TimeUnit.SECONDS));
+        assertEquals(response, future.get(100, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testCloseRejectsNewRequests() {
+        sender.close();
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+
+    @Test
+    public void testWakeupCalledOnSendRequest() {
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        verify(networkClient).wakeup();
+        assertTrue(future != null);
+    }
+
+    private static class StubRequestBuilder extends AbstractRequest.Builder<AbstractRequest> {
+        public StubRequestBuilder() {
+            super(ApiKeys.END_TXN);
+        }
+
+        @Override
+        public AbstractRequest build(short version) {
+            return mock(AbstractRequest.class);
+        }
+    }
+}

--- a/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/InterBrokerAsyncSenderTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,6 +51,7 @@ import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -325,6 +327,51 @@ public class InterBrokerAsyncSenderTest {
         ExecutionException exception = assertThrows(ExecutionException.class,
             () -> future.get(100, TimeUnit.MILLISECONDS));
         assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+
+    @Test
+    public void testSendRequestRejectsEmptyNode() {
+        CompletableFuture<ClientResponse> future = sender.sendRequest(Node.noNode(), requestBuilder);
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+        verify(networkClient, never()).wakeup();
+    }
+
+    @Test
+    public void testSendRequestRejectsNullRequestBuilder() {
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, null);
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(NullPointerException.class, exception.getCause());
+        verify(networkClient, never()).wakeup();
+    }
+
+    @Test
+    public void testCompletionHandlerTurnsUnexpectedExceptionIntoFutureFailure() throws Exception {
+        ClientRequest clientRequest = mock(ClientRequest.class);
+        ArgumentCaptor<RequestCompletionHandler> handlerCaptor = ArgumentCaptor.forClass(RequestCompletionHandler.class);
+
+        when(networkClient.newClientRequest(
+            ArgumentMatchers.eq("1"),
+            same(requestBuilder),
+            anyLong(),
+            ArgumentMatchers.eq(true),
+            ArgumentMatchers.eq(requestTimeoutMs),
+            handlerCaptor.capture()
+        )).thenReturn(clientRequest);
+        when(networkClient.ready(node, time.milliseconds())).thenReturn(true);
+        when(networkClient.poll(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        CompletableFuture<ClientResponse> future = sender.sendRequest(node, requestBuilder);
+        sender.pollOnce(100);
+
+        assertDoesNotThrow(() -> handlerCaptor.getValue().onComplete(null));
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> future.get(100, TimeUnit.MILLISECONDS));
+        assertInstanceOf(NullPointerException.class, exception.getCause());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cherry-pick #3246 to main: SPI-based enterprise API routing prerequisite
- cherry-pick #3248 to main: fetch listener callbacks and InterBrokerAsyncSender support
- cherry-pick #3359 to main: harden InterBrokerAsyncSender validation

## Context
#3359 was merged to 1.7, but main did not yet contain its prerequisites. #3248 depends on #3246, so this PR now carries the full dependency order: #3246 -> #3248 -> #3359.

Conflict adaptation: #3248 conflicted in UnifiedLog because main keeps the 4-argument LocalLog.append signature. The resolution preserves main's append call and adds the latest-append-state update from #3248.

## Tests
- ./gradlew :server-common:spotlessJavaCheck :server-common:test --tests org.apache.kafka.server.util.InterBrokerAsyncSenderTest :core:compileScala :core:compileTestScala