### PR TITLE
fix: stabilize enterprise E2E on main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1035,6 +1035,7 @@ project(':core') {
     implementation ('org.apache.hadoop:hadoop-common:3.4.1') {
       exclude group: 'org.eclipse.jetty', module: '*'
       exclude group: 'com.sun.jersey', module: '*'
+      exclude group: 'com.github.pjfanning', module: 'jersey-json'
     }
     // for hadoop common
     implementation ("org.eclipse.jetty:jetty-webapp:${versions.jetty}")

--- a/tests/kafkatest/automq/quota_test.py
+++ b/tests/kafkatest/automq/quota_test.py
@@ -41,6 +41,7 @@ class QuotaTest(Test):
         block_size = 256 * 1024 * 1024
         server_prop_overrides = [
             ['broker.quota.enabled', 'true'],
+            ['automq.backpressure.enabled', 'false'],
             ['broker.quota.produce.bytes', str(broker_quota_in)],
             ['broker.quota.fetch.bytes', str(broker_quota_out)],
             ['s3.wal.cache.size', str(log_size)],


### PR DESCRIPTION
## Summary
- Disable AutoMQ backpressure in the quota E2E test so broker quota assertions are not mixed with backpressure throttling.
- Exclude legacy Hadoop jersey-json from core runtimeClasspath to avoid pulling JAXB impl into the flat classpath used by enterprise E2E.

## Verification
- python3 -m py_compile tests/kafkatest/automq/quota_test.py
- GRADLE_USER_HOME=/tmp/gradle-no-init-automq-main ./gradlew :core:dependencyInsight --configuration runtimeClasspath --dependency jaxb-impl
- GRADLE_USER_HOME=/tmp/gradle-no-init-automq-main ./gradlew :core:dependencyInsight --configuration runtimeClasspath --dependency jersey-json

Both dependencyInsight checks report no matching dependencies in :core:runtimeClasspath.

## Related
- Backport/base-1.7 PR: https://github.com/AutoMQ/automq/pull/3382