### PR TITLE
test: backport static consumer fencing fix

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1815,7 +1815,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 return False
         return True
 
-    def list_consumer_groups(self, node=None, command_config=None):
+    def list_consumer_groups(self, node=None, command_config=None,
+                             # // AutoMQ inject start
+                             state=None, type=None,
+                             # // AutoMQ inject end
+                             ):
         """ Get list of consumer groups.
         """
         if node is None:
@@ -1832,6 +1836,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
               (consumer_group_script,
                self.bootstrap_servers(self.security_protocol),
                command_config)
+        # // AutoMQ inject start
+        if state is not None:
+            cmd += " --state %s" % state
+        if type is not None:
+            cmd += " --type %s" % type
+        # // AutoMQ inject end
         return self.run_cli_tool(node, cmd)
 
     def describe_consumer_group(self, group, node=None, command_config=None):

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -50,11 +50,17 @@ class ConsumerEventHandler(object):
         self.committed = {}
         self.total_consumed = 0
         self.verify_offsets = verify_offsets
+        # // AutoMQ inject start
+        self.shutdown_complete = False
+        # // AutoMQ inject end
 
     def handle_shutdown_complete(self, node=None, logger=None):
         self.state = ConsumerState.Dead
         self.assignment = []
         self.position = {}
+        # // AutoMQ inject start
+        self.shutdown_complete = True
+        # // AutoMQ inject end
 
         if node is not None and logger is not None:
             logger.debug("Shut down %s" % node.account.hostname)
@@ -253,6 +259,9 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                 else:
                     self.event_handlers[node] = IncrementalAssignmentConsumerEventHandler(node, self.verify_offsets, idx)
             handler = self.event_handlers[node]
+            # // AutoMQ inject start
+            handler.shutdown_complete = False
+            # // AutoMQ inject end
 
         node.account.ssh("mkdir -p %s" % VerifiableConsumer.PERSISTENT_ROOT, allow_fail=False)
 
@@ -479,6 +488,13 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         with self.lock:
             return [handler.node for handler in self.event_handlers.values()
                     if handler.state != ConsumerState.Dead]
+
+    # // AutoMQ inject start
+    def shutdown_complete_nodes(self):
+        with self.lock:
+            return [handler.node for handler in self.event_handlers.values()
+                    if handler.shutdown_complete]
+    # // AutoMQ inject end
 
     def is_consumer_group_protocol_enabled(self):
         return self.group_protocol and self.group_protocol.upper() == "CONSUMER"

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -74,6 +74,16 @@ class OffsetValidationTest(VerifiableConsumerTest):
         self.mark_for_collect(consumer, 'verifiable_consumer_stdout')
         return consumer
 
+    # // AutoMQ inject start
+    def await_conflict_consumers_fenced(self, conflict_consumer):
+        # Rely on explicit shutdown_complete events from the verifiable consumer to guarantee each conflict member
+        # reached the fenced path rather than remaining in the default DEAD state prior to startup.
+        wait_until(lambda: len(conflict_consumer.shutdown_complete_nodes()) == len(conflict_consumer.nodes) and
+                           len(conflict_consumer.dead_nodes()) == len(conflict_consumer.nodes),
+                   timeout_sec=60,
+                   err_msg="Timed out waiting for conflict consumers to report shutdown completion after fencing")
+    # // AutoMQ inject end
+
     @cluster(num_nodes=7)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
@@ -349,6 +359,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
         if fencing_stage == "stable":
             consumer.start()
             self.await_members(consumer, len(consumer.nodes))
+            # // AutoMQ inject start
+            self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=120)
+            # // AutoMQ inject end
 
             num_rebalances = consumer.num_rebalances()
             conflict_consumer.start()
@@ -366,16 +379,29 @@ class OffsetValidationTest(VerifiableConsumerTest):
                 assert num_rebalances == consumer.num_rebalances(), "Static consumers attempt to join with instance id in use should not cause a rebalance"
                 assert len(consumer.joined_nodes()) == len(consumer.nodes)
                 assert len(conflict_consumer.joined_nodes()) == 0
-                
+
+                # // AutoMQ inject start
+                # Conflict consumers will terminate due to a fatal UnreleasedInstanceIdException error.
+                # Wait for termination to complete to prevent conflict consumers from immediately re-joining the group while existing nodes are shutting down.
+                self.await_conflict_consumers_fenced(conflict_consumer)
+                # // AutoMQ inject end
+
                 # Stop existing nodes, so conflicting ones should be able to join.
                 consumer.stop_all()
                 wait_until(lambda: len(consumer.dead_nodes()) == len(consumer.nodes),
                            timeout_sec=self.session_timeout_sec+5,
                            err_msg="Timed out waiting for the consumer to shutdown")
