### PR TITLE
fix: pass table topic schema registry client config

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -194,6 +194,7 @@ public class AutoMQConfig {
 
     public static final String TABLE_TOPIC_SCHEMA_REGISTRY_URL_CONFIG = "automq.table.topic.schema.registry.url";
     private static final String TABLE_TOPIC_SCHEMA_REGISTRY_URL_DOC = "The schema registry url for table topic";
+    public static final String TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX = "automq.table.topic.schema.registry.config.";
 
     public static final String ZONE_ROUTER_CHANNELS_CONFIG = "automq.zonerouter.channels";
     public static final String ZONE_ROUTER_CHANNELS_DOC = "The channels to use for cross zone router. Currently it only support object storage channel."

--- a/core/src/main/java/kafka/automq/table/process/RecordProcessorFactory.java
+++ b/core/src/main/java/kafka/automq/table/process/RecordProcessorFactory.java
@@ -30,6 +30,7 @@ import org.apache.kafka.server.record.TableTopicSchemaType;
 import org.apache.kafka.server.record.TableTopicTransformType;
 
 import java.util.List;
+import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
@@ -38,6 +39,10 @@ public class RecordProcessorFactory {
 
     public RecordProcessorFactory(String registryUrl) {
         this.converterFactory = new ConverterFactory(registryUrl);
+    }
+
+    public RecordProcessorFactory(String registryUrl, Map<String, ?> schemaRegistryClientConfigs) {
+        this.converterFactory = new ConverterFactory(registryUrl, schemaRegistryClientConfigs);
     }
 
     public RecordProcessorFactory(String registryUrl, SchemaRegistryClient client) {

--- a/core/src/main/java/kafka/automq/table/process/convert/ConverterFactory.java
+++ b/core/src/main/java/kafka/automq/table/process/convert/ConverterFactory.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
@@ -64,13 +65,17 @@ public class ConverterFactory {
         .build();
 
     public ConverterFactory(String registryUrl) {
+        this(registryUrl, Map.of());
+    }
+
+    public ConverterFactory(String registryUrl, Map<String, ?> schemaRegistryClientConfigs) {
         this.schemaRegistryUrl = registryUrl;
         if (registryUrl != null && !registryUrl.trim().isEmpty()) {
             this.client = new CachedSchemaRegistryClient(
                 registryUrl,
                 AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
                 List.of(new AvroSchemaProvider(), new ProtobufSchemaProvider()),
-                null
+                Objects.requireNonNullElse(schemaRegistryClientConfigs, Map.of())
             );
         } else {
             this.client = null;

--- a/core/src/main/java/kafka/automq/table/worker/TableWorkers.java
+++ b/core/src/main/java/kafka/automq/table/worker/TableWorkers.java
@@ -19,6 +19,7 @@
 
 package kafka.automq.table.worker;
 
+import kafka.automq.AutoMQConfig;
 import kafka.automq.table.Channel;
 import kafka.automq.table.events.CommitRequest;
 import kafka.automq.table.events.Envelope;
@@ -36,6 +37,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -71,7 +73,17 @@ public class TableWorkers {
         this.eventLoops = new EventLoops(eventLoops);
         executor.submit(new ControlListener());
         this.config = config;
-        this.recordProcessorFactory = new RecordProcessorFactory(config.tableTopicSchemaRegistryUrl());
+        this.recordProcessorFactory = new RecordProcessorFactory(
+            config.tableTopicSchemaRegistryUrl(),
+            tableTopicSchemaRegistryClientConfigs(config)
+        );
+    }
+
+    static Map<String, Object> tableTopicSchemaRegistryClientConfigs(KafkaConfig config) {
+        Map<String, Object> configs = config.originalsWithPrefix(AutoMQConfig.TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX);
+        Map<String, Object> clientConfigs = new HashMap<>();
+        configs.forEach((key, value) -> clientConfigs.put("schema.registry." + key, value));
+        return clientConfigs;
     }
 
     public void add(Partition partition) {

--- a/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
@@ -23,6 +23,7 @@ import kafka.automq.AutoMQConfig;
 import kafka.server.KafkaConfig;
 
 import org.apache.kafka.server.config.ZkConfigs;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.table.worker;
+
+import kafka.automq.AutoMQConfig;
+import kafka.server.KafkaConfig;
+
+import org.apache.kafka.server.config.ZkConfigs;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class TableWorkersTest {
+    @Test
+    void tableTopicSchemaRegistryClientConfigsMapsAutoMQPrefix() {
+        Properties properties = new Properties();
+        properties.setProperty("broker.id", "1");
+        properties.setProperty(ZkConfigs.ZK_CONNECT_CONFIG, "somewhere");
+        properties.setProperty(AutoMQConfig.TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX + "ssl.truststore.type", "PEM");
+        properties.setProperty(AutoMQConfig.TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX + "ssl.truststore.certificates", "ca-pem");
+        properties.setProperty(AutoMQConfig.TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX + "ssl.endpoint.identification.algorithm", "");
+        properties.setProperty("schema.registry.ssl.truststore.type", "ignored-global");
+
+        KafkaConfig config = KafkaConfig.fromProps(properties);
+
+        Map<String, Object> clientConfigs = TableWorkers.tableTopicSchemaRegistryClientConfigs(config);
+        assertEquals("PEM", clientConfigs.get("schema.registry.ssl.truststore.type"));
+        assertEquals("ca-pem", clientConfigs.get("schema.registry.ssl.truststore.certificates"));
+        assertEquals("", clientConfigs.get("schema.registry.ssl.endpoint.identification.algorithm"));
+        assertFalse(clientConfigs.containsKey("ssl.truststore.type"));
+        assertFalse(clientConfigs.containsValue("ignored-global"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Table Topic Schema Registry client config prefix constant
- read automq.table.topic.schema.registry.config.* with the existing originalsWithPrefix pattern at the TableWorkers use site
- map the Table Topic-owned prefix to Confluent schema.registry.* keys and pass the map into CachedSchemaRegistryClient

## Tests
- ./gradlew core:test --tests kafka.automq.table.worker.TableWorkersTest

## Related
- Forward-port/cherry-pick of the Table Topic SR client config fix for main
- 1.6 PR: https://github.com/AutoMQ/automq/pull/3373
- 1.7 PR: https://github.com/AutoMQ/automq/pull/3375