### PR TITLE
fix: improve devkit environment validation

### DIFF
--- a/devkit/README.md
+++ b/devkit/README.md
@@ -440,3 +440,26 @@ my.node.label=node-${NODE_ID}
 ```bash
 just start 1 my-feature
 ```
+
+## Windows Troubleshooting
+
+### Git Bash Path Issues
+
+If `just start-build` fails on Windows Git Bash due to Docker path conversion issues, try:
+
+```bash
+export AUTOMQ_DEV_HOME=/c/automq/devkit
+docker compose up -d
+```
+
+Alternatively, running Docker Compose directly may work better than `just start-build` on Windows environments.
+
+### Docker Engine Errors
+
+If Docker commands fail with:
+
+```text
+failed to connect to the docker API
+```
+
+Restart Docker Desktop and verify the engine is running before starting the devkit.

--- a/devkit/justfile
+++ b/devkit/justfile
@@ -5,6 +5,19 @@ set dotenv-load := false
 export AUTOMQ_DEV_HOME := justfile_directory() + "/.."
 export KAFKA_S3_ACCESS_KEY := S3_ACCESS_KEY
 export KAFKA_S3_SECRET_KEY := S3_SECRET_KEY
+[private]
+validate-env:
+    #!/usr/bin/env bash
+    if [ -z "{{AUTOMQ_DEV_HOME}}" ]; then
+      echo "✗ AUTOMQ_DEV_HOME is not set"
+      exit 1
+    fi
+
+    if [ ! -f "{{justfile_directory()}}/docker-compose.yml" ]; then
+      echo "✗ docker-compose.yml not found"
+      exit 1
+    fi
+    
 
 DEVKIT := justfile_directory() + "/.devkit"
 _ENV_FILE_FLAG := if path_exists(justfile_directory() + "/.devkit/compose.env") == "true" { "--env-file " + justfile_directory() + "/.devkit/compose.env" } else { "" }
@@ -234,7 +247,7 @@ start nodes="1" *FEATURES: ensure-cluster-id
     just wait
 
 [doc("Build image & code, then start. Example: just start-build 3 tabletopic")]
-start-build nodes="1" *FEATURES: build (start nodes FEATURES)
+start-build nodes="1" *FEATURES: validate-env build (start nodes FEATURES)
 
 [doc("Stop all services (keep data)")]
 stop:


### PR DESCRIPTION
## Summary

Adds validation checks before running the devkit startup workflow.

## Problem

When `AUTOMQ_DEV_HOME` or related paths are invalid, Docker Compose fails with cryptic errors such as:

```text
invalid spec: /opt/automq
```

## Changes

* Added environment validation before build/start
* Added validation for `docker-compose.yml`
* Improved startup error visibility for local development

## Motivation

Improves local onboarding and troubleshooting, especially for Windows/Git Bash environments.

