### PR TITLE
feat: expose broker resource stats for autoscaling (#3367)

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
+++ b/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
@@ -19,7 +19,6 @@
 
 package kafka.log.stream.s3;
 
-import kafka.autobalancer.metricsreporter.metric.Derivator;
 import kafka.log.stream.s3.metadata.StreamMetadataManager;
 import kafka.log.stream.s3.network.ControllerRequestSender;
 import kafka.log.stream.s3.node.NodeManager;
@@ -85,8 +84,6 @@ import static com.automq.stream.s3.operator.ObjectStorageFactory.EXTENSION_TYPE_
 public class DefaultS3Client implements Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultS3Client.class);
     protected final Config config;
-    protected final Derivator networkInboundRate = new Derivator();
-    protected final Derivator networkOutboundRate = new Derivator();
     private StreamMetadataManager metadataManager;
 
     protected ControllerRequestSender requestSender;
@@ -137,15 +134,13 @@ public class DefaultS3Client implements Client {
             refillToken, config.refillPeriodMs(), config.networkBaselineBandwidth());
         networkInboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND);
         S3StreamMetricsManager.registerNetworkAvailableBandwidthSupplier(AsyncNetworkBandwidthLimiter.Type.INBOUND, () ->
-            config.networkBaselineBandwidth() - (long) networkInboundRate.derive(
-                TimeUnit.NANOSECONDS.toSeconds(System.nanoTime()), NetworkStats.getInstance().networkInboundUsageTotal().get()));
+            config.networkBaselineBandwidth() - (long) NetworkStats.getInstance().networkInboundRate());
         // Use a larger token pool for outbound traffic to avoid spikes caused by Upload WAL affecting tail-reading performance.
         GlobalNetworkBandwidthLimiters.instance().setup(AsyncNetworkBandwidthLimiter.Type.OUTBOUND,
             refillToken, config.refillPeriodMs(), config.networkBaselineBandwidth() * 5);
         networkOutboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND);
         S3StreamMetricsManager.registerNetworkAvailableBandwidthSupplier(AsyncNetworkBandwidthLimiter.Type.OUTBOUND, () ->
-            config.networkBaselineBandwidth() - (long) networkOutboundRate.derive(
-                TimeUnit.NANOSECONDS.toSeconds(System.nanoTime()), NetworkStats.getInstance().networkOutboundUsageTotal().get()));
+            config.networkBaselineBandwidth() - (long) NetworkStats.getInstance().networkOutboundRate());
 
         this.localIndexCache = LocalStreamRangeIndexCache.create();
         this.objectReaderFactory = new DefaultObjectReaderFactory(() -> this.mainObjectStorage);

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/Metrics.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/Metrics.java
@@ -28,7 +28,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -245,6 +247,7 @@ public class Metrics {
             private final Attributes gaugeAttributes;
             private final AtomicLong value = new AtomicLong();
             private final AtomicBoolean hasValue = new AtomicBoolean(false);
+            private final AtomicReference<LongSupplier> valueGetter = new AtomicReference<>();
             private Attributes finalAttributes = Attributes.empty();
             private volatile boolean shouldRecord = true;
 
@@ -268,16 +271,33 @@ public class Metrics {
             }
 
             public void record(long newValue) {
+                valueGetter.set(null);
                 value.set(newValue);
                 hasValue.set(true);
             }
 
+            public void record(LongSupplier valueGetter) {
+                this.valueGetter.set(valueGetter);
+                hasValue.set(false);
+            }
+
             public void clear() {
+                valueGetter.set(null);
                 hasValue.set(false);
             }
 
             private void record(ObservableLongMeasurement measurement) {
-                if (shouldRecord && hasValue.get()) {
+                if (!shouldRecord) {
+                    return;
+                }
+                LongSupplier getter = valueGetter.get();
+                if (getter != null) {
+                    try {
+                        measurement.record(getter.getAsLong(), finalAttributes);
+                    } catch (Throwable ignored) {
+                        // Skip one callback sample when the dynamic value supplier is temporarily unavailable.
+                    }
+                } else if (hasValue.get()) {
                     measurement.record(value.get(), finalAttributes);
                 }
             }
@@ -327,6 +347,7 @@ public class Metrics {
             private final Attributes gaugeAttributes;
             private final AtomicReference<Double> value = new AtomicReference<>(0.0);
             private final AtomicBoolean hasValue = new AtomicBoolean(false);
+            private final AtomicReference<DoubleSupplier> valueGetter = new AtomicReference<>();
             private Attributes finalAttributes = Attributes.empty();
             private volatile boolean shouldRecord = true;
 
@@ -350,16 +371,33 @@ public class Metrics {
             }
 
             public void record(double newValue) {
+                valueGetter.set(null);
                 value.set(newValue);
                 hasValue.set(true);
             }
 
+            public void record(DoubleSupplier valueGetter) {
+                this.valueGetter.set(valueGetter);
+                hasValue.set(false);
+            }
+
             public void clear() {
+                valueGetter.set(null);
                 hasValue.set(false);
             }
 
             private void record(ObservableDoubleMeasurement measurement) {
-                if (shouldRecord && hasValue.get()) {
+                if (!shouldRecord) {
+                    return;
+                }
+                DoubleSupplier getter = valueGetter.get();
+                if (getter != null) {
+                    try {
+                        measurement.record(getter.getAsDouble(), finalAttributes);
+                    } catch (Throwable ignored) {
+                        // Skip one callback sample when the dynamic value supplier is temporarily unavailable.
+                    }
+                } else if (hasValue.get()) {
                     measurement.record(value.get(), finalAttributes);
                 }
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/MinIntervalRate.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/MinIntervalRate.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.metrics.stats;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+public class MinIntervalRate {
+    private final long minIntervalMs;
+    private final LongSupplier nowMsSupplier;
+    private long lastUpdateMs;
+    private long lastCumulativeValue = 0;
+    private double rate = 0.0;
+
+    public MinIntervalRate(long minIntervalMs) {
+        this(minIntervalMs, System::currentTimeMillis);
+    }
+
+    public MinIntervalRate(long minIntervalMs, LongSupplier nowMsSupplier) {
+        if (minIntervalMs <= 0) {
+            throw new IllegalArgumentException("minIntervalMs must be positive");
+        }
+        this.minIntervalMs = minIntervalMs;
+        this.nowMsSupplier = Objects.requireNonNull(nowMsSupplier, "nowMsSupplier");
+        this.lastUpdateMs = nowMsSupplier.getAsLong();
+    }
+
+    public synchronized double update(long cumulativeValue) {
+        long nowMs = nowMsSupplier.getAsLong();
+        long elapsedMs = nowMs - lastUpdateMs;
+        if (elapsedMs < minIntervalMs) {
+            return rate;
+        }
+        if (cumulativeValue < lastCumulativeValue) {
+            lastUpdateMs = nowMs;
+            lastCumulativeValue = cumulativeValue;
+            rate = 0.0;
+            return rate;
+        }
+        rate = (cumulativeValue - lastCumulativeValue) * 1000.0 / elapsedMs;
+        lastUpdateMs = nowMs;
+        lastCumulativeValue = cumulativeValue;
+        return rate;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
@@ -33,13 +33,17 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class NetworkStats {
+    private static final long NETWORK_RATE_MIN_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
     private static final NetworkStats INSTANCE = new NetworkStats();
     // <StreamId, <FastReadBytes, SlowReadBytes>>
     private final Map<Long, Pair<Counter, Counter>> streamReadBytesStats = new ConcurrentHashMap<>();
     private final Counter networkInboundUsageTotal = new Counter();
     private final Counter networkOutboundUsageTotal = new Counter();
+    private final MinIntervalRate networkInboundRate = new MinIntervalRate(NETWORK_RATE_MIN_INTERVAL_MS);
+    private final MinIntervalRate networkOutboundRate = new MinIntervalRate(NETWORK_RATE_MIN_INTERVAL_MS);
     private final Map<ThrottleStrategy, CounterMetric> networkInboundUsageTotalStats = new ConcurrentHashMap<>();
     private final Map<ThrottleStrategy, CounterMetric> networkOutboundUsageTotalStats = new ConcurrentHashMap<>();
     private final Map<ThrottleStrategy, HistogramMetric> networkInboundLimiterQueueTimeStatsMap = new ConcurrentHashMap<>();
@@ -81,6 +85,32 @@ public class NetworkStats {
 
     public Counter networkOutboundUsageTotal() {
         return networkOutboundUsageTotal;
+    }
+
+    /**
+     * Returns inbound network usage bytes per second using a minimum 30-second smoothing interval.
+     */
+    public double networkInboundRate() {
+        return networkInboundRate.update(networkInboundUsageTotal.get());
+    }
+
+    /**
+     * Returns outbound network usage bytes per second using a minimum 30-second smoothing interval.
+     */
+    public double networkOutboundRate() {
+        return networkOutboundRate.update(networkOutboundUsageTotal.get());
+    }
+
+    /**
+     * Returns the broker-level network utilization against the configured baseline bandwidth.
+     */
+    public double networkUtil(long baselineBandwidth) {
+        if (baselineBandwidth <= 0) {
+            return Double.NaN;
+        }
+        double inboundUtil = networkInboundRate() / baselineBandwidth;
+        double outboundUtil = networkOutboundRate() / baselineBandwidth;
+        return Math.max(inboundUtil, outboundUtil);
     }
 
     public void createStreamReadBytesStats(long streamId) {

--- a/s3stream/src/test/java/com/automq/stream/s3/metrics/MetricsGaugeTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/metrics/MetricsGaugeTest.java
@@ -1,0 +1,61 @@
+package com.automq.stream.s3.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class MetricsGaugeTest {
+    /** Verifies LongGauge can record values lazily from a supplier during callback collection. */
+    @Test
+    void longGaugeShouldRecordFromSupplierDuringCallback() throws Exception {
+        Metrics.LongGaugeBundle.LongGauge gauge = Metrics.instance()
+            .longGauge("test_long_supplier", "test", "")
+            .register(MetricsLevel.INFO, Attributes.empty());
+        AtomicLong value = new AtomicLong(10);
+        ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
+
+        gauge.record(value::get);
+        invokeRecord(gauge, ObservableLongMeasurement.class, measurement);
+        value.set(20);
+        invokeRecord(gauge, ObservableLongMeasurement.class, measurement);
+
+        verify(measurement).record(eq(10L), any());
+        verify(measurement).record(eq(20L), any());
+        gauge.close();
+    }
+
+    /** Verifies DoubleGauge supplier mode is cleared and does not leak stale values. */
+    @Test
+    void doubleGaugeShouldClearSupplierMode() throws Exception {
+        Metrics.DoubleGaugeBundle.DoubleGauge gauge = Metrics.instance()
+            .doubleGauge("test_double_supplier", "test", "")
+            .register(MetricsLevel.INFO, Attributes.empty());
+        ObservableDoubleMeasurement measurement = mock(ObservableDoubleMeasurement.class);
+
+        gauge.record(() -> 0.5);
+        invokeRecord(gauge, ObservableDoubleMeasurement.class, measurement);
+        gauge.clear();
+        invokeRecord(gauge, ObservableDoubleMeasurement.class, measurement);
+
+        verify(measurement).record(eq(0.5), any());
+        verify(measurement, never()).record(eq(0.0), any());
+        gauge.close();
+    }
+
+    private static void invokeRecord(Object gauge, Class<?> measurementClass, Object measurement) throws Exception {
+        Method record = gauge.getClass().getDeclaredMethod("record", measurementClass);
+        record.setAccessible(true);
+        record.invoke(gauge, measurement);
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/metrics/stats/MinIntervalRateTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/metrics/stats/MinIntervalRateTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.metrics.stats;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MinIntervalRateTest {
+    @Test
+    public void testInitialCachedRateIsZero() {
+        AtomicLong nowMs = new AtomicLong(1000);
+        MinIntervalRate rate = new MinIntervalRate(30_000, nowMs::get);
+
+        Assertions.assertEquals(0.0, rate.update(100));
+    }
+
+    @Test
+    public void testReturnCachedRateBeforeMinInterval() {
+        AtomicLong nowMs = new AtomicLong(0);
+        MinIntervalRate rate = new MinIntervalRate(30_000, nowMs::get);
+
+        nowMs.set(30_000);
+        Assertions.assertEquals(10.0, rate.update(300));
+
+        nowMs.set(31_000);
+        Assertions.assertEquals(10.0, rate.update(1000));
+    }
+
+    @Test
+    public void testRecomputeAfterMinInterval() {
+        AtomicLong nowMs = new AtomicLong(0);
+        MinIntervalRate rate = new MinIntervalRate(30_000, nowMs::get);
+
+        nowMs.set(30_000);
+        Assertions.assertEquals(10.0, rate.update(300));
+        nowMs.set(60_000);
+        Assertions.assertEquals(20.0, rate.update(900));
+    }
+
+    @Test
+    public void testResetOnCounterRollback() {
+        AtomicLong nowMs = new AtomicLong(0);
+        MinIntervalRate rate = new MinIntervalRate(30_000, nowMs::get);
+
+        nowMs.set(30_000);
+        Assertions.assertEquals(10.0, rate.update(300));
+        nowMs.set(60_000);
+        Assertions.assertEquals(0.0, rate.update(100));
+        nowMs.set(90_000);
+        Assertions.assertEquals(10.0, rate.update(400));
+    }
+
+    @Test
+    public void testInvalidMinInterval() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new MinIntervalRate(0));
+    }
+}


### PR DESCRIPTION
This pull request introduces improvements to network bandwidth metrics and streamlines the calculation of network rates. It replaces the previous derivation-based approach with a new `MinIntervalRate` utility for more stable rate calculations, enhances the `Metrics` gauges to support dynamic value suppliers, and adds comprehensive tests for these new features.

**Network bandwidth metrics improvements:**

* Introduced the `MinIntervalRate` class to compute rates with a minimum smoothing interval and updated `NetworkStats` to use this for inbound and outbound network rate calculations, replacing the old `Derivator` approach.
(`s3stream/src/main/java/com/automq/stream/s3/metrics/stats/MinIntervalRate.java`, `s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java`, `core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java`) [[1]](diffhunk://#diff-4fd5d7149cbc165426d7a1a2d0c6ad76999a5b89d9b171bacaec281c79c99dc9R1-R60) [[2]](diffhunk://#diff-26d0d9c85e132af6049e152f2b6a0f0c84d4533d628f0acafae398d5da51f017R36-R46) [[3]](diffhunk://#diff-26d0d9c85e132af6049e152f2b6a0f0c84d4533d628f0acafae398d5da51f017R90-R115) [[4]](diffhunk://#diff-9981ba4c22f8371fc3ade16cede20d299afd27487aedd6602a1d639bd155aabcL22) [[5]](diffhunk://#diff-9981ba4c22f8371fc3ade16cede20d299afd27487aedd6602a1d639bd155aabcL88-L89) [[6]](diffhunk://#diff-9981ba4c22f8371fc3ade16cede20d299afd27487aedd6602a1d639bd155aabcL140-R143)

**Metrics gauge enhancements:**

* Extended `Metrics.LongGauge` and `Metrics.DoubleGauge` to support dynamic value suppliers, allowing gauges to record values lazily during metric collection callbacks.
(`s3stream/src/main/java/com/automq/stream/s3/metrics/Metrics.java`) [[1]](diffhunk://#diff-e03af95bf80bb259839239eac913852fd9ecb7a234980a6646e5873fcab9282dR252) [[2]](diffhunk://#diff-e03af95bf80bb259839239eac913852fd9ecb7a234980a6646e5873fcab9282dR276-R302) [[3]](diffhunk://#diff-e03af95bf80bb259839239eac913852fd9ecb7a234980a6646e5873fcab9282dR352) [[4]](diffhunk://#diff-e03af95bf80bb259839239eac913852fd9ecb7a234980a6646e5873fcab9282dR376-R402) [[5]](diffhunk://#diff-e03af95bf80bb259839239eac913852fd9ecb7a234980a6646e5873fcab9282dR31-R33)

**Testing improvements:**

* Added unit tests for the new `MinIntervalRate` logic and for the new supplier-based gauge recording in `Metrics`.
(`s3stream/src/test/java/com/automq/stream/s3/metrics/stats/MinIntervalRateTest.java`, `s3stream/src/test/java/com/automq/stream/s3/metrics/MetricsGaugeTest.java`) [[1]](diffhunk://#diff-9ce664ae2feb61e1943c7994f969b722d101f2cc522a0f14a3ad5e70ff7f5e4dR1-R74) [[2]](diffhunk://#diff-336159f3bcd8009325e399c76cd1d7f61c3342ce93e78edca113c007e10ce5d0R1-R61)

These changes ensure more accurate and robust network metric reporting and make the metrics system more flexible and testable.

---------

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
