### PR TITLE
test: backport static consumer fencing fix

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1762,7 +1762,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 return False
         return True
 
-    def list_consumer_groups(self, node=None, command_config=None):
+    def list_consumer_groups(self, node=None, command_config=None,
+                             # // AutoMQ inject start
+                             state=None, type=None,
+                             # // AutoMQ inject end
+                             ):
         """ Get list of consumer groups.
         """
         if node is None:
@@ -1779,6 +1783,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
               (consumer_group_script,
                self.bootstrap_servers(self.security_protocol),
                command_config)
+        # // AutoMQ inject start
+        if state is not None:
+            cmd += " --state %s" % state
+        if type is not None:
+            cmd += " --type %s" % type
+        # // AutoMQ inject end
         return self.run_cli_tool(node, cmd)
 
     def describe_consumer_group(self, group, node=None, command_config=None):

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -50,11 +50,17 @@ class ConsumerEventHandler(object):
         self.committed = {}
         self.total_consumed = 0
         self.verify_offsets = verify_offsets
+        # // AutoMQ inject start
+        self.shutdown_complete = False
+        # // AutoMQ inject end
 
     def handle_shutdown_complete(self, node=None, logger=None):
         self.state = ConsumerState.Dead
         self.assignment = []
         self.position = {}
+        # // AutoMQ inject start
+        self.shutdown_complete = True
+        # // AutoMQ inject end
 
         if node is not None and logger is not None:
             logger.debug("Shut down %s" % node.account.hostname)
@@ -253,6 +259,9 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                 else:
                     self.event_handlers[node] = IncrementalAssignmentConsumerEventHandler(node, self.verify_offsets, idx)
             handler = self.event_handlers[node]
+            # // AutoMQ inject start
+            handler.shutdown_complete = False
+            # // AutoMQ inject end
 
         node.account.ssh("mkdir -p %s" % VerifiableConsumer.PERSISTENT_ROOT, allow_fail=False)
 
@@ -479,6 +488,13 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         with self.lock:
             return [handler.node for handler in self.event_handlers.values()
                     if handler.state != ConsumerState.Dead]
+
+    # // AutoMQ inject start
+    def shutdown_complete_nodes(self):
+        with self.lock:
+            return [handler.node for handler in self.event_handlers.values()
+                    if handler.shutdown_complete]
+    # // AutoMQ inject end
 
     def is_consumer_group_protocol_enabled(self):
         return self.group_protocol and self.group_protocol.upper() == "CONSUMER"

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -74,6 +74,16 @@ class OffsetValidationTest(VerifiableConsumerTest):
         self.mark_for_collect(consumer, 'verifiable_consumer_stdout')
         return consumer
 
+    # // AutoMQ inject start
+    def await_conflict_consumers_fenced(self, conflict_consumer):
+        # Rely on explicit shutdown_complete events from the verifiable consumer to guarantee each conflict member
+        # reached the fenced path rather than remaining in the default DEAD state prior to startup.
+        wait_until(lambda: len(conflict_consumer.shutdown_complete_nodes()) == len(conflict_consumer.nodes) and
+                           len(conflict_consumer.dead_nodes()) == len(conflict_consumer.nodes),
+                   timeout_sec=60,
+                   err_msg="Timed out waiting for conflict consumers to report shutdown completion after fencing")
+    # // AutoMQ inject end
+
     @cluster(num_nodes=7)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
@@ -349,6 +359,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
         if fencing_stage == "stable":
             consumer.start()
             self.await_members(consumer, len(consumer.nodes))
+            # // AutoMQ inject start
+            self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=120)
+            # // AutoMQ inject end
 
             num_rebalances = consumer.num_rebalances()
             conflict_consumer.start()
@@ -366,16 +379,29 @@ class OffsetValidationTest(VerifiableConsumerTest):
                 assert num_rebalances == consumer.num_rebalances(), "Static consumers attempt to join with instance id in use should not cause a rebalance"
                 assert len(consumer.joined_nodes()) == len(consumer.nodes)
                 assert len(conflict_consumer.joined_nodes()) == 0