+
+                # // AutoMQ inject start
+                # Wait until the group becomes empty to ensure the instance ID is released.
+                wait_until(lambda: self.group_id in self.kafka.list_consumer_groups(state="empty"),
+                           timeout_sec=self.session_timeout_sec,
+                           err_msg="Timed out waiting for the consumers to be removed from the group")
+                # // AutoMQ inject end
+
                 conflict_consumer.start()
                 self.await_members(conflict_consumer, num_conflict_consumers)
 
-            
         else:
             consumer.start()
             conflict_consumer.start()

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -87,3 +87,14 @@ class VerifiableConsumerTest(KafkaTest):
         
     def await_all_members(self, consumer):
         self.await_members(consumer, self.num_consumers)
+
+    # // AutoMQ inject start
+    def await_all_members_stabilized(self, topic, num_partitions, consumer, timeout_sec):
+        # Wait until the group is in STABLE state and the consumers reconcile to a valid assignment.
+        wait_until(lambda: self.group_id in self.kafka.list_consumer_groups(state="stable"),
+                   timeout_sec=timeout_sec,
+                   err_msg="Timed out waiting for group %s to transition to STABLE state." % self.group_id)
+        wait_until(lambda: self.valid_assignment(topic, num_partitions, consumer.current_assignment()),
+                   timeout_sec=timeout_sec,
+                   err_msg="Timeout awaiting for the consumers to reconcile to a valid assignment.")
+    # // AutoMQ inject end


### PR DESCRIPTION
## Summary

Backport Apache Kafka upstream PR apache/kafka#20772 for
`OffsetValidationTest.test_fencing_static_consumer`.

Upstream PR:

https://github.com/apache/kafka/pull/20772

This PR updates the consumer-protocol static-member fencing path to:

- wait until the first batch of conflicting static consumers has fully terminated;
- stop the original static consumers;
- wait until the consumer group becomes `empty`, so the static instance ids are released;
- start the replacement conflicting consumers only after the previous holders are gone.

The backported E2E changes are marked with `// AutoMQ inject start` / `// AutoMQ inject end`.

## Root Cause

The failing Enterprise E2E case was:

```text
OffsetValidationTest.test_fencing_static_consumer
num_conflict_consumers=2
fencing_stage=stable
metadata_quorum=ISOLATED_KRAFT
use_new_coordinator=True
group_protocol=consumer
```

For the consumer group protocol, conflicting static members with an already-owned
`group.instance.id` should not be able to join and should not trigger a rebalance of
the existing members.

The old test flow only asserted that the conflicting consumers did not join:

```python
assert len(conflict_consumer.joined_nodes()) == 0
```

However, "not joined" does not guarantee that those processes have already exited.
They can still be alive while going through the fatal `UnreleasedInstanceIdException`
fencing path. The test then stopped the original consumers and called
`conflict_consumer.start()` again on the same service. That could leave the old and
new conflicting processes racing with the same static instance ids inside the test
itself.

So this is a test-flow race, not a broker-side static membership semantic change.

## Why Enterprise Exposed It

AutoMQ 1.7 inherits the older Apache Kafka 3.9 test flow. Apache Kafka trunk has
already fixed this flow in apache/kafka#20772.

OSS E2E may not always hit the race because it depends on timing: whether the first
batch of conflicting consumers finishes shutdown before the original static members
are stopped and before the service is started again. Enterprise E2E can expose this
more reliably because the Enterprise overlay and CI runtime can change process,
broker, and client timing. The product semantics are not different here; the
Enterprise run made the pre-existing test race visible.

## Changes

- Add shutdown-completion tracking to `VerifiableConsumer`.
- Add `shutdown_complete_nodes()` for tests that need to wait for explicit consumer
  shutdown completion.
- Add `state` / `type` filters to `KafkaService.list_consumer_groups()`.
- Update `test_fencing_static_consumer` to wait for conflicting consumers to
  terminate and for the group to become `empty` before reusing the same static
  instance ids.

## Verification

- `python3 -m py_compile tests/kafkatest/tests/client/consumer_test.py tests/kafkatest/tests/verifiable_consumer_test.py tests/kafkatest/services/kafka/kafka.py tests/kafkatest/services/verifiable_consumer.py`
- `git diff --check HEAD~1..HEAD`
- Exact local ducktape rerun passed:

```text
session_id: 2026-06-03--008
test_id: kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=2.fencing_stage=stable.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=True.group_protocol=consumer
passed: 1
failed: 0
ignored: 0
run time: 2 minutes 34.538 seconds
```
