### PR TITLE
fix: retry delete objects per key (#3392)

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -1150,25 +1150,6 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         }
     }
 
-    static class DeleteObjectsException extends Exception {
-        private final List<String> failedKeys;
-        private final List<String> errorsMessages;
-
-        public DeleteObjectsException(String message, List<String> failedKeys, List<String> errorsMessage) {
-            super(message);
-            this.failedKeys = failedKeys;
-            this.errorsMessages = errorsMessage;
-        }
-
-        public List<String> getFailedKeys() {
-            return failedKeys;
-        }
-
-        public List<String> getErrorsMessages() {
-            return errorsMessages;
-        }
-    }
-
     public static class ObjectStorageCompletedPart {
         private final int partNumber;
         private final String partId;

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -35,9 +35,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -96,6 +99,9 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     // use the root logger to log the error to both log file and stdout
     private static final Logger READINESS_CHECK_LOGGER = LoggerFactory.getLogger("ObjectStorageReadinessCheck");
     public static final String S3_API_NO_SUCH_KEY = "NoSuchKey";
+    private static final Set<String> RETRIABLE_DELETE_OBJECT_ERROR_CODES = Set.of(
+        "InternalError", "ServiceUnavailable", "SlowDown", "RequestTimeout", "OperationAborted");
+    private static final int DELETE_OBJECT_ERROR_LOG_SAMPLE_LIMIT = 10;
     public static final String PATH_STYLE_KEY = "pathStyle";
     public static final String CHECKSUM_ALGORITHM_KEY = "checksumAlgorithm";
 
@@ -151,26 +157,55 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         return new Builder();
     }
 
