### PR TITLE
test: align streams system test dev version

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -122,7 +122,9 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("3.9.1-SNAPSHOT")
+# // AutoMQ inject start
+DEV_VERSION = KafkaVersion("3.9.1")
+# // AutoMQ inject end
 
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
 LATEST_STABLE_METADATA_VERSION = "3.9-IV0"


### PR DESCRIPTION
## Summary

This PR aligns the system test `DEV_VERSION` with the release version used by the current `1.7` build:

```text
gradle.properties: version=3.9.1
tests/kafkatest/version.py: DEV_VERSION=3.9.1
```

The Enterprise Streams E2E run was failing because `StreamsUpgradeTest` expected the current build to print `Kafka version.*3.9.1.*SNAPSHOT`, while the actual test applications printed `Kafka version: 3.9.1`.

## Root Cause

This is a version metadata mismatch in the system tests, not a Streams runtime failure.

Apache Kafka already fixed this release-branch case in apache/kafka#19534 (`MINOR: Update system test dev version to 3.9.1`), which changed `tests/kafkatest/version.py` from `3.9.1-SNAPSHOT` to `3.9.1`.

AutoMQ currently has `gradle.properties` set to `version=3.9.1`, but a later AutoMQ commit [`141693270b2`](https://github.com/AutoMQ/automq/commit/141693270b2) changed only `tests/kafkatest/version.py` back to:

```python
DEV_VERSION = KafkaVersion("3.9.1-SNAPSHOT")
```

That is why `StreamsUpgradeTest.get_version_string()` built a SNAPSHOT probe pattern even though the actual artifacts are release-versioned.

## Evidence

The failing Enterprise Streams E2E run generated timeouts such as:

```text
Could not detect Kafka Streams version 3.9.1-SNAPSHOT
```

Artifacts show the applications were running and repeatedly printed:

```text
Kafka version: 3.9.1
```

So this is not a startup timeout or broker availability issue. The test was waiting for the wrong version string.

## Changes

- Updated `tests/kafkatest/version.py` so `DEV_VERSION = KafkaVersion("3.9.1")`.
- Marked the E2E system-test version adjustment with `# // AutoMQ inject start` / `# // AutoMQ inject end`.
- No timeout or Streams behavior was changed.

## Verification

- `rtk python3 -m py_compile repos/automq-streams-version-fix/tests/kafkatest/version.py repos/automq-streams-version-fix/tests/kafkatest/tests/streams/streams_upgrade_test.py repos/automq-streams-version-fix/tests/kafkatest/tests/streams/streams_application_upgrade_test.py`
- `rtk git -C repos/automq-streams-version-fix diff --check`
- A lightweight semantic check confirmed:
  - `gradle.properties version == DEV_VERSION == 3.9.1`
  - `StreamsUpgradeTest.get_version_string(str(DEV_VERSION))` now resolves to `Kafka version: 3.9.1`

A full ducktape rerun was not executed in this step; the next Streams E2E CI run should cover the affected upgrade/version-probing cases.
