### PR TITLE
fix: stabilize 1.7 nightly E2E reporting

### DIFF
--- a/.github/workflows/nightly-main-e2e.yml
+++ b/.github/workflows/nightly-main-e2e.yml
@@ -99,6 +99,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'AutoMQ' }}
     needs: [ main_e2e_1, main_e2e_2, main_e2e_3, main_e2e_4, main_e2e_5, benchmarks_e2e, connect_e2e_1, connect_e2e_2, connect_e2e_3, streams_e2e, automq_e2e ]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Report results
         run: python3 tests/report_e2e_results.py
         env:

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -83,10 +83,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
     )
-    def test_broker_rolling_bounce(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
     def test_broker_rolling_bounce(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         """
         Verify correct consumer behavior when the brokers are consecutively restarted.
@@ -147,8 +144,6 @@ class OffsetValidationTest(VerifiableConsumerTest):
         clean_shutdown=[True],
         bounce_mode=["all", "rolling"],
         metadata_quorum=[quorum.isolated_kraft],
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
         use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
     )
@@ -411,10 +406,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
     )
-    def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
     def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         partition = TopicPartition(self.TOPIC, 0)
 
@@ -524,10 +516,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
     )
-    def test_group_consumption(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
     def test_group_consumption(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         """
         Verifies correct group rebalance behavior as consumers are started and stopped.


### PR DESCRIPTION
## Summary
- fix the 1.7 nightly summary job by checking out the repository before running tests/report_e2e_results.py
- fix tests/kafkatest/tests/client/consumer_test.py syntax so ducktape can import the test module

## Evidence
- Run https://github.com/AutoMQ/automq/actions/runs/26716428904 summary job failed with: python3: can't open file '/home/runner/work/automq/automq/tests/report_e2e_results.py'
- The same run's main1 job logged: Failed to import kafkatest.tests.client.consumer_test ... SyntaxError ... line 85

## Verification
- python3 -m py_compile tests/kafkatest/tests/client/consumer_test.py
- git diff --check HEAD~2 HEAD