### PR TITLE
fix: isolate MirrorMaker KRaft cluster IDs

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import json
 import math
 import os.path
@@ -21,7 +20,10 @@ import re
 import signal
 import time
 import subprocess
+# // AutoMQ inject start
+import base64
 import uuid
+# // AutoMQ inject end
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -195,10 +197,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             "collect_default": True}
     }
 
+    # // AutoMQ inject start
     @staticmethod
     def _random_cluster_id():
-        # AutoMQ inject: generate Kafka-compatible ids for tests that run multiple independent KRaft clusters.
         return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
+    # // AutoMQ inject end
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,
                  interbroker_security_protocol=SecurityConfig.PLAINTEXT,
@@ -216,7 +219,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  quorum_info_provider=None,
                  use_new_coordinator=None,
                  project_name=None,# AutoMQ inject
-                 cluster_id=None, # AutoMQ inject
+                 # // AutoMQ inject start
+                 cluster_id=None,
+                 # // AutoMQ inject end
                  ):
         """
         :param context: test context
@@ -289,12 +294,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.quorum_info = quorum.ServiceQuorumInfo.from_test_context(self, context)
         else:
             self.quorum_info = quorum_info_provider(self)
+        # // AutoMQ inject start
         if isolated_kafka is not None:
             self._cluster_id = isolated_kafka._cluster_id
         elif cluster_id is not None:
             self._cluster_id = cluster_id
         else:
             self._cluster_id = config_property.CLUSTER_ID
+        # // AutoMQ inject end
         self.controller_quorum = None # will define below if necessary
         self.isolated_controller_quorum = None # will define below if necessary
         self.configured_for_zk_migration = False
@@ -357,7 +364,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     listener_security_config=listener_security_config,
                     extra_kafka_opts=extra_kafka_opts, tls_version=tls_version,
                     isolated_kafka=self, allow_zk_with_kraft=self.allow_zk_with_kraft,
+                    # // AutoMQ inject start
                     cluster_id=self._cluster_id,
+                    # // AutoMQ inject end
                     server_prop_overrides=server_prop_overrides
                 )
                 self.controller_quorum = self.isolated_controller_quorum
@@ -929,7 +938,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.quorum_info.using_kraft:
             # format log directories if necessary
             kafka_storage_script = self.path.script("kafka-storage.sh", node)
+            # // AutoMQ inject start
             cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, self._cluster_id)
+            # // AutoMQ inject end
             self.logger.info("Running log directory format command...\n%s" % cmd)
             node.account.ssh(cmd)
 
@@ -1690,8 +1701,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def cluster_id(self):
         """ Get the current cluster id
         """
+        # // AutoMQ inject start
         if self.quorum_info.using_kraft:
             return self._cluster_id
+        # // AutoMQ inject end
 
         self.logger.debug("Querying ZooKeeper to retrieve cluster id")
         cluster = self.zk.query("/cluster/id", chroot=self.zk_chroot)

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -197,6 +197,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     @staticmethod
     def _random_cluster_id():
+        # AutoMQ inject: generate Kafka-compatible ids for tests that run multiple independent KRaft clusters.
         return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,
@@ -292,8 +293,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self._cluster_id = isolated_kafka._cluster_id
         elif cluster_id is not None:
             self._cluster_id = cluster_id
-        elif self.quorum_info.using_kraft:
-            self._cluster_id = self._random_cluster_id()
         else:
             self._cluster_id = config_property.CLUSTER_ID
         self.controller_quorum = None # will define below if necessary

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import json
 import math
 import os.path
@@ -20,6 +21,7 @@ import re
 import signal
 import time
 import subprocess
+import uuid
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -193,6 +195,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             "collect_default": True}
     }
 
+    @staticmethod
+    def _random_cluster_id():
+        return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
+
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,
                  interbroker_security_protocol=SecurityConfig.PLAINTEXT,
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
@@ -209,6 +215,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  quorum_info_provider=None,
                  use_new_coordinator=None,
                  project_name=None,# AutoMQ inject
+                 cluster_id=None, # AutoMQ inject
                  ):
         """
         :param context: test context
@@ -281,6 +288,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.quorum_info = quorum.ServiceQuorumInfo.from_test_context(self, context)
         else:
             self.quorum_info = quorum_info_provider(self)
+        if isolated_kafka is not None:
+            self._cluster_id = isolated_kafka._cluster_id
+        elif cluster_id is not None:
+            self._cluster_id = cluster_id
+        elif self.quorum_info.using_kraft:
+            self._cluster_id = self._random_cluster_id()
+        else:
+            self._cluster_id = config_property.CLUSTER_ID
         self.controller_quorum = None # will define below if necessary
         self.isolated_controller_quorum = None # will define below if necessary
         self.configured_for_zk_migration = False