-                
+
+                # // AutoMQ inject start
+                # Conflict consumers will terminate due to a fatal UnreleasedInstanceIdException error.
+                # Wait for termination to complete to prevent conflict consumers from immediately re-joining the group while existing nodes are shutting down.
+                self.await_conflict_consumers_fenced(conflict_consumer)
+                # // AutoMQ inject end
+
                 # Stop existing nodes, so conflicting ones should be able to join.
                 consumer.stop_all()
                 wait_until(lambda: len(consumer.dead_nodes()) == len(consumer.nodes),
                            timeout_sec=self.session_timeout_sec+5,
                            err_msg="Timed out waiting for the consumer to shutdown")
+
+                # // AutoMQ inject start
+                # Wait until the group becomes empty to ensure the instance ID is released.
+                wait_until(lambda: self.group_id in self.kafka.list_consumer_groups(state="empty"),
+                           timeout_sec=self.session_timeout_sec,
+                           err_msg="Timed out waiting for the consumers to be removed from the group")
+                # // AutoMQ inject end
+
                 conflict_consumer.start()
                 self.await_members(conflict_consumer, num_conflict_consumers)
 
-            
         else:
             consumer.start()
             conflict_consumer.start()

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -87,3 +87,14 @@ class VerifiableConsumerTest(KafkaTest):
         
     def await_all_members(self, consumer):
         self.await_members(consumer, self.num_consumers)
+
+    # // AutoMQ inject start
+    def await_all_members_stabilized(self, topic, num_partitions, consumer, timeout_sec):
+        # Wait until the group is in STABLE state and the consumers reconcile to a valid assignment.
+        wait_until(lambda: self.group_id in self.kafka.list_consumer_groups(state="stable"),
+                   timeout_sec=timeout_sec,
+                   err_msg="Timed out waiting for group %s to transition to STABLE state." % self.group_id)
+        wait_until(lambda: self.valid_assignment(topic, num_partitions, consumer.current_assignment()),
+                   timeout_sec=timeout_sec,
+                   err_msg="Timeout awaiting for the consumers to reconcile to a valid assignment.")
+    # // AutoMQ inject end


### PR DESCRIPTION
## Summary

Cherry-pick the static consumer fencing test fix from AutoMQ/automq#3400 to `main`.

This keeps `main` aligned with the Apache Kafka upstream fix in apache/kafka#20772 and the already-merged AutoMQ `1.7` backport.

## Root Cause

`OffsetValidationTest.test_fencing_static_consumer` reuses the same static `group.instance.id` values for conflict consumers after stopping the original static members.

For the consumer group protocol path, the conflict consumers are expected to fail with `UnreleasedInstanceIdException`. The old test flow did not wait for those conflict consumers to fully terminate before stopping the original consumers and restarting the conflict consumers with the same instance ids. That left a race where the old conflict processes could still hold or immediately retry the same static member identities.

Apache Kafka fixed this in apache/kafka#20772 by waiting for the fenced conflict consumers and for the group to become empty before reusing the static instance ids. AutoMQ `1.7` already carries the same fix via AutoMQ/automq#3400. `main` did not yet contain it.

## Changes

- Track verifiable consumer shutdown completion explicitly.
- Add a helper to wait for all members to reach a stable assignment.
- In the consumer group protocol branch, wait for conflict consumers to be fenced and for the group to become empty before restarting them.
- Extend `KafkaService.list_consumer_groups` with `--state` and `--type` filters needed by the test.
- Mark the E2E-specific backport with `# // AutoMQ inject start` / `# // AutoMQ inject end`.

## Verification

- `python3 -m py_compile tests/kafkatest/tests/client/consumer_test.py tests/kafkatest/tests/verifiable_consumer_test.py tests/kafkatest/services/kafka/kafka.py tests/kafkatest/services/verifiable_consumer.py`
- `git diff --check HEAD~1..HEAD`

The same fix was locally verified for the original failing Enterprise E2E matrix before merging AutoMQ/automq#3400 into `1.7`.
