### PR TITLE
test: run 1.7 compatibility e2e on x86

### DIFF
--- a/.github/workflows/nightly-main-e2e.yml
+++ b/.github/workflows/nightly-main-e2e.yml
@@ -13,6 +13,14 @@ jobs:
       suite-id: "main1"
       test-yaml: "tests/suites/main_kos_test_suite1.yml"
       runner: "ubicloud-standard-8-arm-ubuntu-2204"
+  main_compatibility_e2e:
+    name: "Run Main Compatibility E2E Tests"
+    uses: ./.github/workflows/e2e-run.yml
+    if: ${{ github.repository_owner == 'AutoMQ' }}
+    with:
+      suite-id: "main_compatibility"
+      test-yaml: "tests/suites/main_kos_compatibility_test_suite.yml"
+      runner: "ubicloud-standard-8-ubuntu-2204"
   main_e2e_2:
     name: "Run Main E2E Tests 2"
     uses: ./.github/workflows/e2e-run.yml
@@ -97,7 +105,7 @@ jobs:
     runs-on: "ubicloud-standard-8-arm-ubuntu-2204"
     name: "E2E Tests Summary"
     if: ${{ always() && github.repository_owner == 'AutoMQ' }}
-    needs: [ main_e2e_1, main_e2e_2, main_e2e_3, main_e2e_4, main_e2e_5, benchmarks_e2e, connect_e2e_1, connect_e2e_2, connect_e2e_3, streams_e2e, automq_e2e ]
+    needs: [ main_e2e_1, main_compatibility_e2e, main_e2e_2, main_e2e_3, main_e2e_4, main_e2e_5, benchmarks_e2e, connect_e2e_1, connect_e2e_2, connect_e2e_3, streams_e2e, automq_e2e ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -107,5 +115,5 @@ jobs:
           CURRENT_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           WEB_HOOK_URL: ${{ secrets.E2E_REPORT_WEB_HOOK_URL }}
-          DATA_MAP: "{\"main_e2e_1\": ${{ toJSON(needs.main_e2e_1.outputs) }}, \"main_e2e_2\": ${{ toJSON(needs.main_e2e_2.outputs) }}, \"main_e2e_3\": ${{ toJSON(needs.main_e2e_3.outputs) }}, \"main_e2e_4\": ${{ toJSON(needs.main_e2e_4.outputs) }}, \"main_e2e_5\": ${{ toJSON(needs.main_e2e_5.outputs) }}, \"benchmarks_e2e\": ${{ toJSON(needs.benchmarks_e2e.outputs) }}, \"connect_e2e_1\": ${{ toJSON(needs.connect_e2e_1.outputs) }}, \"connect_e2e_2\": ${{ toJSON(needs.connect_e2e_2.outputs) }}, \"connect_e2e_3\": ${{ toJSON(needs.connect_e2e_3.outputs) }}, \"streams_e2e\": ${{ toJSON(needs.streams_e2e.outputs) }}, \"automq_e2e\": ${{ toJSON(needs.automq_e2e.outputs) }}}"
+          DATA_MAP: "{\"main_e2e_1\": ${{ toJSON(needs.main_e2e_1.outputs) }}, \"main_compatibility_e2e\": ${{ toJSON(needs.main_compatibility_e2e.outputs) }}, \"main_e2e_2\": ${{ toJSON(needs.main_e2e_2.outputs) }}, \"main_e2e_3\": ${{ toJSON(needs.main_e2e_3.outputs) }}, \"main_e2e_4\": ${{ toJSON(needs.main_e2e_4.outputs) }}, \"main_e2e_5\": ${{ toJSON(needs.main_e2e_5.outputs) }}, \"benchmarks_e2e\": ${{ toJSON(needs.benchmarks_e2e.outputs) }}, \"connect_e2e_1\": ${{ toJSON(needs.connect_e2e_1.outputs) }}, \"connect_e2e_2\": ${{ toJSON(needs.connect_e2e_2.outputs) }}, \"connect_e2e_3\": ${{ toJSON(needs.connect_e2e_3.outputs) }}, \"streams_e2e\": ${{ toJSON(needs.streams_e2e.outputs) }}, \"automq_e2e\": ${{ toJSON(needs.automq_e2e.outputs) }}}"
           REPORT_TITLE_PREFIX: "Main"

--- a/tests/suites/main_kos_compatibility_test_suite.yml
+++ b/tests/suites/main_kos_compatibility_test_suite.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The old Kafka client compatibility tests use historical client binary
+# distributions. Keep them on x86_64 so their bundled native dependencies,
+# such as snappy-java, run in the architecture they support.
+core_test_suite:
+  included:
+    - ../kafkatest/tests/core/compatibility_test_new_broker_test.py

--- a/tests/suites/main_kos_test_suite1.yml
+++ b/tests/suites/main_kos_test_suite1.yml
@@ -20,7 +20,6 @@ core_test_suite:
     - ../kafkatest/tests/client
     - ../kafkatest/tests/tools
     - ../kafkatest/tests/core/authorizer_test.py
-    - ../kafkatest/tests/core/compatibility_test_new_broker_test.py
     - ../kafkatest/tests/core/consume_bench_test.py
 
   # exclude zk tests and other no-needed tests
@@ -31,4 +30,3 @@ core_test_suite:
     - ../kafkatest/tests/client/message_format_change_test.py::MessageFormatChangeTest.test_compatibility
     # unclean election or truncation will not happen in KOS
     - ../kafkatest/tests/client/truncation_test.py::TruncationTest.test_offset_truncate
-


### PR DESCRIPTION
Backport of #3394 to `1.7`.

## Why

Old Kafka compatibility clients that use `snappy` depend on bundled `snappy-java` versions that do not work reliably on Linux `aarch64`. Keeping those historical client runtimes unchanged is more faithful to compatibility testing than injecting a newer runtime jar.

## What

- Move `compatibility_test_new_broker_test.py` out of `main1`.
- Add a dedicated `main_compatibility` suite.
- Run that suite on the x86 runner `ubicloud-standard-8-ubuntu-2204`.
- Include the new job in the nightly summary map.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-main-e2e.yml"); YAML.load_file("tests/suites/main_kos_test_suite1.yml"); YAML.load_file("tests/suites/main_kos_compatibility_test_suite.yml"); puts "yaml ok"'`
- `git diff --check origin/1.7...HEAD`
