### PR TITLE
fix: stabilize enterprise E2E dependencies and quota test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1033,6 +1033,7 @@ project(':core') {
     implementation ('org.apache.hadoop:hadoop-common:3.4.1') {
       exclude group: 'org.eclipse.jetty', module: '*'
       exclude group: 'com.sun.jersey', module: '*'
+      exclude group: 'com.github.pjfanning', module: 'jersey-json'
     }
     // for hadoop common
     implementation ("org.eclipse.jetty:jetty-webapp:${versions.jetty}")

--- a/tests/kafkatest/automq/quota_test.py
+++ b/tests/kafkatest/automq/quota_test.py
@@ -43,6 +43,7 @@ class QuotaTest(Test):
             ['broker.quota.enabled', 'true'],
             ['broker.quota.produce.bytes', str(broker_quota_in)],
             ['broker.quota.fetch.bytes', str(broker_quota_out)],
+            ['automq.backpressure.enabled', 'false'],
             ['s3.wal.cache.size', str(log_size)],
             ['s3.wal.capacity', str(log_size)],
             ['s3.wal.upload.threshold', str(log_size // 4)],


### PR DESCRIPTION
## Summary

- disable Enterprise backpressure in QuotaTest so explicit fetch quota assertions are not rewritten by QuotaRegulator
- exclude Hadoop's legacy `com.github.pjfanning:jersey-json` from OSS `:core`
- remove the accidental `:core -> hadoop-common -> jersey-json -> jaxb-impl` path instead of adding `istack` to unrelated Trogdor classpaths

## Verification

- `GRADLE_USER_HOME=/tmp/gradle-no-init-automq ./gradlew :core:dependencyInsight --configuration runtimeClasspath --dependency jaxb-impl`
- `GRADLE_USER_HOME=/tmp/gradle-no-init-automq ./gradlew :core:dependencyInsight --configuration runtimeClasspath --dependency jersey-json`
- `GRADLE_USER_HOME=/tmp/gradle-no-init-automq ./gradlew :trogdor:dependencyInsight --configuration runtimeClasspath --dependency jaxb-impl`
- `GRADLE_USER_HOME=/tmp/gradle-no-init-automq ./gradlew :core:clean :trogdor:clean :core:copyDependantLibs :trogdor:copyDependantLibs`
- `python3 -m py_compile opensource/tests/kafkatest/automq/quota_test.py` from the Enterprise parent checkout
