### PR TITLE
docs: add Windows devkit troubleshooting notes

### DIFF
--- a/devkit/README.md
+++ b/devkit/README.md
@@ -440,3 +440,26 @@ my.node.label=node-${NODE_ID}
 ```bash
 just start 1 my-feature
 ```
+
+## Windows Troubleshooting
+
+### Git Bash Path Issues
+
+If `just start-build` fails on Windows Git Bash due to Docker path conversion issues, try:
+
+```bash
+export AUTOMQ_DEV_HOME=/c/automq/devkit
+docker compose up -d
+```
+
+Alternatively, running Docker Compose directly may work better than `just start-build` on Windows environments.
+
+### Docker Engine Errors
+
+If Docker commands fail with:
+
+```text
+failed to connect to the docker API
+```
+
+Restart Docker Desktop and verify the engine is running before starting the devkit.


### PR DESCRIPTION
## Summary

Adds troubleshooting guidance for Windows users running the devkit locally.

## Issues Encountered

* Git Bash path conversion issues with `just start-build`
* Missing `AUTOMQ_DEV_HOME` environment variable
* Docker Compose startup issues on Windows

## Changes

* Added Windows-specific setup/troubleshooting notes for local development

## Validation

* Verified Docker Compose startup manually on Windows
* Confirmed MinIO container launches successfully

