### PR TITLE
test: stabilize combined kraft snapshot e2e

### DIFF
--- a/tests/kafkatest/tests/core/snapshot_test.py
+++ b/tests/kafkatest/tests/core/snapshot_test.py
@@ -26,6 +26,9 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
 import random
+# AutoMQ inject start
+import re
+# AutoMQ inject end
 import time
 
 class TestSnapshots(ProduceConsumeValidateTest):
@@ -126,6 +129,39 @@ class TestSnapshots(ProduceConsumeValidateTest):
         else:
             self.logger.debug("File %s was found" % file_path)
             return True
+
+    # AutoMQ inject start
+    def wait_for_cleaned_controller_node(self, node):
+        if self.kafka.isolated_controller_quorum:
+            time.sleep(10)
+            return
+
+        node_id = self.kafka.idx(node)
+        describe_node = next(n for n in self.kafka.nodes if n != node)
+        automq_cli_script = self.kafka.path.script("automq-cli.sh", describe_node)
+        bootstrap_servers = self.kafka.bootstrap_servers(offline_nodes=[node])
+        node_pattern = re.compile(r"NodeMetadata\{nodeId=%d\b[^}]*hasOpeningStreams=(true|false)" % node_id)
+
+        def has_no_opening_streams():
+            cmd = "%s cluster describe --bootstrap-server %s" % (automq_cli_script, bootstrap_servers)
+            try:
+                output = self.kafka.run_cli_tool(describe_node, cmd)
+            except Exception:
+                self.logger.debug("Failed to describe AutoMQ nodes while waiting for node %d failover", node_id,
+                                  exc_info=True)
+                return False
+
+            match = node_pattern.search(output)
+            if match is None:
+                self.logger.debug("AutoMQ node %d is not visible yet in cluster describe output: %s", node_id, output)
+                return False
+            return match.group(1) == "false"
+
+        wait_until(has_no_opening_streams,
+                   timeout_sec=120,
+                   backoff_sec=2,
+                   err_msg="Timed out waiting for AutoMQ failover to close opening streams on node %d" % node_id)
+    # AutoMQ inject end
 
     def validate_success(self, topic = None, group_protocol=None):
         if topic is None:
@@ -252,7 +288,9 @@ class TestSnapshots(ProduceConsumeValidateTest):
         for node in self.controller_nodes:
             self.logger.debug("Restarting node: %s", self.kafka.controller_quorum.who_am_i(node))
             self.kafka.controller_quorum.clean_node(node)
-            time.sleep(10) # AutoMQ inject, try fix the test in azure runner
+            # AutoMQ inject start
+            self.wait_for_cleaned_controller_node(node)
+            # AutoMQ inject end
             self.kafka.controller_quorum.start_node(node)
 
         # Scenario -- Re-init controllers with a clean kafka dir and
@@ -263,7 +301,9 @@ class TestSnapshots(ProduceConsumeValidateTest):
         for node in self.controller_nodes:
             self.logger.debug("Restarting node: %s", self.kafka.controller_quorum.who_am_i(node))
             self.kafka.controller_quorum.clean_node(node)
-            time.sleep(10) # AutoMQ inject
+            # AutoMQ inject start
+            self.wait_for_cleaned_controller_node(node)
+            # AutoMQ inject end
             # Now modify the cluster to create more metadata changes
             self.topics_created += self.create_n_topics(topic_count=5)
             self.kafka.controller_quorum.start_node(node)


### PR DESCRIPTION
## Why

Nightly main2 run `26712668301` failed three `TestSnapshots.test_controller` matrices, all in `COMBINED_KRAFT`.

The startup timeout was not just a slow broker startup. The failed node hit `S3Storage start fail` with `WALFencedException` while verifying `READ_WRITE` WAL permission. At the same time, another node was processing cross-node failover for the cleaned node's old WAL epoch.

This is the same class of WAL reservation race we saw in the Streams hard-bounce investigation, but `snapshot_test.py::test_controller` makes it much easier to trigger: Apache Kafka's upstream test treats this as a controller clean-restart scenario, while AutoMQ combined KRaft means those controller nodes are also brokers with WAL/opening-stream ownership.

## What

- Keep isolated KRaft behavior unchanged.
- For combined KRaft, after `clean_node`, wait until `automq-cli.sh cluster describe` reports the cleaned node with `hasOpeningStreams=false` before restarting it.
- Mark the AutoMQ-only logic with `AutoMQ inject` comments.

This keeps the test aligned with the actual AutoMQ lifecycle: do not start same-node WAL recovery until the old WAL ownership has been failover-cleaned.

## Testing

- `python3 -m py_compile tests/kafkatest/tests/core/snapshot_test.py`
- `git diff --check`
- Local ducktape targeted rerun:

```bash
tests/docker/ducker-ak test tests/kafkatest/tests/core/snapshot_test.py::TestSnapshots.test_controller -- --parameters '{"metadata_quorum":"COMBINED_KRAFT","use_new_coordinator":false}' --test-runner-timeout 1800000
```

Result: PASS, session `2026-06-01--012`, runtime `8 minutes 42.292 seconds`.