@@ -343,6 +358,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     listener_security_config=listener_security_config,
                     extra_kafka_opts=extra_kafka_opts, tls_version=tls_version,
                     isolated_kafka=self, allow_zk_with_kraft=self.allow_zk_with_kraft,
+                    cluster_id=self._cluster_id,
                     server_prop_overrides=server_prop_overrides
                 )
                 self.controller_quorum = self.isolated_controller_quorum
@@ -914,7 +930,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.quorum_info.using_kraft:
             # format log directories if necessary
             kafka_storage_script = self.path.script("kafka-storage.sh", node)
-            cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, config_property.CLUSTER_ID)
+            cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, self._cluster_id)
             self.logger.info("Running log directory format command...\n%s" % cmd)
             node.account.ssh(cmd)
 
@@ -1676,7 +1692,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         """ Get the current cluster id
         """
         if self.quorum_info.using_kraft:
-            return config_property.CLUSTER_ID
+            return self._cluster_id
 
         self.logger.debug("Querying ZooKeeper to retrieve cluster id")
         cluster = self.zk.query("/cluster/id", chroot=self.zk_chroot)

--- a/tests/kafkatest/tests/core/mirror_maker_test.py
+++ b/tests/kafkatest/tests/core/mirror_maker_test.py
@@ -39,9 +39,13 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.source_zk = ZookeeperService(test_context, num_nodes=1)
         self.target_zk = ZookeeperService(test_context, num_nodes=1)
 
+        # AutoMQ inject: source and target are independent KRaft clusters in AutoMQ's
+        # default quorum mode, so they must not share the object-storage WAL reservation namespace.
         self.source_kafka = KafkaService(test_context, num_nodes=1, zk=self.source_zk,
+                                  cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
         self.target_kafka = KafkaService(test_context, num_nodes=1, zk=self.target_zk,
+                                  cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
         # This will produce to source kafka cluster
         self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.source_kafka, topic=self.topic,

--- a/tests/kafkatest/tests/core/mirror_maker_test.py
+++ b/tests/kafkatest/tests/core/mirror_maker_test.py
@@ -39,7 +39,8 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.source_zk = ZookeeperService(test_context, num_nodes=1)
         self.target_zk = ZookeeperService(test_context, num_nodes=1)
 
-        # AutoMQ inject: source and target are independent KRaft clusters in AutoMQ's
+        # // AutoMQ inject start
+        # Source and target are independent KRaft clusters in AutoMQ's
         # default quorum mode, so they must not share the object-storage WAL reservation namespace.
         self.source_kafka = KafkaService(test_context, num_nodes=1, zk=self.source_zk,
                                   cluster_id=KafkaService._random_cluster_id(),
@@ -47,6 +48,7 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.target_kafka = KafkaService(test_context, num_nodes=1, zk=self.target_zk,
                                   cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
+        # // AutoMQ inject end
         # This will produce to source kafka cluster
         self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.source_kafka, topic=self.topic,
                                            throughput=1000)


### PR DESCRIPTION
## Summary
- keep KafkaService default KRaft cluster id aligned with the Apache Kafka system-test constant
- add an explicit cluster_id override path for AutoMQ system tests
- give MirrorMaker source and target KafkaService instances distinct cluster ids so independent AutoMQ KRaft clusters do not share the S3 WAL reservation namespace
- keep isolated controller quorums on the same cluster id as their broker service and use that id for kafka-storage format / KafkaService.cluster_id()

## Root Cause
Nightly E2E run 26712668301 failed in MirrorMaker because the source and target single-node AutoMQ clusters both formatted with the fixed test cluster id I2eXt9rvSnyhct8BYmW6-w and node.id=1. AutoMQ S3 WAL reservation keys are based on clusterId/nodeId, so the concurrent clusters fenced each other. The fenced source broker force-closed storage, closed the data-plane socket, and MirrorMaker eventually timed out waiting for Resetting offset for partition.

Apache Kafka system tests use a fixed KRaft cluster id by default, which is harmless for local-disk isolated clusters. AutoMQ keeps that default and only overrides the id for MirrorMaker, where two independent clusters run concurrently against a shared object-storage namespace.

## Verification
- python3 -m py_compile tests/kafkatest/services/kafka/kafka.py tests/kafkatest/tests/core/mirror_maker_test.py
- git diff --check