-    void checkDeleteObjectsResponse(DeleteObjectsResponse response) throws Exception {
-        int errDeleteCount = 0;
-        ArrayList<String> failedKeys = new ArrayList<>();
-        ArrayList<String> errorsMessages = new ArrayList<>();
+    void checkDeleteObjectsResponse(DeleteObjectsResponse response, List<String> objectKeys) throws Exception {
+        Set<String> successKeys = new HashSet<>(objectKeys);
+        Map<String, DeleteObjectError> retriableKeys = new HashMap<>();
+        Map<String, DeleteObjectError> failedKeys = new HashMap<>();
         for (S3Error error : response.errors()) {
             if (S3_API_NO_SUCH_KEY.equals(error.code())) {
                 // ignore for delete objects.
                 continue;
             }
-            if (errDeleteCount < 5) {
-                logger.error("Delete objects for key [{}] error code [{}] message [{}]",
-                    error.key(), error.code(), error.message());
+            successKeys.remove(error.key());
+            DeleteObjectError deleteObjectError = new DeleteObjectError(error.code(), -1, error.message());
+            if (RETRIABLE_DELETE_OBJECT_ERROR_CODES.contains(error.code())) {
+                retriableKeys.put(error.key(), deleteObjectError);
+            } else {
+                failedKeys.put(error.key(), deleteObjectError);
             }
-            failedKeys.add(error.key());
-            errorsMessages.add(error.message());
-            errDeleteCount++;
         }
-        if (errDeleteCount > 0) {
-            throw new DeleteObjectsException("Failed to delete objects", failedKeys, errorsMessages);
+        logDeleteObjectErrors(retriableKeys, failedKeys);
+        if (!retriableKeys.isEmpty() || !failedKeys.isEmpty()) {
+            throw new DeleteObjectsException("Failed to delete objects", successKeys, retriableKeys, failedKeys);
         }
+    }
+
+    private void logDeleteObjectErrors(Map<String, DeleteObjectError> retriableKeys,
+        Map<String, DeleteObjectError> failedKeys) {
+        if (!retriableKeys.isEmpty() && logger.isWarnEnabled()) {
+            logger.warn("Delete objects retriable failures, count={}, samples={}",
+                retriableKeys.size(), formatDeleteObjectErrors(retriableKeys));
+        }
+        if (!failedKeys.isEmpty() && logger.isErrorEnabled()) {
+            logger.error("Delete objects failed, count={}, samples={}",
+                failedKeys.size(), formatDeleteObjectErrors(failedKeys));
+        }
+    }
+
+    private String formatDeleteObjectErrors(Map<String, DeleteObjectError> errors) {
+        StringBuilder builder = new StringBuilder();
+        int count = 0;
+        for (Map.Entry<String, DeleteObjectError> entry : errors.entrySet()) {
+            if (count >= DELETE_OBJECT_ERROR_LOG_SAMPLE_LIMIT) {
+                break;
+            }
+            if (count > 0) {
+                builder.append(", ");
+            }
+            builder.append('(').append(entry.getKey()).append(", ").append(entry.getValue()).append(')');
+            count++;
+        }
+        return builder.toString();
     }
 
     @Override
@@ -315,18 +350,53 @@ public class AwsObjectStorage extends AbstractObjectStorage {
             writeS3Client.deleteObjects(request)
                 .thenAccept(resp -> {
                     try {
-                        checkDeleteObjectsResponse(resp);
+                        checkDeleteObjectsResponse(resp, objectKeys);
                         cf.complete(null);
                     } catch (Throwable ex) {
                         cf.completeExceptionally(ex);
                     }
                 })
                 .exceptionally(ex -> {
-                    cf.completeExceptionally(ex);
+                    cf.completeExceptionally(toDeleteObjectsException(objectKeys, cause(ex)));
                     return null;
                 });
             return cf;
         }, S3Operation.DELETE_OBJECTS, 0);
+    }
+
+    private DeleteObjectsException toDeleteObjectsException(List<String> objectKeys, Throwable ex) {
+        DeleteObjectError error = deleteObjectError(ex);
+        Map<String, DeleteObjectError> retriableKeys = new HashMap<>();
+        Map<String, DeleteObjectError> failedKeys = new HashMap<>();
+        Map<String, DeleteObjectError> target = isRetriableDeleteError(error) ? retriableKeys : failedKeys;
+        objectKeys.forEach(key -> target.put(key, error));
+        logDeleteObjectErrors(retriableKeys, failedKeys);
+        return new DeleteObjectsException("Failed to delete objects", Set.of(), retriableKeys, failedKeys);
+    }
+
+    private boolean isRetriableDeleteError(DeleteObjectError error) {
+        return isRetriableDeleteStatus(error.statusCode())
+            || RETRIABLE_DELETE_OBJECT_ERROR_CODES.contains(error.code());
+    }
+
+    private boolean isRetriableDeleteStatus(int statusCode) {
+        return statusCode == HttpStatusCode.THROTTLING
+            || statusCode == HttpStatusCode.REQUEST_TIMEOUT
+            || statusCode == HttpStatusCode.INTERNAL_SERVER_ERROR
+            || statusCode == HttpStatusCode.BAD_GATEWAY
+            || statusCode == HttpStatusCode.SERVICE_UNAVAILABLE
+            || statusCode == HttpStatusCode.GATEWAY_TIMEOUT;
+    }
+
+    private DeleteObjectError deleteObjectError(Throwable ex) {
+        if (ex instanceof S3Exception s3Ex) {
+            String code = s3Ex.awsErrorDetails() == null ? "Unknown" : s3Ex.awsErrorDetails().errorCode();
+            return new DeleteObjectError(code, s3Ex.statusCode(), s3Ex.getMessage());
+        }
+        if (ex instanceof ApiCallAttemptTimeoutException || ex instanceof TimeoutException || ex instanceof SdkClientException) {
+            return new DeleteObjectError(ex.getClass().getSimpleName(), HttpStatusCode.SERVICE_UNAVAILABLE, ex.getMessage());
+        }
+        return new DeleteObjectError(ex.getClass().getSimpleName(), -1, ex.getMessage());
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectError.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectError.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.operator;
+
+public class DeleteObjectError {
+    private final String code;
+    private final int statusCode;
+    private final String message;
+
+    public DeleteObjectError(String code, int statusCode, String message) {
+        this.code = code == null ? "Unknown" : code;
+        this.statusCode = statusCode;
+        this.message = message == null ? "" : message;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "code=" + code + ",status=" + statusCode + ",message=" + message;
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsAccumulator.java
@@ -22,6 +22,7 @@ package com.automq.stream.s3.operator;
 import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.metrics.stats.S3OperationStats;
 import com.automq.stream.utils.FutureUtil;
+import com.automq.stream.utils.Threads;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.slf4j.Logger;
@@ -29,8 +30,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Semaphore;
@@ -43,6 +47,8 @@ public class DeleteObjectsAccumulator {
     static final Logger LOGGER = LoggerFactory.getLogger(DeleteObjectsAccumulator.class);
     public static final int DEFAULT_DELETE_OBJECTS_MAX_BATCH_SIZE = 1000;
     public static final int DEFAULT_DELETE_OBJECTS_MAX_CONCURRENT_REQUEST_NUMBER = 100;
+    private static final long DELETE_OBJECTS_RETRY_BASE_DELAY_MS = 1000;
+    private static final long DELETE_OBJECTS_RETRY_MAX_DELAY_MS = 30 * 1000;
     private static final long DELETE_OPERATION_LOG_INTERVAL = 60 * 1000;
     private final Function<List<String>, CompletableFuture<Void>> deleteObjectsFunction;
     private final ConcurrentLinkedDeque<PendingDeleteRequest> deleteRequestQueue = new ConcurrentLinkedDeque<>();
@@ -68,10 +74,17 @@ public class DeleteObjectsAccumulator {
     static class PendingDeleteRequest {
         List<ObjectStorage.ObjectPath> deleteObjectPath;
         CompletableFuture<Void> future;
+        int retryAttempt;
 
         public PendingDeleteRequest(List<ObjectStorage.ObjectPath> deleteObjectPath, CompletableFuture<Void> future) {
+            this(deleteObjectPath, future, 0);
+        }
+
+        public PendingDeleteRequest(List<ObjectStorage.ObjectPath> deleteObjectPath, CompletableFuture<Void> future,
+            int retryAttempt) {
             this.deleteObjectPath = deleteObjectPath;
             this.future = future;
+            this.retryAttempt = retryAttempt;
         }
     }
 
@@ -112,7 +125,7 @@ public class DeleteObjectsAccumulator {
                 if (!deleteRequestQueue.isEmpty()) {
                     deleteRequestQueue.add(new PendingDeleteRequest(subBatchList, subBatchCf));
                     // try to submit pending requests
-                } else if (!submitDeleteObjectsRequest(subBatchList, List.of(subBatchCf))) {
+                } else if (!submitDeleteObjectsRequest(List.of(new PendingDeleteRequest(subBatchList, subBatchCf)))) {
                     // if not submitted, add to queue
                     deleteRequestQueue.add(new PendingDeleteRequest(subBatchList, subBatchCf));
                 }
@@ -128,32 +141,114 @@ public class DeleteObjectsAccumulator {
             }).exceptionally(cf::completeExceptionally);
     }
 
-    private boolean submitDeleteObjectsRequest(List<ObjectStorage.ObjectPath> objectPaths, List<CompletableFuture<Void>> subBatchCf) {
+    private boolean submitDeleteObjectsRequest(List<PendingDeleteRequest> requests) {
         if (!concurrentRequestLimiter.tryAcquire()) {
             return false;
         }
+        List<ObjectStorage.ObjectPath> objectPaths = requests.stream()
+            .flatMap(request -> request.deleteObjectPath.stream())
+            .collect(Collectors.toList());
         List<String> objectKeys = objectPaths.stream().map(ObjectStorage.ObjectPath::key).collect(Collectors.toList());
         TimerUtil timerUtil = new TimerUtil();
         deleteObjectsFunction.apply(objectKeys).whenComplete((res, e) -> concurrentRequestLimiter.release())
             .thenAccept(nil -> {
                 deleteOperationSummary.recordDeleteOperation(objectKeys.size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS), true, Collections.emptyList());
                 S3OperationStats.getInstance().deleteObjectsStats(true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-                FutureUtil.complete(subBatchCf.iterator(), null);
+                completeRequests(requests);
                 handleDeleteRequestQueue();
             }).exceptionally(ex -> {
                 Throwable cause = ex.getCause();
-                if (cause instanceof AbstractObjectStorage.DeleteObjectsException) {
-                    AbstractObjectStorage.DeleteObjectsException deleteObjectsException = (AbstractObjectStorage.DeleteObjectsException) cause;
+                if (cause instanceof DeleteObjectsException) {
+                    DeleteObjectsException deleteObjectsException = (DeleteObjectsException) cause;
                     deleteOperationSummary.recordDeleteOperation(objectKeys.size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS), false, deleteObjectsException.getFailedKeys());
+                    handleDeleteObjectsException(requests, deleteObjectsException);
                 } else {
                     S3OperationStats.getInstance().deleteObjectsStats(false).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
                     deleteOperationSummary.recordDeleteOperation(objectKeys.size(), timerUtil.elapsedAs(TimeUnit.NANOSECONDS), false, Collections.emptyList());
+                    completeRequestsExceptionally(requests, ex);
                 }
-                FutureUtil.completeExceptionally(subBatchCf.iterator(), ex);
                 handleDeleteRequestQueue();
                 return null;
             });
         return true;
+    }
+
+    private void completeRequests(List<PendingDeleteRequest> requests) {
+        FutureUtil.complete(requests.stream().map(request -> request.future).iterator(), null);
+    }
+
+    private void completeRequestsExceptionally(List<PendingDeleteRequest> requests, Throwable ex) {
+        FutureUtil.completeExceptionally(requests.stream().map(request -> request.future).iterator(), ex);
+    }
+
+    private void handleDeleteObjectsException(List<PendingDeleteRequest> requests,
+        DeleteObjectsException ex) {
+        Set<String> retriableKeys = ex.getRetriableKeys().keySet();
+        Set<String> failedKeys = ex.getFailedKeyErrors().keySet();
+        for (PendingDeleteRequest request : requests) {
+            List<ObjectStorage.ObjectPath> requestRetriablePaths = request.deleteObjectPath.stream()
+                .filter(path -> retriableKeys.contains(path.key()))
+                .collect(Collectors.toList());
+            Map<String, DeleteObjectError> requestFailedKeys = request.deleteObjectPath.stream()
+                .filter(path -> failedKeys.contains(path.key()))
+                .collect(Collectors.toMap(ObjectStorage.ObjectPath::key, path -> ex.getFailedKeyErrors().get(path.key())));
+
+            if (requestRetriablePaths.isEmpty()) {
+                if (!requestFailedKeys.isEmpty()) {
+                    completeRequestWithFailedKeys(request.future, requestFailedKeys);
+                } else {
+                    request.future.complete(null);
+                }
+            } else if (requestFailedKeys.isEmpty()) {
+                scheduleRetry(new PendingDeleteRequest(requestRetriablePaths, request.future, request.retryAttempt + 1));
+            } else {
+                CompletableFuture<Void> retryFuture = new CompletableFuture<>();
+                retryFuture.whenComplete((nil, retryEx) -> {
+                    Map<String, DeleteObjectError> failedKeyErrors = new HashMap<>(requestFailedKeys);
+                    DeleteObjectsException retryDeleteException = deleteObjectsException(retryEx);
+                    if (retryDeleteException != null) {
+                        failedKeyErrors.putAll(retryDeleteException.getFailedKeyErrors());
+                    }
+                    completeRequestWithFailedKeys(request.future, failedKeyErrors);
+                });
+                scheduleRetry(new PendingDeleteRequest(requestRetriablePaths, retryFuture, request.retryAttempt + 1));
+            }
+        }
+    }
+
+    private void scheduleRetry(PendingDeleteRequest request) {
+        Threads.COMMON_SCHEDULER.schedule(() -> submitOrQueue(request), retryDelayMs(request.retryAttempt), TimeUnit.MILLISECONDS);
+    }
+
+    private long retryDelayMs(int retryAttempt) {
+        int shift = Math.max(0, Math.min(retryAttempt - 1, 5));
+        return Math.min(DELETE_OBJECTS_RETRY_BASE_DELAY_MS << shift, DELETE_OBJECTS_RETRY_MAX_DELAY_MS);
+    }
+
+    private DeleteObjectsException deleteObjectsException(Throwable ex) {
+        if (ex instanceof DeleteObjectsException deleteObjectsException) {
+            return deleteObjectsException;
+        }
+        if (ex != null && ex.getCause() instanceof DeleteObjectsException deleteObjectsException) {
+            return deleteObjectsException;
+        }
+        return null;
+    }
+
+    private void completeRequestWithFailedKeys(CompletableFuture<Void> future, Map<String, DeleteObjectError> failedKeys) {
+        future.completeExceptionally(new DeleteObjectsException(
+            "Failed to delete objects", Collections.emptySet(), Collections.emptyMap(), failedKeys));
+    }
+
+    private void submitOrQueue(PendingDeleteRequest request) {
+        queueLock.lock();
+        try {
+            if (!deleteRequestQueue.isEmpty() || !submitDeleteObjectsRequest(List.of(request))) {
+                deleteRequestQueue.add(request);
+            }
+        } finally {
+            queueLock.unlock();
+        }
     }
 
     private void handleDeleteRequestQueue() {
@@ -187,16 +282,8 @@ public class DeleteObjectsAccumulator {
 
     private void submitPendingRequests(List<PendingDeleteRequest> pendingRequests) {
         // merge all delete requests
-        List<ObjectStorage.ObjectPath> combinedPaths = new ArrayList<>();
-        List<CompletableFuture<Void>> combinedFutures = new ArrayList<>();
-
-        for (PendingDeleteRequest request : pendingRequests) {
-            combinedPaths.addAll(request.deleteObjectPath);
-            combinedFutures.add(request.future);
-        }
-
         // submit delete requests
-        boolean isSubmit = submitDeleteObjectsRequest(combinedPaths, combinedFutures);
+        boolean isSubmit = submitDeleteObjectsRequest(pendingRequests);
 
         // if not submitted, add back to queue
         if (!isSubmit) {

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsException.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DeleteObjectsException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.operator;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DeleteObjectsException extends Exception {
+    private static final int UNKNOWN_STATUS_CODE = -1;
+    private final Set<String> successKeys;
+    private final Map<String, DeleteObjectError> retriableKeys;
+    private final Map<String, DeleteObjectError> failedKeys;
+
+    public DeleteObjectsException(String message, List<String> failedKeys, List<String> errorsMessage) {
+        super(message);
+        this.successKeys = Set.of();
+        this.retriableKeys = Map.of();
+        Map<String, DeleteObjectError> keyErrors = new HashMap<>();
+        for (int i = 0; i < failedKeys.size(); i++) {
+            String errorMessage = i < errorsMessage.size() ? errorsMessage.get(i) : "";
+            keyErrors.put(failedKeys.get(i), new DeleteObjectError("Unknown", UNKNOWN_STATUS_CODE, errorMessage));
+        }
+        this.failedKeys = Map.copyOf(keyErrors);
+    }
+
+    public DeleteObjectsException(String message, Set<String> successKeys,
+        Map<String, DeleteObjectError> retriableKeys,
+        Map<String, DeleteObjectError> failedKeys) {
+        super(message);
+        this.successKeys = Set.copyOf(successKeys);
+        this.retriableKeys = Map.copyOf(retriableKeys);
+        this.failedKeys = Map.copyOf(failedKeys);
+    }
+
+    public Set<String> getSuccessKeys() {
+        return successKeys;
+    }
+
+    public Map<String, DeleteObjectError> getRetriableKeys() {
+        return retriableKeys;
+    }
+
+    public List<String> getFailedKeys() {
+        return List.copyOf(failedKeys.keySet());
+    }
+
+    public List<String> getErrorsMessages() {
+        return failedKeys.values().stream().map(DeleteObjectError::message).toList();
+    }
+
+    public Map<String, DeleteObjectError> getFailedKeyErrors() {
+        return failedKeys;
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
@@ -3,10 +3,15 @@ package com.automq.stream.s3.operator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Set;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Error;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -39,5 +44,24 @@ public class AwsObjectStorageTest {
         basicCredentials = (AwsBasicCredentials) credentials;
         Assertions.assertEquals("ak", basicCredentials.accessKeyId());
         Assertions.assertEquals("sk", basicCredentials.secretAccessKey());
+    }
+
+    @Test
+    void testCheckDeleteObjectsResponseClassifiesPerKeyErrors() {
+        AwsObjectStorage storage = new AwsObjectStorage(null, "bucket");
+        DeleteObjectsResponse response = DeleteObjectsResponse.builder()
+            .errors(
+                S3Error.builder().key("missing").code("NoSuchKey").message("missing").build(),
+                S3Error.builder().key("retry").code("SlowDown").message("slow down").build(),
+                S3Error.builder().key("fail").code("AccessDenied").message("denied").build())
+            .build();
+
+        DeleteObjectsException ex = Assertions.assertThrows(
+            DeleteObjectsException.class,
+            () -> storage.checkDeleteObjectsResponse(response, List.of("ok", "missing", "retry", "fail")));
+
+        Assertions.assertEquals(Set.of("ok", "missing"), ex.getSuccessKeys());
+        Assertions.assertTrue(ex.getRetriableKeys().containsKey("retry"));
+        Assertions.assertTrue(ex.getFailedKeyErrors().containsKey("fail"));
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/DeleteObjectsAccumulatorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/DeleteObjectsAccumulatorTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.automq.stream.s3.operator.DeleteObjectsAccumulator.LOGGER;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -226,6 +227,101 @@ public class DeleteObjectsAccumulatorTest {
         });
 
         assertEquals(ioSize * ioNumber, totalDeleteObjectNumber.get());
+    }
+
+    @Test
+    void testRetriableKeysAreRetriedWithoutResendingSuccessfulKeys() {
+        Map<String, AtomicInteger> deleteAttempts = new ConcurrentHashMap<>();
+        Function<List<String>, CompletableFuture<Void>> deleteFunction = path -> {
+            path.forEach(key -> deleteAttempts.computeIfAbsent(key, ignored -> new AtomicInteger()).incrementAndGet());
+            if (path.contains("retry-once") && deleteAttempts.get("retry-once").get() == 1) {
+                return CompletableFuture.failedFuture(new DeleteObjectsException(
+                    "retry one key",
+                    Set.of("ok"),
+                    Map.of("retry-once", new DeleteObjectError("SlowDown", 503, "slow down")),
+                    Map.of()));
+            }
+            return CompletableFuture.completedFuture(null);
+        };
+
+        DeleteObjectsAccumulator accumulator = new DeleteObjectsAccumulator(10, 10, deleteFunction);
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+
+        accumulator.batchDeleteObjects(List.of(
+            new ObjectStorage.ObjectPath((short) 0, "ok"),
+            new ObjectStorage.ObjectPath((short) 0, "retry-once")
+        ), cf);
+
+        cf.join();
+        assertEquals(1, deleteAttempts.get("ok").get());
+        assertEquals(2, deleteAttempts.get("retry-once").get());
+    }
+
+    @Test
+    void testFailedKeysOnlyFailOwningFutureInMergedBatch() {
+        CompletableFuture<Void> firstCall = new CompletableFuture<>();
+        AtomicInteger callCount = new AtomicInteger();
+        Function<List<String>, CompletableFuture<Void>> deleteFunction = path -> {
+            if (callCount.incrementAndGet() == 1) {
+                return firstCall;
+            }
+            return CompletableFuture.failedFuture(new DeleteObjectsException(
+                "one key failed",
+                Set.of("success-key"),
+                Map.of(),
+                Map.of("failed-key", new DeleteObjectError("AccessDenied", 403, "denied"))));
+        };
+
+        DeleteObjectsAccumulator accumulator = new DeleteObjectsAccumulator(10, 1, deleteFunction);
+        CompletableFuture<Void> blockedCf = new CompletableFuture<>();
+        CompletableFuture<Void> failedCf = new CompletableFuture<>();
+        CompletableFuture<Void> successCf = new CompletableFuture<>();
+
+        accumulator.batchDeleteObjects(List.of(new ObjectStorage.ObjectPath((short) 0, "blocked-key")), blockedCf);
+        accumulator.batchDeleteObjects(List.of(new ObjectStorage.ObjectPath((short) 0, "failed-key")), failedCf);
+        accumulator.batchDeleteObjects(List.of(new ObjectStorage.ObjectPath((short) 0, "success-key")), successCf);
+
+        firstCall.complete(null);
+
+        blockedCf.join();
+        successCf.join();
+        assertTrue(failedCf.isCompletedExceptionally());
+    }
+
+    @Test
+    void testRetriableKeysAreStillRetriedWhenOwningFutureHasFailedKeys() {
+        Map<String, AtomicInteger> deleteAttempts = new ConcurrentHashMap<>();
+        CompletableFuture<Void> retryFuture = new CompletableFuture<>();
+        Function<List<String>, CompletableFuture<Void>> deleteFunction = path -> {
+            path.forEach(key -> deleteAttempts.computeIfAbsent(key, ignored -> new AtomicInteger()).incrementAndGet());
+            if (path.contains("retry-key") && deleteAttempts.get("retry-key").get() == 1) {
+                return CompletableFuture.failedFuture(new DeleteObjectsException(
+                    "mixed failure",
+                    Set.of(),
+                    Map.of("retry-key", new DeleteObjectError("SlowDown", 503, "slow down")),
+                    Map.of("failed-key", new DeleteObjectError("AccessDenied", 403, "denied"))));
+            }
+            if (path.contains("retry-key")) {
+                return retryFuture;
+            }
+            return CompletableFuture.completedFuture(null);
+        };
+
+        DeleteObjectsAccumulator accumulator = new DeleteObjectsAccumulator(10, 10, deleteFunction);
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+
+        accumulator.batchDeleteObjects(List.of(
+            new ObjectStorage.ObjectPath((short) 0, "retry-key"),
+            new ObjectStorage.ObjectPath((short) 0, "failed-key")
+        ), cf);
+
+        assertFalse(cf.isDone());
+        await().atMost(2, TimeUnit.SECONDS).until(() -> deleteAttempts.get("retry-key").get() == 2);
+        retryFuture.complete(null);
+        await().atMost(1, TimeUnit.SECONDS).until(cf::isCompletedExceptionally);
+        assertTrue(cf.isCompletedExceptionally());
+        assertEquals(2, deleteAttempts.get("retry-key").get());
+        assertEquals(1, deleteAttempts.get("failed-key").get());
     }
 
     @Test


### PR DESCRIPTION
- add detailed DeleteObjectsException/DeleteObjectError for batch delete failures
- classify delete failures per key as retriable or failed and retry only retriable keys
- add indefinite retriable delete retry with exponential backoff capped at 30s
- limit delete error log samples to 10 entries