### PR TITLE
fix: isolate 1.7 MirrorMaker KRaft cluster IDs

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import json
 import math
 import os.path
@@ -21,7 +20,10 @@ import re
 import signal
 import time
 import subprocess
+# // AutoMQ inject start
+import base64
 import uuid
+# // AutoMQ inject end
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -195,10 +197,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             "collect_default": True}
     }
 
+    # // AutoMQ inject start
     @staticmethod
     def _random_cluster_id():
-        # AutoMQ inject: generate Kafka-compatible ids for tests that run multiple independent KRaft clusters.
         return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
+    # // AutoMQ inject end
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,
                  interbroker_security_protocol=SecurityConfig.PLAINTEXT,
@@ -963,7 +966,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.quorum_info.using_kraft:
             # format log directories if necessary
             kafka_storage_script = self.path.script("kafka-storage.sh", node)
+            # // AutoMQ inject start
             cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, self._cluster_id)
+            # // AutoMQ inject end
             if self.dynamicRaftQuorum:
                 if self.node_quorum_info.has_controller_role:
                     if self.standalone_controller_bootstrapped:
@@ -1749,8 +1754,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def cluster_id(self):
         """ Get the current cluster id
         """
+        # // AutoMQ inject start
         if self.quorum_info.using_kraft:
             return self._cluster_id
+        # // AutoMQ inject end
 
         self.logger.debug("Querying ZooKeeper to retrieve cluster id")
         cluster = self.zk.query("/cluster/id", chroot=self.zk_chroot)

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -197,6 +197,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     @staticmethod
     def _random_cluster_id():
+        # AutoMQ inject: generate Kafka-compatible ids for tests that run multiple independent KRaft clusters.
         return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import json
 import math
 import os.path
@@ -20,6 +21,7 @@ import re
 import signal
 import time
 import subprocess
+import uuid
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -193,6 +195,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             "collect_default": True}
     }
 
+    @staticmethod
+    def _random_cluster_id():
+        return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=')
+
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT,
                  interbroker_security_protocol=SecurityConfig.PLAINTEXT,
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
@@ -209,7 +215,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  quorum_info_provider=None,
                  use_new_coordinator=None,
                  project_name=None,# AutoMQ inject
-                 dynamicRaftQuorum=False
+                 dynamicRaftQuorum=False,
+                 # // AutoMQ inject start
+                 cluster_id=None,
+                 # // AutoMQ inject end
                  ):
         """
         :param context: test context
@@ -283,6 +292,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.quorum_info = quorum.ServiceQuorumInfo.from_test_context(self, context)
         else:
             self.quorum_info = quorum_info_provider(self)
+        # // AutoMQ inject start
+        if isolated_kafka is not None:
+            self._cluster_id = isolated_kafka._cluster_id
+        elif cluster_id is not None:
+            self._cluster_id = cluster_id
+        else:
+            self._cluster_id = config_property.CLUSTER_ID
+        # // AutoMQ inject end
         self.controller_quorum = None # will define below if necessary
         self.isolated_controller_quorum = None # will define below if necessary
         self.configured_for_zk_migration = False
@@ -349,6 +366,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     listener_security_config=listener_security_config,
                     extra_kafka_opts=extra_kafka_opts, tls_version=tls_version,
                     isolated_kafka=self, allow_zk_with_kraft=self.allow_zk_with_kraft,
+                    # // AutoMQ inject start
+                    cluster_id=self._cluster_id,
+                    # // AutoMQ inject end
                     server_prop_overrides=server_prop_overrides, dynamicRaftQuorum=self.dynamicRaftQuorum
                 )
                 self.controller_quorum = self.isolated_controller_quorum
@@ -942,7 +962,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.quorum_info.using_kraft:
             # format log directories if necessary
             kafka_storage_script = self.path.script("kafka-storage.sh", node)
-            cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, config_property.CLUSTER_ID)
+            cmd = "%s format --ignore-formatted --config %s --cluster-id %s" % (kafka_storage_script, KafkaService.CONFIG_FILE, self._cluster_id)
             if self.dynamicRaftQuorum:
                 if self.node_quorum_info.has_controller_role:
                     if self.standalone_controller_bootstrapped:
@@ -1729,7 +1749,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         """ Get the current cluster id
         """
         if self.quorum_info.using_kraft:
-            return config_property.CLUSTER_ID
+            return self._cluster_id
 
         self.logger.debug("Querying ZooKeeper to retrieve cluster id")
         cluster = self.zk.query("/cluster/id", chroot=self.zk_chroot)

--- a/tests/kafkatest/tests/core/mirror_maker_test.py
+++ b/tests/kafkatest/tests/core/mirror_maker_test.py
@@ -39,9 +39,13 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.source_zk = ZookeeperService(test_context, num_nodes=1)
         self.target_zk = ZookeeperService(test_context, num_nodes=1)
 
+        # AutoMQ inject: source and target are independent KRaft clusters in AutoMQ's
+        # default quorum mode, so they must not share the object-storage WAL reservation namespace.
         self.source_kafka = KafkaService(test_context, num_nodes=1, zk=self.source_zk,
+                                  cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
         self.target_kafka = KafkaService(test_context, num_nodes=1, zk=self.target_zk,
+                                  cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
         # This will produce to source kafka cluster
         self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.source_kafka, topic=self.topic,

--- a/tests/kafkatest/tests/core/mirror_maker_test.py
+++ b/tests/kafkatest/tests/core/mirror_maker_test.py
@@ -39,7 +39,8 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.source_zk = ZookeeperService(test_context, num_nodes=1)
         self.target_zk = ZookeeperService(test_context, num_nodes=1)
 
-        # AutoMQ inject: source and target are independent KRaft clusters in AutoMQ's
+        # // AutoMQ inject start
+        # Source and target are independent KRaft clusters in AutoMQ's
         # default quorum mode, so they must not share the object-storage WAL reservation namespace.
         self.source_kafka = KafkaService(test_context, num_nodes=1, zk=self.source_zk,
                                   cluster_id=KafkaService._random_cluster_id(),
@@ -47,6 +48,7 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
         self.target_kafka = KafkaService(test_context, num_nodes=1, zk=self.target_zk,
                                   cluster_id=KafkaService._random_cluster_id(),
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
+        # // AutoMQ inject end
         # This will produce to source kafka cluster
         self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.source_kafka, topic=self.topic,
                                            throughput=1000)


### PR DESCRIPTION
## Summary
- backport the MirrorMaker-scoped KRaft cluster id isolation from #3387 to the 1.7 branch
- keep the default KafkaService cluster id fixed; only MirrorMaker source/target clusters get explicit distinct ids
- preserve 1.7 dynamicRaftQuorum handling while passing the broker cluster id to isolated controllers

## Evidence
- 1.7 nightly run https://github.com/AutoMQ/automq/actions/runs/26716428904 has 12 MirrorMaker failures in main3, matching the main-branch failure group fixed by #3387
- targeted main-branch rerun for #3387 succeeded: https://github.com/AutoMQ/automq/actions/runs/26738274053

## Verification
- python3 -m py_compile tests/kafkatest/services/kafka/kafka.py tests/kafkatest/tests/core/mirror_maker_test.py
- git diff --check origin/1.7..HEAD