### PR TITLE
fix: e2e test discovery issues for 1.6

### DIFF
--- a/tests/kafkatest/tests/core/consumer_group_command_test.py
+++ b/tests/kafkatest/tests/core/consumer_group_command_test.py
@@ -120,10 +120,7 @@ class ConsumerGroupCommandTest(Test):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
     )
-    def test_describe_consumer_group(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
     def test_describe_consumer_group(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         """
         Tests if ConsumerGroupCommand is describing a consumer group correctly

--- a/tests/kafkatest/tests/core/mirror_maker_test.py
+++ b/tests/kafkatest/tests/core/mirror_maker_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.mirror_maker import MirrorMaker
 from kafkatest.services.security.minikdc import MiniKdc
-from kafkatest.tests.monitor_util import get_monitor_with_offset
+from kafkatest.monitor_util import get_monitor_with_offset
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
 

--- a/tests/kafkatest/tests/streams/streams_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_smoke_test.py
@@ -19,7 +19,7 @@ from ducktape.mark.resource import cluster
 from kafkatest.services.kafka import quorum
 from kafkatest.tests.kafka_test import KafkaTest
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService
-from kafkatest.tests.monitor_util import get_monitor_with_offset
+from kafkatest.monitor_util import get_monitor_with_offset
 
 class StreamsSmokeTest(KafkaTest):
     """


### PR DESCRIPTION
## What changed

Backport the E2E test-discovery fixes from the main-branch test-discovery PR:

- Main PR: https://github.com/AutoMQ/automq/pull/3385
- Workflow-only PR split out separately: https://github.com/AutoMQ/automq/pull/3381
- Base branch: `1.6`
- Commit: `e4056dddc6 fix:e2e test discovery issues`

## Test discovery failures fixed

- `tests/kafkatest/tests/core/consumer_group_command_test.py`
  - Related PR: [#1427 feat: merge from apache kafka 3.8 0971924ebc7e65eb7055010d2400626d31967d8c](https://github.com/AutoMQ/automq/pull/1427)
  - File diff in that PR: [consumer_group_command_test.py](https://github.com/AutoMQ/automq/pull/1427/files#diff-0578900784531532f96c02fb0655cac63e551d429056543622a83bbdaff4be23)
  - Merge commit [`b9bad9d29d`](https://github.com/AutoMQ/automq/commit/b9bad9d29dc86dc880b4a4b6e5d49985f943093e) (`fix merge 3.8 confict`) left duplicated conflict-resolution text around `test_describe_consumer_group`.
  - This PR removes the duplicated `use_new_coordinator` / `group_protocol` fragment and duplicate method declaration while keeping the intended KIP-848 matrix coverage.

- `tests/kafkatest/tests/core/mirror_maker_test.py`
- `tests/kafkatest/tests/streams/streams_smoke_test.py`
  - Related commit: [`03d83fb29c`](https://github.com/AutoMQ/automq/commit/03d83fb29cfec819680fb0b34a8caaa1a07a54b1) (`feat(test): migrate e2e test (#923)`)
  - That migration added `tests/kafkatest/monitor_util.py`, but these two tests imported it as `kafkatest.tests.monitor_util`.
  - Since `tests/kafkatest/tests/monitor_util.py` does not exist on `1.6`, this PR updates both imports to `kafkatest.monitor_util`.

## Verification

- `python3 -m py_compile tests/kafkatest/tests/core/consumer_group_command_test.py tests/kafkatest/tests/core/mirror_maker_test.py tests/kafkatest/tests/streams/streams_smoke_test.py tests/kafkatest/monitor_util.py`
- `git diff --check`
