### PR TITLE
test: fix connect sink coordinator matrix

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -365,12 +365,19 @@ class ConnectDistributedTest(Test):
                    err_msg="Failed to produce messages after resuming source connector")
 
     @cluster(num_nodes=5)
+    # // AutoMQ inject start
     @matrix(
         connect_protocol=['sessioned', 'compatible', 'eager'],
         metadata_quorum=[quorum.isolated_kraft],
-        use_new_coordinator=[True, False],
+        use_new_coordinator=[False]
+    )
+    @matrix(
+        connect_protocol=['sessioned', 'compatible', 'eager'],
+        metadata_quorum=[quorum.isolated_kraft],
+        use_new_coordinator=[True],
         group_protocol=consumer_group.all_group_protocols
     )
+    # // AutoMQ inject end
     def test_pause_and_resume_sink(self, connect_protocol, metadata_quorum, use_new_coordinator=False, group_protocol=None):
         """
         Verify that sink connectors stop consuming records when paused and begin again after


### PR DESCRIPTION
## Summary

This PR fixes the `ConnectDistributedTest.test_pause_and_resume_sink` system test matrix so that the KIP-848 `consumer` group protocol is only exercised with the new group coordinator enabled.

The failed Enterprise Connect E2E run generated invalid combinations such as:

```text
metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=False.group_protocol=consumer
```

Those combinations make the sink connector consumer send `GroupHeartbeatRequest` while the broker is configured for the old/classic coordinator only. The worker then fails with `UNSUPPORTED_VERSION` and the test eventually times out waiting for sink records.

## Root Cause

This is a test matrix merge/backport issue, not a Connect sink pause/resume product bug.

Apache Kafka upstream introduced `group_protocol=consumer_group.all_group_protocols` in `KAFKA-16272` / apache/kafka#15594, but the upstream matrix kept the old and new coordinator cases separate:

- `use_new_coordinator=False`: no `group_protocol` dimension
- `use_new_coordinator=True`: runs all group protocols

This PR is related to the earlier AutoMQ backport PR AutoMQ/automq#2616 and its commit [`47a4517a4de`](https://github.com/AutoMQ/automq/commit/47a4517a4de) (`fix(e2e): cherry pick fix e2e 1.5`). That commit unintentionally changed this upstream structure in `test_pause_and_resume_sink` by removing the standalone old-coordinator matrix and collapsing the remaining matrix to:

```python
use_new_coordinator=[True, False],
group_protocol=consumer_group.all_group_protocols
```

That was the problematic part of the backport: it preserved the upstream `group_protocol` dimension but expanded it to the old coordinator path as well. As a result, ducktape generated `use_new_coordinator=False + group_protocol=consumer`, which Apache Kafka's original matrix did not generate.

The broker-side system test service also follows the upstream `KAFKA-16390` semantics: `group.coordinator.rebalance.protocols=classic,consumer` is only configured when `use_new_coordinator=True`; otherwise only `classic` is enabled. Therefore the observed `GroupHeartbeatRequest failed due to UNSUPPORTED_VERSION` is expected for the invalid matrix.

## Changes

- Split `test_pause_and_resume_sink` back into two matrix decorators:
  - old coordinator: `use_new_coordinator=False`, no `group_protocol` parameter
  - new coordinator: `use_new_coordinator=True`, all group protocols
- Marked the E2E matrix adjustment with `# // AutoMQ inject start` / `# // AutoMQ inject end`.
- No timeout or behavioral assertion was relaxed.

## Verification

- `rtk python3 -m py_compile repos/automq-connect-matrix-fix/tests/kafkatest/tests/connect/connect_distributed_test.py`
- `rtk git -C repos/automq-connect-matrix-fix diff --check`
- AST inspection confirmed the generated decorators no longer combine `use_new_coordinator=False` with `group_protocol=consumer_group.all_group_protocols`.

A full ducktape rerun was not executed in this step because the invalid matrix is removed rather than made passable; adjacent valid combinations should be covered by the next Connect E2E CI run.
