### PR TITLE
fix: dedupe S3 metadata after snapshot replay

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/KVDelta.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.metadata.RemoveKVRecord;
 import org.apache.kafka.controller.stream.KVKey;
 import org.apache.kafka.timeline.TimelineHashMap;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,6 +68,14 @@ public final class KVDelta {
         }
     }
 
+    public void finishSnapshot() {
+        image.forEach((key, value) -> {
+            if (!changedKV.containsKey(key)) {
+                removedKeys.add(key);
+            }
+        });
+    }
+
     public KVImage apply() {
         RegistryRef registry = image.registryRef();
         // get original objects first
@@ -93,7 +103,13 @@ public final class KVDelta {
         return changedKV.get(kvKey);
     }
 
+    @VisibleForTesting
     Map<KVKey, ByteBuffer> changedKV() {
         return changedKV;
+    }
+
+    @VisibleForTesting
+    Set<KVKey> removedKeys() {
+        return removedKeys;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -561,6 +561,9 @@ public final class MetadataDelta {
         getOrCreateAclsDelta().finishSnapshot();
         getOrCreateScramDelta().finishSnapshot();
         getOrCreateDelegationTokenDelta().finishSnapshot();
+        getOrCreateStreamsMetadataDelta().finishSnapshot();
+        getOrCreateObjectsMetadataDelta().finishSnapshot();
+        getOrCreateKVDelta().finishSnapshot();
     }
 
     public MetadataImage apply(MetadataProvenance provenance) {

--- a/metadata/src/main/java/org/apache/kafka/image/NodeS3WALMetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/NodeS3WALMetadataDelta.java
@@ -22,6 +22,9 @@ import org.apache.kafka.common.metadata.RemoveStreamSetObjectRecord;
 import org.apache.kafka.common.metadata.S3StreamSetObjectRecord;
 import org.apache.kafka.metadata.stream.S3StreamSetObject;
 
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -36,6 +39,7 @@ public class NodeS3WALMetadataDelta {
     private final Map<Long/*objectId*/, S3StreamSetObject> addedS3StreamSetObjects = new HashMap<>();
 
     private final Set<Long/*objectId*/> removedS3StreamSetObjects = new HashSet<>();
+    private boolean snapshotReplay = false;
 
     public NodeS3WALMetadataDelta(NodeS3StreamSetObjectMetadataImage image) {
         this.image = image;
@@ -60,12 +64,43 @@ public class NodeS3WALMetadataDelta {
         addedS3StreamSetObjects.remove(record.objectId());
     }
 
+    public void finishSnapshot() {
+        snapshotReplay = true;
+        image.getObjects().toList().forEach(object -> {
+            if (!addedS3StreamSetObjects.containsKey(object.objectId())) {
+                removedS3StreamSetObjects.add(object.objectId());
+            }
+        });
+    }
+
+    @VisibleForTesting
+    Map<Long, S3StreamSetObject> addedS3StreamSetObjects() {
+        return addedS3StreamSetObjects;
+    }
+
+    @VisibleForTesting
+    Set<Long> removedS3StreamSetObjects() {
+        return removedS3StreamSetObjects;
+    }
+
     public NodeS3StreamSetObjectMetadataImage apply() {
-        DeltaList<S3StreamSetObject> streamSetObjects = image.getObjects().copy();
-        // add all changed stream set objects
-        addedS3StreamSetObjects.forEach((id, obj) -> streamSetObjects.add(obj));
-        // remove all removed stream set objects
-        removedS3StreamSetObjects.forEach(id -> streamSetObjects.remove(obj -> Objects.equals(obj.objectId(), id)));
+        DeltaList<S3StreamSetObject> streamSetObjects;
+        if (addedS3StreamSetObjects.isEmpty() && removedS3StreamSetObjects.isEmpty()) {
+            streamSetObjects = image.getObjects();
+        } else if (snapshotReplay) {
+            // Snapshot replay is a full-state replacement over a non-empty image. Rebuild
+            // a clean list by object id so old DeltaList tombstones cannot hide updated
+            // stream set objects with the same object id from forEach/orderList readers.
+            Map<Long, S3StreamSetObject> objects = new HashMap<>();
+            image.getObjects().toList().forEach(object -> objects.put(object.objectId(), object));
+            removedS3StreamSetObjects.forEach(objects::remove);
+            addedS3StreamSetObjects.forEach(objects::put);
+            streamSetObjects = new DeltaList<>(new ArrayList<>(objects.values()));
+        } else {
+            streamSetObjects = image.getObjects().copy();
+            addedS3StreamSetObjects.values().forEach(streamSetObjects::add);
+            removedS3StreamSetObjects.forEach(id -> streamSetObjects.remove(obj -> Objects.equals(obj.objectId(), id)));
+        }
         return new NodeS3StreamSetObjectMetadataImage(this.nodeId, this.nodeEpoch, streamSetObjects);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/S3ObjectsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/S3ObjectsDelta.java
@@ -74,6 +74,14 @@ public final class S3ObjectsDelta {
         changedObjects.remove(record.objectId());
     }
 
+    public void finishSnapshot() {
+        image.objectIds().forEach(objectId -> {
+            if (!changedObjects.containsKey(objectId)) {
+                removedObjectIds.add(objectId);
+            }
+        });
+    }
+
     public S3ObjectsImage apply() {
         RegistryRef registry = image.registryRef();
         // get original objects first

--- a/metadata/src/main/java/org/apache/kafka/image/S3StreamMetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/S3StreamMetadataDelta.java
@@ -27,6 +27,7 @@ import org.apache.kafka.metadata.stream.RangeMetadata;
 import org.apache.kafka.metadata.stream.S3StreamObject;
 
 import com.automq.stream.s3.metadata.StreamState;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,6 +53,7 @@ public class S3StreamMetadataDelta {
     private final Set<Integer/*rangeIndex*/> removedRanges = new HashSet<>();
     private final Map<Long/*objectId*/, S3StreamObject> changedS3StreamObjects = new HashMap<>();
     private final Set<Long/*objectId*/> removedS3StreamObjectIds = new HashSet<>();
+    private boolean snapshotReplay = false;
 
     public S3StreamMetadataDelta(S3StreamMetadataImage image) {
         this.image = image;
@@ -96,6 +98,30 @@ public class S3StreamMetadataDelta {
         changedS3StreamObjects.remove(record.objectId());
     }
 
+    public void finishSnapshot() {
+        snapshotReplay = true;
+        image.getRanges().forEach(range -> {
+            if (!changedRanges.containsKey(range.rangeIndex())) {
+                removedRanges.add(range.rangeIndex());
+            }
+        });
+        image.streamObjects.toList().forEach(object -> {
+            if (!changedS3StreamObjects.containsKey(object.objectId())) {
+                removedS3StreamObjectIds.add(object.objectId());
+            }
+        });
+    }
+
+    @VisibleForTesting
+    Map<Long, S3StreamObject> changedS3StreamObjects() {
+        return changedS3StreamObjects;
+    }
+
+    @VisibleForTesting
+    Set<Long> removedS3StreamObjectIds() {
+        return removedS3StreamObjectIds;
+    }
+
     public S3StreamMetadataImage apply() {
         List<RangeMetadata> newRanges;
         if (changedRanges.isEmpty() && removedRanges.isEmpty()) {
@@ -113,9 +139,18 @@ public class S3StreamMetadataDelta {
         DeltaList<S3StreamObject> newS3StreamObjects;
         if (changedS3StreamObjects.isEmpty() && removedS3StreamObjectIds.isEmpty()) {
             newS3StreamObjects = image.streamObjects;
+        } else if (snapshotReplay) {
+            // Snapshot replay is a full-state replacement over a non-empty image. Rebuild
+            // a clean list by object id so old DeltaList tombstones cannot hide updated
+            // stream objects with the same object id from toList/getStreamObjects readers.
+            Map<Long, S3StreamObject> objects = new HashMap<>();
+            image.streamObjects.toList().forEach(object -> objects.put(object.objectId(), object));
+            removedS3StreamObjectIds.forEach(objects::remove);
+            changedS3StreamObjects.forEach(objects::put);
+            newS3StreamObjects = new DeltaList<>(new ArrayList<>(objects.values()));
         } else {
             newS3StreamObjects = image.streamObjects.copy();
-            changedS3StreamObjects.forEach((id, obj) -> newS3StreamObjects.add(obj));
+            changedS3StreamObjects.values().forEach(newS3StreamObjects::add);
             removedS3StreamObjectIds.forEach(id -> newS3StreamObjects.remove(obj -> Objects.equals(obj.objectId(), id)));
         }
         return new S3StreamMetadataImage(streamId, newEpoch, currentState, tags, newStartOffset, newRanges, newS3StreamObjects);

--- a/metadata/src/main/java/org/apache/kafka/image/S3StreamsMetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/S3StreamsMetadataDelta.java
@@ -142,6 +142,32 @@ public final class S3StreamsMetadataDelta {
         return set;
     }
 
+    public void finishSnapshot() {
+        for (S3StreamMetadataImage stream : image.streamMetadataList()) {
+            long streamId = stream.getStreamId();
+            S3StreamMetadataDelta delta = changedStreams.get(streamId);
+            if (delta == null) {
+                deletedStreams.add(streamId);
+            } else {
+                delta.finishSnapshot();
+            }
+        }
+        for (NodeS3StreamSetObjectMetadataImage node : image.nodeMetadataList()) {
+            NodeS3WALMetadataDelta delta = changedNodes.get(node.getNodeId());
+            if (delta == null) {
+                deletedNodes.add(node.getNodeId());
+            } else {
+                delta.finishSnapshot();
+            }
+        }
+        for (Long streamId : image.streamEndOffsets().keySet()) {
+            if (!changedStreamEndOffsets.containsKey(streamId)) {
+                // Null marks an end-offset deletion during snapshot finalization.
+                changedStreamEndOffsets.put(streamId, null);
+            }
+        }
+    }
+
     private void updateStreamEndOffset(long streamId, long newEndOffset) {
         changedStreamEndOffsets.compute(streamId, (id, offset) -> {
             if (offset == null) {
@@ -203,6 +229,10 @@ public final class S3StreamsMetadataDelta {
 
             changedStreamEndOffsets.forEach((streamId, newEndOffset) -> newStreamEndOffsets.compute(streamId, (key, oldEndOffset) -> {
                 if (!newStreamMetadataMap.containsKey(streamId)) {
+                    return null;
+                }
+                if (newEndOffset == null) {
+                    // Returning null from compute removes the entry marked by finishSnapshot().
                     return null;
                 }
                 if (oldEndOffset == null) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/stream/S3StreamSetObject.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/stream/S3StreamSetObject.java
@@ -89,6 +89,8 @@ public class S3StreamSetObject implements Comparable<S3StreamSetObject> {
         this.nodeId = nodeId;
         this.ranges = ranges;
         this.dataTimeInMs = dataTimeInMs;
+        // A snapshot can rematerialize the same object id with different ranges.
+        invalidateCache(objectId);
     }
 
     public List<StreamOffsetRange> offsetRangeList() {
@@ -198,6 +200,8 @@ public class S3StreamSetObject implements Comparable<S3StreamSetObject> {
         streamOffsetRanges = new ArrayList<>(streamOffsetRanges);
         streamOffsetRanges.sort(Comparator.comparingLong(StreamOffsetRange::streamId));
         RANGES_CACHE.put(objectId, streamOffsetRanges);
+        // Keep find(streamId)'s map cache consistent with the updated range list.
+        RANGE_MAP_CACHE.invalidate(objectId);
         return encode(streamOffsetRanges);
     }
 
@@ -259,5 +263,10 @@ public class S3StreamSetObject implements Comparable<S3StreamSetObject> {
     public static void cleanCache() {
         RANGES_CACHE.invalidateAll();
         RANGE_MAP_CACHE.invalidateAll();
+    }
+
+    private static void invalidateCache(long objectId) {
+        RANGES_CACHE.invalidate(objectId);
+        RANGE_MAP_CACHE.invalidate(objectId);
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/KVImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/KVImageTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Timeout;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -99,6 +101,26 @@ public class KVImageTest {
     @Test
     public void testApplyDelta1() {
         assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testFinishSnapshotRemovesMissingKVs() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineHashMap<KVKey, ByteBuffer> map = new TimelineHashMap<>(registry, 10);
+        map.put(KVKey.of("key1"), ByteBuffer.wrap("value1".getBytes()));
+        map.put(KVKey.of("key2"), ByteBuffer.wrap("value2".getBytes()));
+        registry.getOrCreateSnapshot(0);
+        KVDelta delta = new KVDelta(new KVImage(map, new RegistryRef(registry, 0, new ArrayList<>())));
+        delta.replay(new KVRecord()
+            .setKeyValues(List.of(new KeyValue()
+                .setKey("key2")
+                .setValue("value2".getBytes()))));
+        delta.finishSnapshot();
+
+        assertEquals(Set.of(KVKey.of("key1")), delta.removedKeys());
+        assertEquals(Set.of(KVKey.of("key2")), delta.changedKV().keySet());
+
+        assertEquals(Map.of(KVKey.of("key2"), ByteBuffer.wrap("value2".getBytes())), delta.apply().kvs());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/NodeRuntimeMetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/NodeRuntimeMetadataImageTest.java
@@ -34,7 +34,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -116,6 +118,74 @@ public class NodeRuntimeMetadataImageTest {
                     new StreamOffsetRange(STREAM1, 0L, 200L)), 0L)));
         assertEquals(image3, delta2.apply());
         testToImageAndBack(image3);
+    }
+
+    @Test
+    public void testFinishSnapshotHandlesStreamSetObjectUpdatesAddsAndRemoves() {
+        NodeS3StreamSetObjectMetadataImage image = new NodeS3StreamSetObjectMetadataImage(BROKER0, 1,
+            DeltaList.of(
+                new S3StreamSetObject(0L, BROKER0, List.of(
+                    new StreamOffsetRange(STREAM0, 0L, 100L)), 0L),
+                new S3StreamSetObject(1L, BROKER0, List.of(
+                    new StreamOffsetRange(STREAM1, 0L, 100L)), 1L)));
+        NodeS3WALMetadataDelta delta = new NodeS3WALMetadataDelta(image);
+        delta.replay(new S3StreamSetObjectRecord()
+            .setObjectId(0L)
+            .setNodeId(BROKER0)
+            .setOrderId(2L)
+            .setRanges(S3StreamSetObject.encode(List.of(
+                new StreamOffsetRange(STREAM0, 100L, 200L)))));
+        delta.replay(new S3StreamSetObjectRecord()
+            .setObjectId(2L)
+            .setNodeId(BROKER0)
+            .setOrderId(3L)
+            .setRanges(S3StreamSetObject.encode(List.of(
+                new StreamOffsetRange(STREAM1, 100L, 200L)))));
+        delta.finishSnapshot();
+
+        assertEquals(Set.of(0L, 2L), delta.addedS3StreamSetObjects().keySet());
+        assertEquals(Set.of(1L), delta.removedS3StreamSetObjects());
+
+        List<S3StreamSetObject> objects = delta.apply().getObjects().toList();
+        objects.sort(Comparator.comparingLong(S3StreamSetObject::objectId));
+        assertEquals(2, objects.size());
+        assertEquals(0L, objects.get(0).objectId());
+        assertEquals(2L, objects.get(0).orderId());
+        assertEquals(List.of(new StreamOffsetRange(STREAM0, 100L, 200L)), objects.get(0).offsetRangeList());
+        assertEquals(2L, objects.get(1).objectId());
+        assertEquals(3L, objects.get(1).orderId());
+        assertEquals(List.of(new StreamOffsetRange(STREAM1, 100L, 200L)), objects.get(1).offsetRangeList());
+
+        List<S3StreamSetObject> orderedObjects = delta.apply().orderList();
+        assertEquals(2, orderedObjects.size());
+        assertEquals(0L, orderedObjects.get(0).objectId());
+        assertEquals(2L, orderedObjects.get(0).orderId());
+        assertEquals(List.of(new StreamOffsetRange(STREAM0, 100L, 200L)), orderedObjects.get(0).offsetRangeList());
+        assertEquals(2L, orderedObjects.get(1).objectId());
+        assertEquals(3L, orderedObjects.get(1).orderId());
+        assertEquals(List.of(new StreamOffsetRange(STREAM1, 100L, 200L)), orderedObjects.get(1).offsetRangeList());
+    }
+
+    @Test
+    public void testFinishSnapshotRemovesMissingStreamSetObjects() {
+        NodeS3StreamSetObjectMetadataImage image = new NodeS3StreamSetObjectMetadataImage(BROKER0, 1,
+            DeltaList.of(
+                new S3StreamSetObject(0L, BROKER0, List.of(
+                    new StreamOffsetRange(STREAM0, 0L, 100L)), 0L),
+                new S3StreamSetObject(1L, BROKER0, List.of(
+                    new StreamOffsetRange(STREAM0, 100L, 200L)), 1L)));
+        NodeS3WALMetadataDelta delta = new NodeS3WALMetadataDelta(image);
+        delta.replay(new S3StreamSetObjectRecord()
+            .setObjectId(0L)
+            .setNodeId(BROKER0)
+            .setOrderId(0L)
+            .setRanges(S3StreamSetObject.encode(List.of(
+                new StreamOffsetRange(STREAM0, 0L, 100L)))));
+        delta.finishSnapshot();
+
+        List<S3StreamSetObject> objects = delta.apply().getObjects().toList();
+        assertEquals(List.of(new S3StreamSetObject(0L, BROKER0, List.of(
+            new StreamOffsetRange(STREAM0, 0L, 100L)), 0L)), objects);
     }
 
     private void testToImageAndBack(NodeS3StreamSetObjectMetadataImage image) {

--- a/metadata/src/test/java/org/apache/kafka/image/S3ObjectsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/S3ObjectsImageTest.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -137,6 +138,28 @@ public class S3ObjectsImageTest {
     @Test
     public void testApplyDelta1() {
         assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testFinishSnapshotRemovesMissingObjects() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineHashMap<Long, S3Object> map = new TimelineHashMap<>(registry, 10);
+        map.put(0L, new S3Object(0L, -1, -1, S3ObjectState.PREPARED, ObjectAttributes.DEFAULT.attributes()));
+        map.put(1L, new S3Object(1L, -1, -1, S3ObjectState.PREPARED, ObjectAttributes.DEFAULT.attributes()));
+        registry.getOrCreateSnapshot(0);
+        S3ObjectsDelta delta = new S3ObjectsDelta(new S3ObjectsImage(1L, map, new RegistryRef(registry, 0, new ArrayList<>())));
+        delta.replay(new S3ObjectRecord()
+            .setObjectId(0L)
+            .setObjectState((byte) S3ObjectState.COMMITTED.ordinal())
+            .setAttributes(ObjectAttributes.DEFAULT.attributes()));
+        delta.finishSnapshot();
+
+        assertEquals(Set.of(0L), delta.changedObjects().keySet());
+        assertEquals(Set.of(1L), delta.removedObjects());
+
+        S3ObjectsImage image = delta.apply();
+        assertEquals(1, image.objectsCount());
+        assertTrue(image.objectIds().contains(0L));
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/StreamRuntimeMetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/StreamRuntimeMetadataImageTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -182,6 +183,54 @@ public class StreamRuntimeMetadataImageTest {
             new S3StreamObject(1L, 999, STREAM0, 100L)));
         assertEquals(image2, delta1.apply());
         testToImageAndBack(image2);
+    }
+
+    @Test
+    public void testFinishSnapshotHandlesStreamObjectUpdatesAddsAndRemoves() {
+        S3StreamMetadataImage image = new S3StreamMetadataImage(
+            STREAM0, 0L, StreamState.OPENED, new S3StreamRecord.TagCollection(), 0L, Collections.emptyList(),
+            DeltaList.of(
+                new S3StreamObject(0L, STREAM0, 0L, 100L),
+                new S3StreamObject(1L, STREAM0, 100L, 200L)));
+        S3StreamMetadataDelta delta = new S3StreamMetadataDelta(image);
+        delta.replay(new S3StreamObjectRecord()
+            .setObjectId(0L)
+            .setStreamId(STREAM0)
+            .setStartOffset(100L)
+            .setEndOffset(200L));
+        delta.replay(new S3StreamObjectRecord()
+            .setObjectId(2L)
+            .setStreamId(STREAM0)
+            .setStartOffset(200L)
+            .setEndOffset(300L));
+        delta.finishSnapshot();
+
+        assertEquals(Set.of(0L, 2L), delta.changedS3StreamObjects().keySet());
+        assertEquals(Set.of(1L), delta.removedS3StreamObjectIds());
+
+        List<S3StreamObject> objects = delta.apply().getStreamObjects();
+        assertEquals(List.of(
+            new S3StreamObject(0L, STREAM0, 100L, 200L),
+            new S3StreamObject(2L, STREAM0, 200L, 300L)
+        ), objects);
+    }
+
+    @Test
+    public void testFinishSnapshotRemovesMissingStreamObjects() {
+        S3StreamMetadataImage image = new S3StreamMetadataImage(
+            STREAM0, 0L, StreamState.OPENED, new S3StreamRecord.TagCollection(), 0L, Collections.emptyList(),
+            DeltaList.of(
+                new S3StreamObject(0L, STREAM0, 0L, 100L),
+                new S3StreamObject(1L, STREAM0, 100L, 200L)));
+        S3StreamMetadataDelta delta = new S3StreamMetadataDelta(image);
+        delta.replay(new S3StreamObjectRecord()
+            .setObjectId(0L)
+            .setStreamId(STREAM0)
+            .setStartOffset(0L)
+            .setEndOffset(100L));
+        delta.finishSnapshot();
+
+        assertEquals(List.of(new S3StreamObject(0L, STREAM0, 0L, 100L)), delta.apply().getStreamObjects());
     }
 
     @Test

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
@@ -57,6 +57,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -264,7 +265,12 @@ public class CompactionManager {
     }
 
     void updateStreamDataBlockMap(List<S3ObjectMetadata> objectMetadataList) {
+        objectMetadataList = deduplicateObjectsById(objectMetadataList, "stream set compaction");
         this.streamDataBlockMap = CompactionUtils.blockWaitObjectIndices(objectMetadataList, objectStorage, logger);
+    }
+
+    Map<Long, List<StreamDataBlock>> streamDataBlockMap() {
+        return streamDataBlockMap;
     }
 
     void filterInvalidStreamDataBlocks(List<StreamMetadata> streamMetadataList) {
@@ -281,6 +287,7 @@ public class CompactionManager {
             logger.info("Compaction manager is shutdown, skip compaction");
             return;
         }
+        objectMetadataList = deduplicateObjectsById(objectMetadataList, "stream set compaction");
         Map<Boolean, List<S3ObjectMetadata>> objectMetadataFilterMap = convertS3Objects(objectMetadataList);
         List<S3ObjectMetadata> objectsToForceSplit = objectMetadataFilterMap.get(true);
         List<S3ObjectMetadata> objectsToCompact = objectMetadataFilterMap.get(false);
@@ -310,6 +317,7 @@ public class CompactionManager {
     }
 
     void forceSplitObjects(List<StreamMetadata> streamMetadataList, List<S3ObjectMetadata> objectsToForceSplit) {
+        objectsToForceSplit = deduplicateObjectsById(objectsToForceSplit, "force split");
         logger.info("Force split {} stream set objects", objectsToForceSplit.size());
         TimerUtil timerUtil = new TimerUtil();
         for (int i = 0; i < objectsToForceSplit.size(); i++) {
@@ -356,6 +364,7 @@ public class CompactionManager {
         if (objectsToCompact.isEmpty()) {
             return;
         }
+        objectsToCompact = deduplicateObjectsById(objectsToCompact, "stream set compaction");
         // sort by S3 object data time in descending order
         objectsToCompact.sort((o1, o2) -> Long.compare(o2.dataTimeInMs(), o1.dataTimeInMs()));
         int totalSize = objectsToCompact.size();
@@ -585,6 +594,7 @@ public class CompactionManager {
     CommitStreamSetObjectRequest buildCompactRequest(List<StreamMetadata> streamMetadataList,
         List<S3ObjectMetadata> objectsToCompact)
         throws CompletionException {
+        objectsToCompact = deduplicateObjectsById(objectsToCompact, "stream set compaction");
         CommitStreamSetObjectRequest request = new CommitStreamSetObjectRequest();
         request.setObjectId(-1L);
 
@@ -815,5 +825,25 @@ public class CompactionManager {
         request.setOrderId(s3ObjectMetadata.get(0).objectId());
         request.setObjectSize(uploader.complete());
         request.setAttributes(ObjectAttributes.builder().bucket(uploader.bucketId()).build().attributes());
+    }
+
+    List<S3ObjectMetadata> deduplicateObjectsById(List<S3ObjectMetadata> objects, String inputName) {
+        if (objects.size() < 2) {
+            return objects;
+        }
+        Map<Long, S3ObjectMetadata> deduplicated = new LinkedHashMap<>();
+        int duplicates = 0;
+        for (S3ObjectMetadata object : objects) {
+            S3ObjectMetadata previous = deduplicated.put(object.objectId(), object);
+            if (previous != null) {
+                duplicates++;
+            }
+        }
+        if (duplicates > 0) {
+            logger.warn("Detected {} duplicate object ids in {} input, deduplicated {} objects to {} objects",
+                duplicates, inputName, objects.size(), deduplicated.size());
+            return new ArrayList<>(deduplicated.values());
+        }
+        return objects;
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -50,8 +50,10 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -165,7 +167,9 @@ public class StreamObjectCompactor {
         long streamId = stream.streamId();
         long startOffset = stream.startOffset();
 
-        List<S3ObjectMetadata> objects = objectManager.getStreamObjects(stream.streamId(), 0L, stream.confirmOffset(), Integer.MAX_VALUE).get();
+        List<S3ObjectMetadata> objects = deduplicateObjectsById(
+            objectManager.getStreamObjects(stream.streamId(), 0L, stream.confirmOffset(), Integer.MAX_VALUE).get(),
+            "stream object compaction");
         List<S3ObjectMetadata> expiredObjects = new ArrayList<>(objects.size());
         List<S3ObjectMetadata> livingObjects = new ArrayList<>(objects.size());
         for (S3ObjectMetadata object : objects) {
@@ -268,6 +272,26 @@ public class StreamObjectCompactor {
             }
             i = end;
         }
+    }
+
+    static List<S3ObjectMetadata> deduplicateObjectsById(List<S3ObjectMetadata> objects, String inputName) {
+        if (objects.size() < 2) {
+            return objects;
+        }
+        Map<Long, S3ObjectMetadata> deduplicated = new LinkedHashMap<>();
+        int duplicates = 0;
+        for (S3ObjectMetadata object : objects) {
+            S3ObjectMetadata previous = deduplicated.put(object.objectId(), object);
+            if (previous != null) {
+                duplicates++;
+            }
+        }
+        if (duplicates > 0) {
+            LOGGER.warn("Detected {} duplicate object ids in {} input, deduplicated {} objects to {} objects",
+                duplicates, inputName, objects.size(), deduplicated.size());
+            return new ArrayList<>(deduplicated.values());
+        }
+        return objects;
     }
 
     static class CompactByPhysicalMerge {
@@ -487,6 +511,7 @@ public class StreamObjectCompactor {
     static List<List<S3ObjectMetadata>> group0(List<S3ObjectMetadata> objects,
                                                long maxStreamObjectSize,
                                                Predicate<S3ObjectMetadata> objectFilter) {
+        objects = deduplicateObjectsById(objects, "stream object compaction");
         // TODO: switch to include/exclude composite object
         List<List<S3ObjectMetadata>> objectGroups = new LinkedList<>();
         long groupSize = 0;

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionManagerTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionManagerTest.java
@@ -178,6 +178,23 @@ public class CompactionManagerTest extends CompactionTestBase {
     }
 
     @Test
+    public void testDeduplicateObjectsByIdKeepsLatestMetadata() {
+        List<S3ObjectMetadata> s3ObjectMetadata = this.objectManager.getServerObjects().join();
+        compactionManager = new CompactionManager(config, objectManager, streamManager, objectStorage);
+
+        S3ObjectMetadata oldObject = s3ObjectMetadata.get(0);
+        S3ObjectMetadata latestObject = new S3ObjectMetadata(oldObject.objectId(), S3ObjectType.STREAM_SET,
+            List.of(new StreamOffsetRange(STREAM_0, 0L, 15L)), oldObject.dataTimeInMs(),
+            oldObject.committedTimestamp(), oldObject.objectSize(), oldObject.getOrderId(), oldObject.attributes());
+        S3ObjectMetadata secondObject = s3ObjectMetadata.get(1);
+
+        List<S3ObjectMetadata> deduplicated = compactionManager.deduplicateObjectsById(
+            List.of(oldObject, latestObject, secondObject), "test");
+
+        assertEquals(List.of(latestObject, secondObject), deduplicated);
+    }
+
+    @Test
     public void testForceSplitWithOutDatedObject() {
         when(streamManager.getStreams(Collections.emptyList())).thenReturn(CompletableFuture.completedFuture(
             List.of(new StreamMetadata(STREAM_0, 0, 999, 9999, StreamState.OPENED),

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -214,6 +214,27 @@ class StreamObjectCompactorTest {
     }
 
     @Test
+    public void testGroup0DeduplicatesObjectsByObjectIdAndKeepsLatestMetadata() {
+        S3ObjectMetadata first = new S3ObjectMetadata(
+            1, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, 0, 10)),
+            System.currentTimeMillis(), System.currentTimeMillis(), 100, 1);
+        S3ObjectMetadata duplicate = new S3ObjectMetadata(
+            1, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, 10, 20)),
+            System.currentTimeMillis(), System.currentTimeMillis(), 100, 2);
+        S3ObjectMetadata second = new S3ObjectMetadata(
+            2, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, 10, 20)),
+            System.currentTimeMillis(), System.currentTimeMillis(), 100, 3);
+
+        List<List<S3ObjectMetadata>> groups = group0(List.of(first, duplicate, second), Long.MAX_VALUE, obj -> true);
+
+        List<S3ObjectMetadata> deduplicated = groups.stream().flatMap(List::stream).collect(Collectors.toList());
+        assertEquals(List.of(duplicate, second), deduplicated);
+    }
+
+    @Test
     public void testCompact() throws ExecutionException, InterruptedException {
         List<S3ObjectMetadata> objects = prepareData();
         when(objectManager.getStreamObjects(eq(streamId), eq(0L), eq(32L), eq(Integer.MAX_VALUE)))


### PR DESCRIPTION
## Summary

- Complete snapshot finalization for AutoMQ S3/KV metadata deltas so snapshot replay removes stale metadata from non-empty images.
- In snapshot-finalization mode only, rebuild S3 stream-set-object and stream-object `DeltaList` instances from the final objectId-keyed state. Normal incremental replay keeps the existing `DeltaList.copy()` append/remove path.
- Add defensive compaction input deduplication by `objectId` with warning logs.
- Add regression coverage for same-`objectId` snapshot replay, snapshot finalization, delta changed/removed sets, and compaction duplicate inputs.

Closes #3369

## Tests

- `./gradlew :metadata:test --tests 'org.apache.kafka.image.NodeRuntimeMetadataImageTest' --tests 'org.apache.kafka.image.StreamRuntimeMetadataImageTest' --tests 'org.apache.kafka.image.S3ObjectsImageTest' --tests 'org.apache.kafka.image.KVImageTest' --tests 'org.apache.kafka.image.S3StreamsMetadataImageTest'`
- `./gradlew :s3stream:test --tests 'com.automq.stream.s3.compact.CompactionManagerTest' --tests 'com.automq.stream.s3.compact.StreamObjectCompactorTest'`
- `git diff --check`
