### PR TITLE
feat: add retry storm backoff (#3380)

### DIFF
--- a/.agents/coding-conventions.md
+++ b/.agents/coding-conventions.md
@@ -1,0 +1,39 @@
+---
+last_updated: 2026-05-28
+---
+
+# Coding Conventions
+
+## 1. Language Choice
+
+- AutoMQ runtime code is Java-first.
+- New production classes should be Java unless they are tightly extending an
+  existing Scala-only Kafka integration surface.
+- Avoid adding new Scala runtime types for standalone AutoMQ behavior.
+- If a change touches an existing Scala class, keep the edit local and do not
+  migrate unrelated code just to satisfy the Java-first rule.
+
+## 2. Documentation
+
+- Code comments and Javadocs are written in English.
+- New public classes should have class docs that describe responsibility and
+  boundary.
+- New public methods should have method docs that describe behavior, inputs,
+  outputs, state changes, lifecycle effects, or failure semantics when relevant.
+- Avoid comments that only repeat the method or field name.
+
+## 3. Scope Control
+
+- Prefer existing Kafka/AutoMQ abstractions and module boundaries.
+- Do not introduce new dependencies when the JDK or existing project utilities
+  are enough.
+- For stateful runtime code, make ownership of lifecycle, concurrency, and
+  cleanup explicit in the API or class documentation.
+
+## 4. Kafka Fork Markers
+
+- When adding or changing AutoMQ logic inside an existing Kafka source file,
+  wrap the logic with `// AutoMQ inject start` and `// AutoMQ inject end`.
+- Do not add inject markers around import-only changes.
+- Keep marker ranges small so future Kafka upstream merges can identify the
+  AutoMQ-owned behavior.

--- a/.agents/review.md
+++ b/.agents/review.md
@@ -1,0 +1,28 @@
+---
+last_updated: 2026-05-29
+---
+
+# Review Conventions
+
+## 1. Review Range
+
+- Review pull requests against the target branch full diff, such as
+  `origin/1.7...HEAD`.
+- Do not limit review to the latest commit unless the user explicitly asks for
+  an incremental review.
+
+## 2. Repository Rules
+
+- Check new production and test classes against the Java-first rule in
+  `coding-conventions.md` and `testing.md`.
+- Check new public class, public method, and test method docs against the
+  documentation rules in `coding-conventions.md` and `testing.md`.
+- Check AutoMQ changes inside existing Kafka source files for narrow
+  `// AutoMQ inject start` and `// AutoMQ inject end` markers.
+
+## 3. Verification
+
+- Before claiming an AutoMQ coding task is done, confirm the required local gate
+  from `testing.md` has passed.
+- Treat CI failures as review feedback: reproduce or inspect the failing gate,
+  fix the cause, and rerun the relevant local command before handing off.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -1,0 +1,59 @@
+---
+last_updated: 2026-05-29
+---
+
+# Testing Conventions
+
+## 1. Language Choice
+
+- New AutoMQ tests are Java-first.
+- Add Scala tests only when extending an existing Scala test class is clearly
+  lower-risk than creating a Java test.
+
+## 2. Test Documentation
+
+- Test method docs are written in English.
+- Each new test method should describe the scenario or contract being protected.
+- Prefer Given/When/Then wording for rule-heavy behavior and edge cases.
+- Avoid comments that only restate the test method name.
+
+## 3. Tagged Test Selection
+
+- AutoMQ CI commonly runs tagged test tasks instead of every Gradle test task.
+- New focused AutoMQ unit tests should be tagged with `@Tag("S3Unit")` when
+  they are expected to run in the tagged S3Unit selection.
+- When verifying AutoMQ changes locally, prefer the workflow-style tagged
+  selection when the change is broad enough:
+
+```bash
+./gradlew --build-cache metadata:S3UnitTest core:S3UnitTest s3stream:test
+```
+
+- For narrow changes, run focused `core:S3UnitTest --tests ...` first, then
+  broaden to the workflow-style selection before handing off.
+- When adding E2E coverage, include the test in the appropriate
+  `tests/suites/automq_test_suite*.yml` suite so the CI selection can discover
+  it.
+
+## 4. Required Completion Gate
+
+- Before claiming an AutoMQ coding task is done, run the CI-style formatting,
+  license, and checkstyle gate:
+
+```bash
+./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck
+```
+
+- Do not replace this gate with focused unit tests. Run it in addition to the
+  relevant focused or tagged test selection for the change.
+
+## 5. Checkstyle Suppression
+
+- Use narrow `@SuppressWarnings` only when the rule conflicts with a deliberate
+  structure, such as enum-switch hot-path classification, schema dispatch, or a
+  test class that must cover many generated protocol data types together.
+- Prefer fixing ordinary style issues, unused imports, missing locale, and
+  low-cost complexity reductions instead of suppressing them.
+- When suppressing a Checkstyle rule in code, keep the annotation at the
+  smallest practical scope and include the `checkstyle:` prefix when suppressing
+  a specific method-level Checkstyle rule.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,29 @@ on:
     branches: [ "main" ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build:
+              - '**'
+              - '!.agents/**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!specs/**'
   build-automq:
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.build == 'true' }}
     uses: ./.github/workflows/build_automq.yml
   build-result:
     runs-on: ubuntu-latest
-    needs: [ build-automq ]
+    needs: [ changes, build-automq ]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AutoMQ Agent Instructions
+
+This repository is the open-source AutoMQ Kafka fork.
+
+Follow this file first when working with coding agents. The detailed,
+progressively loaded rules live in `.agents/`.
+
+## Context Loading
+
+- Before changing production code, read `.agents/coding-conventions.md`.
+- Before adding or changing tests, read `.agents/testing.md`.
+- Before reviewing or handing off a PR, read `.agents/review.md`.
+
+## Core Rules
+
+- Keep changes scoped to the requested task and the existing Kafka/AutoMQ module
+  boundaries.
+- Follow `.agents/coding-conventions.md` for language choice, public docs, scope
+  control, and Kafka fork markers.
+- Follow `.agents/testing.md` for focused tests, tagged test selection, required
+  completion gates, SpotBugs, E2E suite registration, and suppression rules.
+- Follow `.agents/review.md` for PR review range, repository rule checks, and
+  CI failure handling.
+
+## Verification
+
+Do not claim an AutoMQ coding task is complete without running the relevant
+verification from `.agents/testing.md` and recording any command that could not
+be run.

--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
+import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.ConfigDef.Type.BOOLEAN;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
@@ -192,6 +193,15 @@ public class AutoMQConfig {
     public static final String S3_BACK_PRESSURE_COOLDOWN_MS_DOC = "The cooldown time in milliseconds to wait between two regulator actions";
     public static final long S3_BACK_PRESSURE_COOLDOWN_MS_DEFAULT = TimeUnit.SECONDS.toMillis(15);
 
+    public static final String RETRY_STORM_BACKOFF_ENABLED_CONFIG = "automq.retry.storm.backoff.enabled";
+    public static final String RETRY_STORM_BACKOFF_ENABLED_DOC = "Whether retry storm delayed response backoff is enabled";
+    public static final boolean RETRY_STORM_BACKOFF_ENABLED_DEFAULT = false;
+
+    public static final String RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG = "automq.retry.storm.backoff.max.delay.ms";
+    public static final String RETRY_STORM_BACKOFF_MAX_DELAY_MS_DOC = "The maximum retry storm delayed response time in milliseconds, from 0 to 10000";
+    public static final long RETRY_STORM_BACKOFF_MAX_DELAY_MS_DEFAULT = 1000L;
+    public static final long RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX = TimeUnit.SECONDS.toMillis(10);
+
     public static final String TABLE_TOPIC_SCHEMA_REGISTRY_URL_CONFIG = "automq.table.topic.schema.registry.url";
     private static final String TABLE_TOPIC_SCHEMA_REGISTRY_URL_DOC = "The schema registry url for table topic";
     public static final String TABLE_TOPIC_SCHEMA_REGISTRY_CONFIG_PREFIX = "automq.table.topic.schema.registry.config.";
@@ -293,6 +303,8 @@ public class AutoMQConfig {
             .define(AutoMQConfig.S3_TELEMETRY_METRICS_BASE_LABELS_CONFIG, STRING, null, MEDIUM, AutoMQConfig.S3_TELEMETRY_METRICS_BASE_LABELS_DOC)
             .define(AutoMQConfig.S3_BACK_PRESSURE_ENABLED_CONFIG, BOOLEAN, AutoMQConfig.S3_BACK_PRESSURE_ENABLED_DEFAULT, MEDIUM, AutoMQConfig.S3_BACK_PRESSURE_ENABLED_DOC)
             .define(AutoMQConfig.S3_BACK_PRESSURE_COOLDOWN_MS_CONFIG, LONG, AutoMQConfig.S3_BACK_PRESSURE_COOLDOWN_MS_DEFAULT, MEDIUM, AutoMQConfig.S3_BACK_PRESSURE_COOLDOWN_MS_DOC)
+            .define(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG, BOOLEAN, AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_DEFAULT, MEDIUM, AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_DOC)
+            .define(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, LONG, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_DEFAULT, between(0, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX), MEDIUM, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_DOC)
             .define(AutoMQConfig.ZONE_ROUTER_CHANNELS_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, AutoMQConfig.ZONE_ROUTER_CHANNELS_DOC)
             // Deprecated config start
             .define(AutoMQConfig.S3_ENDPOINT_CONFIG, STRING, null, HIGH, AutoMQConfig.S3_ENDPOINT_DOC)

--- a/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffConfig.java
+++ b/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffConfig.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import kafka.automq.AutoMQConfig;
+import kafka.server.KafkaConfig;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.ConfigUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Runtime snapshot for retry storm backoff broker configs.
+ *
+ * <p>The object is shared by request-time policy evaluation and Kafka dynamic
+ * config callbacks. Reads are lock-free through volatile fields; updates validate
+ * only retry storm keys and affect later decisions without changing already
+ * scheduled responses.</p>
+ */
+public class RetryStormBackoffConfig {
+
+    public static final Set<String> RECONFIGURABLE_CONFIGS = Set.of(
+        AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG,
+        AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG
+    );
+
+    private volatile boolean enabled;
+    private volatile long maxDelayMs;
+
+    /**
+     * Creates a runtime config snapshot with explicit values.
+     */
+    public RetryStormBackoffConfig(boolean enabled, long maxDelayMs) {
+        validateMaxDelayMs(maxDelayMs);
+        this.enabled = enabled;
+        this.maxDelayMs = maxDelayMs;
+    }
+
+    /**
+     * Builds the initial runtime config from the broker's parsed KafkaConfig.
+     */
+    public static RetryStormBackoffConfig from(KafkaConfig config) {
+        return new RetryStormBackoffConfig(config.retryStormBackoffEnabled(), config.retryStormBackoffMaxDelayMs());
+    }
+
+    /**
+     * Builds a runtime config from raw config values and validates max delay before publishing it.
+     */
+    public static RetryStormBackoffConfig from(Map<String, ?> raw) {
+        Map<String, Object> configs = new HashMap<>(raw);
+        long maxDelayMs = ConfigUtils.getLong(configs, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG);
+        validateMaxDelayMs(maxDelayMs);
+        return new RetryStormBackoffConfig(
+            ConfigUtils.getBoolean(configs, AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG),
+            maxDelayMs
+        );
+    }
+
+    /**
+     * Validates retry storm keys present in a dynamic broker config update.
+     */
+    public static void validate(Map<String, ?> raw) throws ConfigException {
+        Map<String, Object> configs = new HashMap<>(raw);
+        if (configs.containsKey(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG)) {
+            ConfigUtils.getBoolean(configs, AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG);
+        }
+        if (configs.containsKey(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG)) {
+            validateMaxDelayMs(ConfigUtils.getLong(configs, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG));
+        }
+    }
+
+    /**
+     * Rejects max delay values outside the bounded delayed-response range.
+     */
+    public static void validateMaxDelayMs(long maxDelayMs) throws ConfigException {
+        if (maxDelayMs < 0 || maxDelayMs > AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX) {
+            throw new ConfigException(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, maxDelayMs,
+                "The retry storm backoff max delay must be between 0 and "
+                    + AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX + " milliseconds.");
+        }
+    }
+
+    /**
+     * Applies a partial dynamic update; keys absent from {@code raw} keep their current runtime values.
+     */
+    public void update(Map<String, ?> raw) {
+        Map<String, Object> configs = new HashMap<>(raw);
+        if (configs.containsKey(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG)) {
+            this.enabled = ConfigUtils.getBoolean(configs, AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG);
+        }
+        if (configs.containsKey(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG)) {
+            long nextMaxDelayMs = ConfigUtils.getLong(configs, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG);
+            validateMaxDelayMs(nextMaxDelayMs);
+            this.maxDelayMs = nextMaxDelayMs;
+        }
+    }
+
+    /**
+     * Returns whether retry storm delayed responses are enabled for future policy evaluations.
+     */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns the current maximum delay in milliseconds for future policy decisions.
+     */
+    public long maxDelayMs() {
+        return maxDelayMs;
+    }
+}

--- a/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffManager.java
+++ b/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffManager.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import kafka.server.retrystorm.RetryStormBackoffLogger;
+import kafka.server.retrystorm.RetryStormBackoffPolicy;
+import kafka.server.retrystorm.RetryStormDelayedResponseScheduler;
+import kafka.server.retrystorm.RetryStormResponseGate;
+
+import org.apache.kafka.common.Reconfigurable;
+import org.apache.kafka.common.config.ConfigException;
+
+import com.automq.stream.utils.ThreadUtils;
+import com.automq.stream.utils.Threads;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Owns retry storm backoff runtime components for a broker.
+ *
+ * <p>The manager connects Kafka dynamic config callbacks to the shared runtime config,
+ * exposes the response gate to request handlers, and closes delayed response scheduling
+ * during broker shutdown. It does not evaluate responses itself.</p>
+ */
+public class RetryStormBackoffManager implements Reconfigurable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryStormBackoffManager.class);
+    private static final long LOG_INTERVAL_MS = TimeUnit.MINUTES.toMillis(1);
+    private static final long MIN_DELAYING_AGE_TO_LOG_MS = TimeUnit.SECONDS.toMillis(10);
+    private static final int MAX_LOGGED_STATES_PER_INTERVAL = 10;
+
+    private final RetryStormBackoffConfig config;
+    private final RetryStormBackoffPolicy policy;
+    private final RetryStormResponseGate responseGate;
+    private final RetryStormDelayedResponseScheduler scheduler;
+    private final RetryStormBackoffStateStore stateStore;
+    private final RetryStormBackoffLogger logger;
+    private final ScheduledExecutorService logScheduler;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    /**
+     * Creates a manager with only config ownership, primarily for dynamic config tests.
+     */
+    public RetryStormBackoffManager(RetryStormBackoffConfig config) {
+        this(config, null, null, null, null, RetryStormBackoffLogger.NOOP);
+    }
+
+    /**
+     * Creates a broker runtime manager over config, policy, response gate, and scheduler.
+     */
+    public RetryStormBackoffManager(RetryStormBackoffConfig config,
+                                    RetryStormBackoffPolicy policy,
+                                    RetryStormResponseGate responseGate,
+                                    RetryStormDelayedResponseScheduler scheduler,
+                                    RetryStormBackoffStateStore stateStore,
+                                    RetryStormBackoffLogger logger) {
+        this.config = config;
+        this.policy = policy;
+        this.responseGate = responseGate;
+        this.scheduler = scheduler;
+        this.stateStore = stateStore;
+        this.logger = logger;
+        this.logScheduler = stateStore == null
+            ? null
+            : Threads.newSingleThreadScheduledExecutor(
+                ThreadUtils.createThreadFactory("retry-storm-backoff-logger-%d", true),
+                LOGGER,
+                true,
+                false
+            );
+    }
+
+    /**
+     * Returns the broker config keys this manager can validate and apply dynamically.
+     */
+    @Override
+    public Set<String> reconfigurableConfigs() {
+        return RetryStormBackoffConfig.RECONFIGURABLE_CONFIGS;
+    }
+
+    /**
+     * Validates a dynamic broker config update before Kafka publishes it to the runtime config.
+     */
+    @Override
+    public void validateReconfiguration(Map<String, ?> configs) throws ConfigException {
+        RetryStormBackoffConfig.validate(configs);
+    }
+
+    /**
+     * Applies a validated dynamic broker config update to later retry storm policy decisions.
+     */
+    @Override
+    public void reconfigure(Map<String, ?> configs) {
+        config.update(configs);
+    }
+
+    /**
+     * Kafka Reconfigurable lifecycle hook; retry storm config is initialized by BrokerServer.
+     */
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    /**
+     * Starts periodic delayed-state logging for the broker runtime manager.
+     */
+    public void startup() {
+        if (logScheduler != null && started.compareAndSet(false, true)) {
+            logScheduler.scheduleAtFixedRate(this::logDelayedStatesOnce,
+                LOG_INTERVAL_MS, LOG_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Runs one delayed-state logging scan without updating state cache access time.
+     */
+    public void logDelayedStatesOnce() {
+        if (stateStore == null) {
+            return;
+        }
+        logger.logDelayedStates(stateStore.delayedSnapshots(
+            System.currentTimeMillis(),
+            MIN_DELAYING_AGE_TO_LOG_MS,
+            MAX_LOGGED_STATES_PER_INTERVAL
+        ));
+    }
+
+    /**
+     * Closes delayed response scheduling and best-effort sends pending delayed responses.
+     */
+    public void shutdown() {
+        if (logScheduler != null) {
+            logScheduler.shutdownNow();
+        }
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    /**
+     * Returns the shared runtime config snapshot used by policy evaluation.
+     */
+    public RetryStormBackoffConfig config() {
+        return config;
+    }
+
+    /**
+     * Returns the policy owned by this broker, or null in config-only tests.
+     */
+    public RetryStormBackoffPolicy policy() {
+        return policy;
+    }
+
+    /**
+     * Returns the response gate injected into request send paths, or null in config-only tests.
+     */
+    public RetryStormResponseGate responseGate() {
+        return responseGate;
+    }
+}

--- a/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffStateStore.java
+++ b/core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffStateStore.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import kafka.automq.AutoMQConfig;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Maintains per-resource retry storm backoff state for policy evaluation.
+ *
+ * <p>Each key tracks independent delayable-transient and protective-error windows,
+ * plus a delaying mode that keeps delaying repeated failures until quiet time expires.
+ * The store owns state lifecycle through a bounded Guava cache while each
+ * {@link BackoffState} owns its per-resource state machine and synchronization.</p>
+ */
+public class RetryStormBackoffStateStore {
+    public static final int DEFAULT_DELAYABLE_TRANSIENT_THRESHOLD = 1;
+    public static final int DEFAULT_PROTECTIVE_THRESHOLD = 5;
+    public static final long DEFAULT_WINDOW_MS = 1000L;
+    public static final long DEFAULT_RECOVERY_QUIET_MS = 1000L;
+    public static final long DEFAULT_DELAY_MS = 1000L;
+    public static final int DEFAULT_MAX_TRACKED_DIMENSIONS = 100000;
+    public static final int REASON_DELAYABLE_TRANSIENT = 1;
+    public static final int REASON_PROTECTIVE_ERROR = 1 << 1;
+
+    private static final String DELAYABLE_TRANSIENT = "delayable-transient";
+    private static final String PROTECTIVE_ERROR = "protective-error";
+
+    private final long slidingWindowMs;
+    private final long recoveryQuietMs;
+    private final long defaultDelayMs;
+    private final LoadingCache<BackoffKey, BackoffState> states;
+
+    /**
+     * Creates a store with production retry storm thresholds and capacity.
+     */
+    public RetryStormBackoffStateStore() {
+        this(DEFAULT_WINDOW_MS, DEFAULT_RECOVERY_QUIET_MS, DEFAULT_DELAY_MS, DEFAULT_MAX_TRACKED_DIMENSIONS);
+    }
+
+    /**
+     * Creates a store with testable timing and capacity knobs.
+     *
+     * @param slidingWindowMs logical window used before a dimension enters delaying mode
+     * @param recoveryQuietMs quiet time after the latest expected send time before a dimension returns to candidate mode
+     * @param delayMs default delay returned by {@link #recordAndDecide(BackoffKey, ErrorClassSet, long)}
+     * @param maxTrackedDimensions maximum number of dimensions retained by the state cache
+     */
+    public RetryStormBackoffStateStore(long slidingWindowMs, long recoveryQuietMs, long delayMs, int maxTrackedDimensions) {
+        this(slidingWindowMs, recoveryQuietMs, delayMs, maxTrackedDimensions, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX);
+    }
+
+    RetryStormBackoffStateStore(long slidingWindowMs,
+                                long recoveryQuietMs,
+                                long delayMs,
+                                int maxTrackedDimensions,
+                                long stateRetentionDelayMs) {
+        if (maxTrackedDimensions <= 0) {
+            throw new IllegalArgumentException("maxTrackedDimensions must be positive");
+        }
+        if (recoveryQuietMs < 0 || stateRetentionDelayMs < 0) {
+            throw new IllegalArgumentException("state retention timing must be non-negative");
+        }
+        this.slidingWindowMs = slidingWindowMs;
+        this.recoveryQuietMs = recoveryQuietMs;
+        this.defaultDelayMs = delayMs;
+        this.states = CacheBuilder.newBuilder()
+            .maximumSize(maxTrackedDimensions)
+            .expireAfterAccess(recoveryQuietMs + stateRetentionDelayMs, TimeUnit.MILLISECONDS)
+            .build(new CacheLoader<>() {
+                @Override
+                public BackoffState load(BackoffKey key) {
+                    return new BackoffState();
+                }
+            });
+    }
+
+    /**
+     * Records an error observation using the default delay and returns the resource-level decision.
+     */
+    public StateDecision recordAndDecide(BackoffKey key, ErrorClassSet errorClasses, long nowMs) {
+        return recordAndDecide(key, errorClasses, nowMs, defaultDelayMs);
+    }
+
+    /**
+     * Records an error observation, updates candidate/delaying state, and returns whether this resource should delay.
+     *
+     * <p>In candidate mode the method evaluates thresholds before appending the current timestamp,
+     * making the first delayable-transient failure immediate and the second one delayed. In delaying
+     * mode it refreshes {@code lastFailureMs} to the expected response send time
+     * {@code nowMs + decisionDelayMs}, so quiet timeout starts after the delayed response can leave.</p>
+     */
+    public StateDecision recordAndDecide(BackoffKey key, ErrorClassSet errorClasses, long nowMs, long decisionDelayMs) {
+        BackoffState state = states.getUnchecked(key);
+        synchronized (state) {
+            return state.recordAndDecide(errorClasses, nowMs, decisionDelayMs, slidingWindowMs, recoveryQuietMs);
+        }
+    }
+
+    /**
+     * Runs cache maintenance for size and quiet-time based state eviction.
+     */
+    public void evictIfNeeded() {
+        states.cleanUp();
+    }
+
+    int trackedDimensions() {
+        return (int) states.size();
+    }
+
+    /**
+     * Returns delaying state snapshots for periodic logging without updating cache access time.
+     *
+     * <p>The scan reads {@link LoadingCache#asMap()} instead of {@code get} or {@code getUnchecked},
+     * so expire-after-access metadata is not refreshed by observability scans.</p>
+     */
+    public List<DelayedStateSnapshot> delayedSnapshots(long nowMs, long minDelayingAgeMs, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        ArrayList<DelayedStateSnapshot> snapshots = new ArrayList<>(Math.min(limit, 10));
+        for (var entry : states.asMap().entrySet()) {
+            BackoffState state = entry.getValue();
+            synchronized (state) {
+                DelayedStateSnapshot snapshot = state.snapshotIfDelayed(entry.getKey(), nowMs, minDelayingAgeMs);
+                if (snapshot != null) {
+                    snapshots.add(snapshot);
+                    if (snapshots.size() >= limit) {
+                        break;
+                    }
+                }
+            }
+        }
+        return snapshots;
+    }
+
+    /**
+     * Converts internal retry storm reason flags into the stable log-facing reason string.
+     */
+    public static String reasonString(int reasonMask) {
+        boolean delayableReached = (reasonMask & REASON_DELAYABLE_TRANSIENT) != 0;
+        boolean protectiveReached = (reasonMask & REASON_PROTECTIVE_ERROR) != 0;
+        if (delayableReached && protectiveReached) {
+            return DELAYABLE_TRANSIENT + "," + PROTECTIVE_ERROR;
+        }
+        if (delayableReached) {
+            return DELAYABLE_TRANSIENT;
+        }
+        return protectiveReached ? PROTECTIVE_ERROR : "";
+    }
+
+    private enum Mode {
+        CANDIDATE,
+        DELAYING
+    }
+
+    /**
+     * Owns the state machine for one retry storm dimension.
+     *
+     * <p>Callers must synchronize on the instance before invoking methods or reading mutable fields.
+     * The state contains only per-dimension counters and does not manage map lifecycle.</p>
+     */
+    static class BackoffState {
+        private Mode mode = Mode.CANDIDATE;
+        private final ArrayDeque<Long> delayableTransientWindow = new ArrayDeque<>(DEFAULT_DELAYABLE_TRANSIENT_THRESHOLD);
+        private final ArrayDeque<Long> protectiveWindow = new ArrayDeque<>(DEFAULT_PROTECTIVE_THRESHOLD);
+        private long lastFailureMs;
+        private long delayingSinceMs;
+        private int delayReasonMask;
+
+        private StateDecision recordAndDecide(ErrorClassSet errorClasses,
+                                              long nowMs,
+                                              long decisionDelayMs,
+                                              long slidingWindowMs,
+                                              long recoveryQuietMs) {
+            if (mode == Mode.DELAYING) {
+                if (nowMs > lastFailureMs + recoveryQuietMs) {
+                    reset();
+                } else {
+                    lastFailureMs = expectedSendTimeMs(nowMs, decisionDelayMs);
+                    delayReasonMask = errorClasses.reasonMask();
+                    return StateDecision.delayed(decisionDelayMs, delayReasonMask);
+                }
+            }
+
+            cleanExpired(nowMs, slidingWindowMs);
+
+            boolean delayableReached = delayableReached(errorClasses);
+            boolean protectiveReached = protectiveReached(errorClasses);
+
+            if (delayableReached || protectiveReached) {
+                enterDelaying(nowMs, decisionDelayMs, delayableReached, protectiveReached);
+                return StateDecision.delayed(decisionDelayMs, delayReasonMask);
+            }
+
+            recordCandidate(errorClasses, nowMs);
+            return StateDecision.immediate();
+        }
+
+        private void cleanExpired(long nowMs, long slidingWindowMs) {
+            cleanExpired(delayableTransientWindow, nowMs, slidingWindowMs);
+            cleanExpired(protectiveWindow, nowMs, slidingWindowMs);
+        }
+
+        private boolean delayableReached(ErrorClassSet errorClasses) {
+            return errorClasses.delayableTransient()
+                && delayableTransientWindow.size() >= DEFAULT_DELAYABLE_TRANSIENT_THRESHOLD;
+        }
+
+        private boolean protectiveReached(ErrorClassSet errorClasses) {
+            return errorClasses.protective()
+                && protectiveWindow.size() >= DEFAULT_PROTECTIVE_THRESHOLD;
+        }
+
+        private void enterDelaying(long nowMs,
+                                   long decisionDelayMs,
+                                   boolean delayableReached,
+                                   boolean protectiveReached) {
+            mode = Mode.DELAYING;
+            delayingSinceMs = nowMs;
+            lastFailureMs = expectedSendTimeMs(nowMs, decisionDelayMs);
+            delayReasonMask = buildReasonMask(delayableReached, protectiveReached);
+        }
+
+        private void recordCandidate(ErrorClassSet errorClasses, long nowMs) {
+            if (errorClasses.delayableTransient()) {
+                appendBounded(delayableTransientWindow, nowMs, DEFAULT_DELAYABLE_TRANSIENT_THRESHOLD);
+            }
+            if (errorClasses.protective()) {
+                appendBounded(protectiveWindow, nowMs, DEFAULT_PROTECTIVE_THRESHOLD);
+            }
+            lastFailureMs = nowMs;
+            delayReasonMask = errorClasses.reasonMask();
+        }
+
+        private void appendBounded(ArrayDeque<Long> window, long nowMs, int capacity) {
+            if (window.size() == capacity) {
+                window.removeFirst();
+            }
+            window.addLast(nowMs);
+        }
+
+        private void reset() {
+            mode = Mode.CANDIDATE;
+            delayableTransientWindow.clear();
+            protectiveWindow.clear();
+            delayingSinceMs = 0L;
+            delayReasonMask = 0;
+        }
+
+        private long expectedSendTimeMs(long nowMs, long decisionDelayMs) {
+            return nowMs + decisionDelayMs;
+        }
+
+        private DelayedStateSnapshot snapshotIfDelayed(BackoffKey key, long nowMs, long minDelayingAgeMs) {
+            if (mode != Mode.DELAYING || nowMs - delayingSinceMs < minDelayingAgeMs) {
+                return null;
+            }
+            return new DelayedStateSnapshot(key, delayingSinceMs, lastFailureMs, delayReasonMask);
+        }
+
+        private static void cleanExpired(ArrayDeque<Long> window, long nowMs, long slidingWindowMs) {
+            for (Iterator<Long> iterator = window.iterator(); iterator.hasNext(); ) {
+                long timestampMs = iterator.next();
+                if (nowMs - timestampMs > slidingWindowMs) {
+                    iterator.remove();
+                } else {
+                    break;
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Identifies the retry storm state dimension: API, resource, and client connection scope.
+     */
+    public record BackoffKey(short apiKey, String resourceKey, String clientScope) {
+        public BackoffKey {
+            Objects.requireNonNull(resourceKey, "resourceKey");
+            Objects.requireNonNull(clientScope, "clientScope");
+        }
+    }
+
+    /**
+     * Describes which retry storm counters a resource error should update.
+     */
+    public record ErrorClassSet(boolean delayableTransient, boolean protective) {
+        /**
+         * Returns the class set for allowlisted transient errors, which also count as protective errors.
+         */
+        public static ErrorClassSet delayableTransientError() {
+            return new ErrorClassSet(true, true);
+        }
+
+        /**
+         * Returns the class set for non-transient errors that can only reach the protective threshold.
+         */
+        public static ErrorClassSet protectiveOnlyError() {
+            return new ErrorClassSet(false, true);
+        }
+
+        /**
+         * Returns the bit flags for the reason classes represented by this class set.
+         */
+        public int reasonMask() {
+            return buildReasonMask(delayableTransient, protective && !delayableTransient);
+        }
+    }
+
+    /**
+     * Resource-level policy result returned by the state store.
+     */
+    public record StateDecision(boolean delayed, long delayMs, int reasonMask) {
+        private static final StateDecision IMMEDIATE = new StateDecision(false, 0L, 0);
+
+        /**
+         * Returns an immediate resource decision with no delay reason.
+         */
+        public static StateDecision immediate() {
+            return IMMEDIATE;
+        }
+
+        /**
+         * Returns a delayed resource decision when the configured delay is positive.
+         */
+        public static StateDecision delayed(long delayMs, int reasonMask) {
+            return delayMs > 0 ? new StateDecision(true, delayMs, reasonMask) : IMMEDIATE;
+        }
+
+    }
+
+    /**
+     * Read-only delaying-state snapshot used by periodic retry storm logging.
+     */
+    public record DelayedStateSnapshot(BackoffKey key, long delayingSinceMs, long lastFailureMs, int reasonMask) {
+    }
+
+    private static int buildReasonMask(boolean delayable, boolean protective) {
+        int reasonMask = 0;
+        if (delayable) {
+            reasonMask |= REASON_DELAYABLE_TRANSIENT;
+        }
+        if (protective) {
+            reasonMask |= REASON_PROTECTIVE_ERROR;
+        }
+        return reasonMask;
+    }
+}

--- a/core/src/main/java/kafka/server/ResourceErrorExtractor.java
+++ b/core/src/main/java/kafka/server/ResourceErrorExtractor.java
@@ -46,30 +46,68 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.OffsetCommitResponse;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.SyncGroupRequest;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 /**
- * Extracts (errorCode, resource) pairs from request/response for recording in RequestErrorAccumulator.
+ * Extracts resource-scoped response errors for request error accounting and retry storm backoff.
+ *
+ * <p>The extractor owns schema-specific parsing and valid-result detection. It returns response
+ * facts only and does not decide whether an error is retry storm delayable, protective, or eligible
+ * for any policy action.</p>
  */
 public class ResourceErrorExtractor {
 
+    /**
+     * Resource-scoped non-NONE response error.
+     *
+     * @param errorCode Kafka protocol error code from the final response
+     * @param resource partition, topic, coordinator, transaction, or cluster resource key
+     */
     public record ResourceError(short errorCode, String resource) { }
+
+    /**
+     * Shared resource error view for request error accumulation and retry storm backoff.
+     *
+     * <p>The view contains response facts only. It does not classify errors as retry storm
+     * delayable-transient or protective; policy code owns those decisions.</p>
+     */
+    public record ResourceErrorView(boolean allErrorCandidate, List<ResourceError> errors) {
+        private static final ResourceErrorView EMPTY = new ResourceErrorView(false, List.of());
+
+        /**
+         * Returns an empty view for responses without resource-level errors.
+         */
+        public static ResourceErrorView empty() {
+            return EMPTY;
+        }
+    }
 
     /**
      * Extract recordable errors with their associated resource from a response.
      */
     public static List<ResourceError> extract(RequestChannel.Request request, AbstractResponse response) {
+        return extractView(request, response).errors();
+    }
+
+    /**
+     * Extract resource-level errors and whether the response has no valid result.
+     */
+    public static ResourceErrorView extractView(RequestChannel.Request request, AbstractResponse response) {
         try {
-            return doExtract(request, response);
+            if (!hasNonNoneError(response)) {
+                return ResourceErrorView.empty();
+            }
+            return doExtractView(request, response);
         } catch (Exception e) {
             // Never let extraction failures break request processing
-            return Collections.emptyList();
+            return ResourceErrorView.empty();
         }
     }
 
@@ -84,7 +122,7 @@ public class ResourceErrorExtractor {
         }
     }
 
-    private static List<ResourceError> doExtract(RequestChannel.Request request, AbstractResponse response) {
+    private static ResourceErrorView doExtractView(RequestChannel.Request request, AbstractResponse response) {
         ApiKeys apiKey = request.header().apiKey();
         switch (apiKey) {
             case PRODUCE:
@@ -93,8 +131,12 @@ public class ResourceErrorExtractor {
                 return extractFetch((FetchResponse) response);
             case LIST_OFFSETS:
                 return extractListOffsets((ListOffsetsResponse) response);
+            case OFFSET_FOR_LEADER_EPOCH:
+                return extractOffsetForLeaderEpoch((OffsetsForLeaderEpochResponse) response);
             case METADATA:
-                return extractMetadata((MetadataResponse) response);
+                return extractMetadata(request, (MetadataResponse) response);
+            case DESCRIBE_TOPIC_PARTITIONS:
+                return extractDescribeTopicPartitions((org.apache.kafka.common.requests.DescribeTopicPartitionsResponse) response);
             case OFFSET_COMMIT:
                 return extractOffsetCommit(request, (OffsetCommitResponse) response);
             case OFFSET_FETCH:
@@ -112,16 +154,17 @@ public class ResourceErrorExtractor {
         }
     }
 
-    private static List<ResourceError> doExtractOther(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    private static ResourceErrorView doExtractOther(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
         switch (apiKey) {
             case JOIN_GROUP:
-                return extractSingleErrorFromRequest(response, () -> request.body(JoinGroupRequest.class).data().groupId());
+                return extractSingleErrorFromRequest(response, () -> groupKey(request.body(JoinGroupRequest.class).data().groupId()));
             case SYNC_GROUP:
-                return extractSingleErrorFromRequest(response, () -> request.body(SyncGroupRequest.class).data().groupId());
+                return extractSingleErrorFromRequest(response, () -> groupKey(request.body(SyncGroupRequest.class).data().groupId()));
             case HEARTBEAT:
                 return extractSingleErrorFromRequest(response, () -> request.body(HeartbeatRequest.class).data().groupId());
             case LEAVE_GROUP:
-                return extractSingleErrorFromRequest(response, () -> request.body(LeaveGroupRequest.class).data().groupId());
+                return extractSingleErrorFromRequest(response, () -> groupKey(request.body(LeaveGroupRequest.class).data().groupId()));
             case DESCRIBE_GROUPS:
                 return extractDescribeGroups((DescribeGroupsResponse) response);
             case DELETE_GROUPS:
@@ -131,22 +174,29 @@ public class ResourceErrorExtractor {
             case INIT_PRODUCER_ID:
                 return extractSingleErrorFromRequest(response, () -> {
                     String txnId = request.body(InitProducerIdRequest.class).data().transactionalId();
-                    return txnId != null ? txnId : "";
+                    return txnId != null && !txnId.isEmpty()
+                        ? transactionKey(txnId)
+                        : "producer-" + request.body(InitProducerIdRequest.class).data().producerId();
                 });
             case ADD_PARTITIONS_TO_TXN:
                 return extractAddPartitionsToTxn((AddPartitionsToTxnResponse) response);
             case ADD_OFFSETS_TO_TXN:
-                return extractSingleErrorFromRequest(response, () -> request.body(AddOffsetsToTxnRequest.class).data().transactionalId());
+                return extractSingleErrorFromRequest(response, () -> transactionKey(request.body(AddOffsetsToTxnRequest.class).data().transactionalId()));
             case END_TXN:
-                return extractSingleErrorFromRequest(response, () -> request.body(EndTxnRequest.class).data().transactionalId());
+                return extractSingleErrorFromRequest(response, () -> {
+                    String txnId = request.body(EndTxnRequest.class).data().transactionalId();
+                    return txnId != null && !txnId.isEmpty()
+                        ? transactionKey(txnId)
+                        : "producer-" + request.body(EndTxnRequest.class).data().producerId();
+                });
             case TXN_OFFSET_COMMIT:
-                return extractTxnOffsetCommit((TxnOffsetCommitResponse) response);
+                return extractTxnOffsetCommit(request, (TxnOffsetCommitResponse) response);
             default:
                 return doExtractAdmin(request, response, apiKey);
         }
     }
 
-    private static List<ResourceError> doExtractAdmin(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
+    private static ResourceErrorView doExtractAdmin(RequestChannel.Request request, AbstractResponse response, ApiKeys apiKey) {
         switch (apiKey) {
             case ALTER_CONFIGS:
                 return extractAlterConfigs((AlterConfigsResponse) response);
@@ -179,169 +229,306 @@ public class ResourceErrorExtractor {
 
     // ---- Per-topic response extractors ----
 
-    private static List<ResourceError> extractProduce(ProduceResponse response) {
+    private static ResourceErrorView extractProduce(ProduceResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         response.data().responses().forEach(topic ->
-            topic.partitionResponses().forEach(p ->
-                maybeAdd(result, p.errorCode(), topic.name())));
-        return result;
+            topic.partitionResponses().forEach(p -> {
+                if (p.errorCode() == Errors.NONE.code()) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, p.errorCode(), topic.name() + "-" + p.index());
+            }));
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractFetch(FetchResponse response) {
+    private static ResourceErrorView extractFetch(FetchResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         // top-level error
         maybeAdd(result, response.error().code(), "");
         response.data().responses().forEach(topic ->
-            topic.partitions().forEach(p ->
-                maybeAdd(result, p.errorCode(), topic.topic())));
-        return result;
+            topic.partitions().forEach(p -> {
+                if (p.errorCode() == Errors.NONE.code()) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, p.errorCode(), topic.topic() + "-" + p.partitionIndex());
+            }));
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractListOffsets(ListOffsetsResponse response) {
+    private static ResourceErrorView extractListOffsets(ListOffsetsResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         response.data().topics().forEach(topic ->
-            topic.partitions().forEach(p ->
-                maybeAdd(result, p.errorCode(), topic.name())));
-        return result;
+            topic.partitions().forEach(p -> {
+                if (p.errorCode() == Errors.NONE.code()
+                    && (p.offset() != ListOffsetsResponse.UNKNOWN_OFFSET || !p.oldStyleOffsets().isEmpty())) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, p.errorCode(), topic.name() + "-" + p.partitionIndex());
+            }));
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractMetadata(MetadataResponse response) {
+    private static ResourceErrorView extractOffsetForLeaderEpoch(OffsetsForLeaderEpochResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         response.data().topics().forEach(topic ->
-            maybeAdd(result, topic.errorCode(), topic.name() != null ? topic.name() : ""));
-        return result;
+            topic.partitions().forEach(partition -> {
+                if (partition.errorCode() == Errors.NONE.code()
+                    && partition.endOffset() != OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, partition.errorCode(), topic.topic() + "-" + partition.partition());
+            }));
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractOffsetCommit(RequestChannel.Request request, OffsetCommitResponse response) {
+    private static ResourceErrorView extractMetadata(RequestChannel.Request request, MetadataResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        String groupId = request.body(OffsetCommitRequest.class).data().groupId();
+        boolean[] hasValid = {includeClusterValidity(request)
+            && (!response.data().brokers().isEmpty() || response.data().controllerId() >= 0)};
+        response.data().topics().forEach(topic -> {
+            String topicName = topic.name() != null ? topic.name() : topic.topicId().toString();
+            boolean[] topicHasValidPartition = {false};
+            topic.partitions().forEach(partition -> {
+                if (partition.errorCode() == Errors.NONE.code() && partition.leaderId() >= 0) {
+                    topicHasValidPartition[0] = true;
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, partition.errorCode(), topicName + "-" + partition.partitionIndex());
+            });
+            if (topic.errorCode() == Errors.NONE.code() && topicHasValidPartition[0]) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, topic.errorCode(), topicName);
+        });
+        return view(result, hasValid[0]);
+    }
+
+    private static ResourceErrorView extractDescribeTopicPartitions(org.apache.kafka.common.requests.DescribeTopicPartitionsResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
+        response.data().topics().forEach(topic -> {
+            String topicName = topic.name() != null ? topic.name() : "";
+            boolean[] topicHasValidPartition = {false};
+            topic.partitions().forEach(partition -> {
+                if (partition.errorCode() == Errors.NONE.code() && partition.leaderId() >= 0) {
+                    topicHasValidPartition[0] = true;
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, partition.errorCode(), topicName + "-" + partition.partitionIndex());
+            });
+            if (topic.errorCode() == Errors.NONE.code() && topicHasValidPartition[0]) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, topic.errorCode(), topicName);
+        });
+        return view(result, hasValid[0]);
+    }
+
+    private static ResourceErrorView extractOffsetCommit(RequestChannel.Request request, OffsetCommitResponse response) {
+        List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
+        String resource = groupKey(request.body(OffsetCommitRequest.class).data().groupId());
         response.data().topics().forEach(topic ->
             topic.partitions().forEach(p -> {
                 short code = p.errorCode();
-                if (code == Errors.GROUP_AUTHORIZATION_FAILED.code()) {
-                    maybeAdd(result, code, groupId);
-                } else {
-                    maybeAdd(result, code, topic.name());
+                if (code == Errors.NONE.code()) {
+                    hasValid[0] = true;
                 }
+                maybeAdd(result, code, resource);
             }));
-        return result;
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractOffsetFetch(OffsetFetchResponse response) {
+    private static ResourceErrorView extractOffsetFetch(OffsetFetchResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         // v8+ batched groups
-        response.data().groups().forEach(group ->
-            maybeAdd(result, group.errorCode(), group.groupId()));
+        response.data().groups().forEach(group -> {
+            if (group.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, group.errorCode(), groupKey(group.groupId()));
+        });
         // older single-group
         if (response.data().groups().isEmpty()) {
+            if (response.data().errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
             maybeAdd(result, response.data().errorCode(), "");
         }
-        return result;
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractFindCoordinator(RequestChannel.Request request, FindCoordinatorResponse response) {
+    private static ResourceErrorView extractFindCoordinator(RequestChannel.Request request, FindCoordinatorResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         if (!response.data().coordinators().isEmpty()) {
-            response.data().coordinators().forEach(c ->
-                maybeAdd(result, c.errorCode(), c.key()));
+            response.data().coordinators().forEach(c -> {
+                if (c.errorCode() == Errors.NONE.code() && c.nodeId() >= 0) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, c.errorCode(), coordinatorType(request) + "-" + c.key());
+            });
         } else {
             String key = request.body(FindCoordinatorRequest.class).data().key();
-            maybeAdd(result, response.data().errorCode(), key != null ? key : "");
+            if (response.data().errorCode() == Errors.NONE.code() && response.data().nodeId() >= 0) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, response.data().errorCode(), coordinatorType(request) + "-" + (key != null ? key : ""));
         }
-        return result;
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractCreateTopics(CreateTopicsResponse response) {
+    private static ResourceErrorView extractCreateTopics(CreateTopicsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().topics().forEach(topic ->
-            maybeAdd(result, topic.errorCode(), topic.name()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().topics().forEach(topic -> {
+            if (topic.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, topic.errorCode(), topic.name());
+        });
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractDeleteTopics(DeleteTopicsResponse response) {
+    private static ResourceErrorView extractDeleteTopics(DeleteTopicsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().responses().forEach(topic ->
-            maybeAdd(result, topic.errorCode(), topic.name() != null ? topic.name() : ""));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().responses().forEach(topic -> {
+            if (topic.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, topic.errorCode(), topic.name() != null ? topic.name() : "");
+        });
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractCreatePartitions(CreatePartitionsResponse response) {
+    private static ResourceErrorView extractCreatePartitions(CreatePartitionsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().results().forEach(r ->
-            maybeAdd(result, r.errorCode(), r.name()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().results().forEach(r -> {
+            if (r.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, r.errorCode(), r.name());
+        });
+        return view(result, hasValid[0]);
     }
 
     // ---- Per-group response extractors ----
 
-    private static List<ResourceError> extractDescribeGroups(DescribeGroupsResponse response) {
+    private static ResourceErrorView extractDescribeGroups(DescribeGroupsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().groups().forEach(g ->
-            maybeAdd(result, g.errorCode(), g.groupId()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().groups().forEach(g -> {
+            if (g.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, g.errorCode(), g.groupId());
+        });
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractDeleteGroups(DeleteGroupsResponse response) {
+    private static ResourceErrorView extractDeleteGroups(DeleteGroupsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().results().forEach(r ->
-            maybeAdd(result, r.errorCode(), r.groupId()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().results().forEach(r -> {
+            if (r.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, r.errorCode(), r.groupId());
+        });
+        return view(result, hasValid[0]);
     }
 
     // ---- Transaction extractors ----
 
-    private static List<ResourceError> extractAddPartitionsToTxn(AddPartitionsToTxnResponse response) {
+    private static ResourceErrorView extractAddPartitionsToTxn(AddPartitionsToTxnResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
         // v3 and below: per-topic results
         response.data().resultsByTopicV3AndBelow().forEach(topic ->
-            topic.resultsByPartition().forEach(p ->
-                maybeAdd(result, p.partitionErrorCode(), topic.name())));
+            topic.resultsByPartition().forEach(p -> {
+                if (p.partitionErrorCode() == Errors.NONE.code()) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, p.partitionErrorCode(), topic.name() + "-" + p.partitionIndex());
+            }));
         // v4+: per-transaction, per-topic results
         response.data().resultsByTransaction().forEach(txn ->
             txn.topicResults().forEach(topic ->
-                topic.resultsByPartition().forEach(p ->
-                    maybeAdd(result, p.partitionErrorCode(), topic.name()))));
-        return result;
+                topic.resultsByPartition().forEach(p -> {
+                    if (p.partitionErrorCode() == Errors.NONE.code()) {
+                        hasValid[0] = true;
+                    }
+                    maybeAdd(result, p.partitionErrorCode(), topic.name() + "-" + p.partitionIndex());
+                })));
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractTxnOffsetCommit(TxnOffsetCommitResponse response) {
+    private static ResourceErrorView extractTxnOffsetCommit(RequestChannel.Request request, TxnOffsetCommitResponse response) {
         List<ResourceError> result = new ArrayList<>();
+        boolean[] hasValid = {false};
+        String resource = transactionKey(request.body(org.apache.kafka.common.requests.TxnOffsetCommitRequest.class).data().transactionalId());
         response.data().topics().forEach(topic ->
-            topic.partitions().forEach(p ->
-                maybeAdd(result, p.errorCode(), topic.name())));
-        return result;
+            topic.partitions().forEach(p -> {
+                if (p.errorCode() == Errors.NONE.code()) {
+                    hasValid[0] = true;
+                }
+                maybeAdd(result, p.errorCode(), resource);
+            }));
+        return view(result, hasValid[0]);
     }
 
     // ---- Config extractors ----
 
-    private static List<ResourceError> extractAlterConfigs(AlterConfigsResponse response) {
+    private static ResourceErrorView extractAlterConfigs(AlterConfigsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().responses().forEach(r ->
-            maybeAdd(result, r.errorCode(), r.resourceName()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().responses().forEach(r -> {
+            if (r.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, r.errorCode(), r.resourceName());
+        });
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractDescribeConfigs(DescribeConfigsResponse response) {
+    private static ResourceErrorView extractDescribeConfigs(DescribeConfigsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().results().forEach(r ->
-            maybeAdd(result, r.errorCode(), r.resourceName()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().results().forEach(r -> {
+            if (r.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, r.errorCode(), r.resourceName());
+        });
+        return view(result, hasValid[0]);
     }
 
-    private static List<ResourceError> extractIncrementalAlterConfigs(IncrementalAlterConfigsResponse response) {
+    private static ResourceErrorView extractIncrementalAlterConfigs(IncrementalAlterConfigsResponse response) {
         List<ResourceError> result = new ArrayList<>();
-        response.data().responses().forEach(r ->
-            maybeAdd(result, r.errorCode(), r.resourceName()));
-        return result;
+        boolean[] hasValid = {false};
+        response.data().responses().forEach(r -> {
+            if (r.errorCode() == Errors.NONE.code()) {
+                hasValid[0] = true;
+            }
+            maybeAdd(result, r.errorCode(), r.resourceName());
+        });
+        return view(result, hasValid[0]);
     }
 
     // ---- Helpers ----
 
-    private static List<ResourceError> extractSingleError(AbstractResponse response, String resource) {
+    private static ResourceErrorView extractSingleError(AbstractResponse response, String resource) {
         List<ResourceError> result = new ArrayList<>();
         response.errorCounts().forEach((error, count) ->
             maybeAdd(result, error.code(), resource));
-        return result;
+        return view(result, hasNoneError(response));
     }
 
     @FunctionalInterface
@@ -349,26 +536,57 @@ public class ResourceErrorExtractor {
         String get();
     }
 
-    private static List<ResourceError> extractSingleErrorFromRequest(
+    private static ResourceErrorView extractSingleErrorFromRequest(
             AbstractResponse response, ResourceSupplier resourceSupplier) {
         List<ResourceError> result = new ArrayList<>();
         String resource = resourceSupplier.get();
         response.errorCounts().forEach((error, count) ->
             maybeAdd(result, error.code(), resource));
-        return result;
+        return view(result, hasNoneError(response));
     }
 
-    private static List<ResourceError> extractDefaultErrors(AbstractResponse response) {
+    private static ResourceErrorView extractDefaultErrors(AbstractResponse response) {
         List<ResourceError> result = new ArrayList<>();
         response.errorCounts().forEach((error, count) ->
             maybeAdd(result, error.code(), ""));
-        return result;
+        return view(result, hasNoneError(response));
     }
 
     private static void maybeAdd(List<ResourceError> result, short errorCode, String resource) {
         if (errorCode != 0) {
             result.add(new ResourceError(errorCode, resource));
         }
+    }
+
+    private static ResourceErrorView view(List<ResourceError> errors, boolean hasValidResult) {
+        return new ResourceErrorView(!errors.isEmpty() && !hasValidResult, List.copyOf(errors));
+    }
+
+    private static boolean hasNonNoneError(AbstractResponse response) {
+        return response.errorCounts().keySet().stream().anyMatch(error -> error != Errors.NONE);
+    }
+
+    private static boolean hasNoneError(AbstractResponse response) {
+        return response.errorCounts().containsKey(Errors.NONE);
+    }
+
+    private static boolean includeClusterValidity(RequestChannel.Request request) {
+        org.apache.kafka.common.requests.MetadataRequest metadataRequest =
+            request.body(org.apache.kafka.common.requests.MetadataRequest.class);
+        return metadataRequest.isAllTopics() || metadataRequest.data().topics().isEmpty();
+    }
+
+    private static String coordinatorType(RequestChannel.Request request) {
+        FindCoordinatorRequest body = request.body(FindCoordinatorRequest.class);
+        return FindCoordinatorRequest.CoordinatorType.forId(body.data().keyType()).name().toLowerCase(Locale.ROOT);
+    }
+
+    private static String groupKey(String groupId) {
+        return "group-" + (groupId == null ? "" : groupId);
+    }
+
+    private static String transactionKey(String transactionalId) {
+        return "transaction-" + (transactionalId == null ? "" : transactionalId);
     }
 
     private static String doExtractResourceFromRequest(RequestChannel.Request request) {

--- a/core/src/main/java/kafka/server/retrystorm/BackoffAction.java
+++ b/core/src/main/java/kafka/server/retrystorm/BackoffAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+/**
+ * Response-level action selected by the retry storm policy.
+ */
+public enum BackoffAction {
+    IMMEDIATE,
+    DELAYED
+}

--- a/core/src/main/java/kafka/server/retrystorm/BackoffContext.java
+++ b/core/src/main/java/kafka/server/retrystorm/BackoffContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+/**
+ * Request-time policy context, including client isolation scope and logical time.
+ */
+public class BackoffContext {
+    private final String clientScope;
+    private final long nowMs;
+
+    /**
+     * Creates the immutable context used for one retry storm policy evaluation.
+     */
+    public BackoffContext(String clientScope, long nowMs) {
+        this.clientScope = clientScope;
+        this.nowMs = nowMs;
+    }
+
+    /**
+     * Returns the client isolation scope used in retry storm state keys.
+     */
+    public String clientScope() {
+        return clientScope;
+    }
+
+    /**
+     * Returns the logical time used for window and expiry decisions.
+     */
+    public long nowMs() {
+        return nowMs;
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/BackoffDecision.java
+++ b/core/src/main/java/kafka/server/retrystorm/BackoffDecision.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+/**
+ * Response-level policy decision returned to the response gate.
+ */
+public class BackoffDecision {
+    private static final BackoffDecision IMMEDIATE = new BackoffDecision(BackoffAction.IMMEDIATE);
+
+    private final BackoffAction action;
+    private final long delayMs;
+    private final int reasonMask;
+
+    /**
+     * Creates a response decision without delayed-response reason flags.
+     */
+    public BackoffDecision(BackoffAction action) {
+        this(action, 0L, 0);
+    }
+
+    /**
+     * Creates a policy decision with the response action, selected delay, and combined reason flags.
+     */
+    public BackoffDecision(BackoffAction action, long delayMs, int reasonMask) {
+        this.action = action;
+        this.delayMs = delayMs;
+        this.reasonMask = reasonMask;
+    }
+
+    /**
+     * Returns the shared immediate decision instance.
+     */
+    public static BackoffDecision immediate() {
+        return IMMEDIATE;
+    }
+
+    /**
+     * Returns the response-level action selected by the policy.
+     */
+    public BackoffAction action() {
+        return action;
+    }
+
+    /**
+     * Returns the delay to apply before final response send.
+     */
+    public long delayMs() {
+        return delayMs;
+    }
+
+    /**
+     * Returns the internal reason bit flags used for response-level aggregation.
+     */
+    public int reasonMask() {
+        return reasonMask;
+    }
+
+    /**
+     * Returns true when the response should be scheduled through the delayed response scheduler.
+     */
+    public boolean delayed() {
+        return action == BackoffAction.DELAYED;
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/RetryStormBackoffLogger.java
+++ b/core/src/main/java/kafka/server/retrystorm/RetryStormBackoffLogger.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+
+import java.util.List;
+
+/**
+ * Emits periodic snapshots for retry storm dimensions that remain in delaying mode.
+ */
+public interface RetryStormBackoffLogger {
+    RetryStormBackoffLogger NOOP = snapshots -> {
+    };
+
+    /**
+     * Logs periodic snapshots of retry storm dimensions that remain in delaying mode.
+     */
+    void logDelayedStates(List<RetryStormBackoffStateStore.DelayedStateSnapshot> snapshots);
+}

--- a/core/src/main/java/kafka/server/retrystorm/RetryStormBackoffPolicy.java
+++ b/core/src/main/java/kafka/server/retrystorm/RetryStormBackoffPolicy.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.automq.retrystorm.RetryStormBackoffConfig;
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+import kafka.server.ResourceErrorExtractor;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.Set;
+
+/**
+ * Evaluates all-error resource views and updates per-resource retry storm backoff state.
+ *
+ * <p>The policy owns strategy classification from API key and final response error code. The shared
+ * extractor supplies only response facts, the state store decides each resource threshold, and the
+ * policy returns the maximum response delay and combined reasons.</p>
+ */
+public class RetryStormBackoffPolicy {
+    private static final Set<ApiKeys> SUPPORTED_API_KEYS = EnumSet.of(
+        ApiKeys.PRODUCE,
+        ApiKeys.FETCH,
+        ApiKeys.LIST_OFFSETS,
+        ApiKeys.OFFSET_FOR_LEADER_EPOCH,
+        ApiKeys.METADATA,
+        ApiKeys.DESCRIBE_TOPIC_PARTITIONS,
+        ApiKeys.FIND_COORDINATOR,
+        ApiKeys.JOIN_GROUP,
+        ApiKeys.SYNC_GROUP,
+        ApiKeys.OFFSET_COMMIT,
+        ApiKeys.OFFSET_FETCH,
+        ApiKeys.LEAVE_GROUP,
+        ApiKeys.TXN_OFFSET_COMMIT,
+        ApiKeys.ADD_OFFSETS_TO_TXN,
+        ApiKeys.INIT_PRODUCER_ID,
+        ApiKeys.END_TXN
+    );
+    private static final Set<Errors> DELAYABLE_LEADER_ERRORS = EnumSet.of(
+        Errors.NOT_LEADER_OR_FOLLOWER,
+        Errors.LEADER_NOT_AVAILABLE,
+        Errors.FENCED_LEADER_EPOCH
+    );
+    private static final Set<Errors> DELAYABLE_COORDINATOR_ERRORS = EnumSet.of(
+        Errors.COORDINATOR_LOAD_IN_PROGRESS,
+        Errors.COORDINATOR_NOT_AVAILABLE,
+        Errors.NOT_COORDINATOR
+    );
+
+    private final RetryStormBackoffConfig config;
+    private final RetryStormBackoffStateStore stateStore;
+
+    /**
+     * Creates a policy over the dynamic retry storm config and per-resource state store.
+     */
+    public RetryStormBackoffPolicy(RetryStormBackoffConfig config, RetryStormBackoffStateStore stateStore) {
+        this.config = config;
+        this.stateStore = stateStore;
+    }
+
+    /**
+     * Updates retry storm state from all-error resource errors and returns the response-level action.
+     *
+     * <p>The caller must only invoke this method for responses that have no valid result. Error
+     * classification is derived from the API key and final response error code.</p>
+     */
+    public BackoffDecision evaluate(ApiKeys apiKey,
+                                    List<ResourceErrorExtractor.ResourceError> errors,
+                                    BackoffContext context,
+                                    OptionalLong delayCapMs) {
+        if (!config.enabled() || !supports(apiKey) || errors.isEmpty()) {
+            return BackoffDecision.immediate();
+        }
+
+        long decisionDelayMs = delayCapMs.isPresent()
+            ? Math.min(config.maxDelayMs(), Math.max(delayCapMs.getAsLong(), 0L))
+            : config.maxDelayMs();
+        long maxDelayMs = 0L;
+        int reasonMask = 0;
+        for (ResourceErrorExtractor.ResourceError error : errors) {
+            boolean delayableTransient = isDelayableTransient(apiKey, Errors.forCode(error.errorCode()));
+            RetryStormBackoffStateStore.StateDecision decision = stateStore.recordAndDecide(
+                backoffKey(apiKey, error, context),
+                new RetryStormBackoffStateStore.ErrorClassSet(delayableTransient, true),
+                context.nowMs(),
+                decisionDelayMs
+            );
+            if (decision.delayed()) {
+                maxDelayMs = Math.max(maxDelayMs, decision.delayMs());
+                reasonMask |= decision.reasonMask();
+            }
+        }
+
+        if (reasonMask == 0) {
+            return BackoffDecision.immediate();
+        }
+        return new BackoffDecision(BackoffAction.DELAYED, maxDelayMs, reasonMask);
+    }
+
+    /**
+     * Returns whether retry storm backoff should evaluate all-error responses for this API.
+     */
+    public boolean supports(ApiKeys apiKey) {
+        return SUPPORTED_API_KEYS.contains(apiKey);
+    }
+
+    private RetryStormBackoffStateStore.BackoffKey backoffKey(ApiKeys apiKey,
+                                                              ResourceErrorExtractor.ResourceError error,
+                                                              BackoffContext context) {
+        return new RetryStormBackoffStateStore.BackoffKey(apiKey.id, error.resource(), context.clientScope());
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    private boolean isDelayableTransient(ApiKeys apiKey, Errors error) {
+        switch (apiKey) {
+            case PRODUCE:
+            case FETCH:
+            case LIST_OFFSETS:
+            case OFFSET_FOR_LEADER_EPOCH:
+            case METADATA:
+            case DESCRIBE_TOPIC_PARTITIONS:
+                return DELAYABLE_LEADER_ERRORS.contains(error);
+            case FIND_COORDINATOR:
+            case JOIN_GROUP:
+            case SYNC_GROUP:
+            case OFFSET_COMMIT:
+            case OFFSET_FETCH:
+            case LEAVE_GROUP:
+            case TXN_OFFSET_COMMIT:
+            case ADD_OFFSETS_TO_TXN:
+            case INIT_PRODUCER_ID:
+            case END_TXN:
+                return DELAYABLE_COORDINATOR_ERRORS.contains(error);
+            default:
+                return false;
+        }
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/RetryStormDelayedResponseScheduler.java
+++ b/core/src/main/java/kafka/server/retrystorm/RetryStormDelayedResponseScheduler.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timeout;
+
+/**
+ * Schedules final response send callbacks for retry storm delayed responses.
+ *
+ * <p>The scheduler does not inspect or mutate Kafka responses. It only owns timer lifecycle,
+ * shutdown draining, and exactly-once execution of the supplied final-send callback.</p>
+ */
+public class RetryStormDelayedResponseScheduler {
+    private final long tickMs;
+    private final HashedWheelTimer timer;
+    private final ConcurrentHashMap<Timeout, ScheduledSend> pending = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final Object lifecycleLock = new Object();
+
+    /**
+     * Creates a scheduler with the default timer tick.
+     */
+    public RetryStormDelayedResponseScheduler() {
+        this(100L);
+    }
+
+    /**
+     * Creates a scheduler with a caller-defined timer tick in milliseconds.
+     */
+    public RetryStormDelayedResponseScheduler(long tickMs) {
+        this.tickMs = tickMs;
+        this.timer = new HashedWheelTimer(tickMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Schedules the final response send; zero delay or closed scheduler executes the send immediately.
+     */
+    public void schedule(long delayMs, Runnable sendNow) {
+        if (delayMs <= 0) {
+            sendNow.run();
+            return;
+        }
+
+        long roundedDelayMs = roundUpToTick(delayMs);
+        ScheduledSend scheduledSend = new ScheduledSend(sendNow);
+        try {
+            boolean sendImmediately = false;
+            synchronized (lifecycleLock) {
+                if (closed.get()) {
+                    sendImmediately = true;
+                } else {
+                    Timeout timeout = timer.newTimeout(timeoutRef -> {
+                        ScheduledSend scheduled;
+                        synchronized (lifecycleLock) {
+                            scheduled = pending.remove(timeoutRef);
+                        }
+                        if (scheduled != null) {
+                            scheduled.send();
+                        }
+                    }, roundedDelayMs, TimeUnit.MILLISECONDS);
+                    pending.put(timeout, scheduledSend);
+                }
+            }
+            if (sendImmediately) {
+                scheduledSend.send();
+            }
+        } catch (IllegalStateException e) {
+            scheduledSend.send();
+        }
+    }
+
+    /**
+     * Stops accepting new delayed sends and best-effort sends every pending response once.
+     */
+    public void shutdown() {
+        ArrayList<ScheduledSend> sends = new ArrayList<>();
+        synchronized (lifecycleLock) {
+            closed.set(true);
+            for (Map.Entry<Timeout, ScheduledSend> entry : pending.entrySet()) {
+                pending.remove(entry.getKey());
+                entry.getKey().cancel();
+                sends.add(entry.getValue());
+            }
+        }
+        for (ScheduledSend send : sends) {
+            send.send();
+        }
+        timer.stop();
+    }
+
+    private long roundUpToTick(long delayMs) {
+        if (delayMs <= tickMs) {
+            return tickMs;
+        }
+        return ((delayMs + tickMs - 1) / tickMs) * tickMs;
+    }
+
+    private static class ScheduledSend {
+        private final Runnable sendNow;
+        private final AtomicBoolean sent = new AtomicBoolean(false);
+
+        private ScheduledSend(Runnable sendNow) {
+            this.sendNow = sendNow;
+        }
+
+        private void send() {
+            if (sent.compareAndSet(false, true)) {
+                sendNow.run();
+            }
+        }
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/RetryStormRequestContext.java
+++ b/core/src/main/java/kafka/server/retrystorm/RetryStormRequestContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+/**
+ * Request metadata needed by the retry storm response gate.
+ */
+public class RetryStormRequestContext {
+    private final ApiKeys apiKey;
+    private final String clientScope;
+    private final long nowMs;
+
+    /**
+     * Creates immutable request metadata for one response-gate invocation.
+     */
+    public RetryStormRequestContext(ApiKeys apiKey, String clientScope, long nowMs) {
+        this.apiKey = apiKey;
+        this.clientScope = clientScope;
+        this.nowMs = nowMs;
+    }
+
+    /**
+     * Returns the Kafka API key associated with the response.
+     */
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    /**
+     * Returns the client isolation scope used for per-client retry storm state.
+     */
+    public String clientScope() {
+        return clientScope;
+    }
+
+    /**
+     * Returns the logical time for the response-gate policy evaluation.
+     */
+    public long nowMs() {
+        return nowMs;
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/RetryStormResponseGate.java
+++ b/core/src/main/java/kafka/server/retrystorm/RetryStormResponseGate.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.server.ResourceErrorExtractor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.OptionalLong;
+
+/**
+ * Wraps final response sending with retry storm policy evaluation.
+ *
+ * <p>The gate is the integration boundary between Kafka request handlers and retry storm internals:
+ * handlers keep building normal responses and quota state, while the gate either sends immediately
+ * or delegates the final send callback to the scheduler.</p>
+ */
+public class RetryStormResponseGate {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryStormResponseGate.class);
+
+    private final RetryStormBackoffPolicy policy;
+    private final RetryStormDelayedResponseScheduler scheduler;
+
+    /**
+     * Creates a response gate over policy and scheduler.
+     */
+    public RetryStormResponseGate(RetryStormBackoffPolicy policy,
+                                  RetryStormDelayedResponseScheduler scheduler) {
+        this.policy = policy;
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Sends or delays a response using a shared resource error view extracted by RequestChannel.
+     */
+    public void sendOrDelay(RetryStormRequestContext context,
+                            ResourceErrorExtractor.ResourceErrorView errorView,
+                            OptionalLong delayCapMs,
+                            Runnable sendNow) {
+        if (!errorView.allErrorCandidate() || !policy.supports(context.apiKey())) {
+            sendNow.run();
+            return;
+        }
+
+        BackoffDecision decision;
+        try {
+            decision = policy.evaluate(
+                context.apiKey(),
+                errorView.errors(),
+                new BackoffContext(context.clientScope(), context.nowMs()),
+                delayCapMs
+            );
+        } catch (RuntimeException e) {
+            LOGGER.warn("Retry storm response gate failed for apiKey={}, clientScope={}, send response immediately",
+                context.apiKey(), context.clientScope(), e);
+            decision = BackoffDecision.immediate();
+        }
+
+        if (decision.action() == BackoffAction.IMMEDIATE) {
+            sendNow.run();
+        } else {
+            scheduler.schedule(decision.delayMs(), sendNow);
+        }
+    }
+}

--- a/core/src/main/java/kafka/server/retrystorm/SampledRetryStormBackoffLogger.java
+++ b/core/src/main/java/kafka/server/retrystorm/SampledRetryStormBackoffLogger.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Logs periodic snapshots of retry storm dimensions that remain in delaying mode.
+ */
+public class SampledRetryStormBackoffLogger implements RetryStormBackoffLogger {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SampledRetryStormBackoffLogger.class);
+
+    /**
+     * Logs at most one line per delayed state snapshot.
+     */
+    @Override
+    public void logDelayedStates(List<RetryStormBackoffStateStore.DelayedStateSnapshot> snapshots) {
+        for (RetryStormBackoffStateStore.DelayedStateSnapshot snapshot : snapshots) {
+            RetryStormBackoffStateStore.BackoffKey key = snapshot.key();
+            LOGGER.info("Retry storm delaying state apiKey={} resource={} clientScope={} reason={} delayingSinceMs={} lastFailureMs={}",
+                key.apiKey(), key.resourceKey(), key.clientScope(),
+                RetryStormBackoffStateStore.reasonString(snapshot.reasonMask()),
+                snapshot.delayingSinceMs(), snapshot.lastFailureMs());
+        }
+    }
+}

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -22,6 +22,7 @@ import com.typesafe.scalalogging.Logger
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.network
 import kafka.server.{KafkaConfig, RequestErrorAccumulator, RequestLocal, ResourceErrorExtractor}
+import kafka.server.retrystorm.{RetryStormRequestContext, RetryStormResponseGate}
 import kafka.utils.Implicits._
 import kafka.utils.{Logging, Pool}
 import org.apache.kafka.common.config.ConfigResource
@@ -390,6 +391,7 @@ class RequestChannel(val queueSize: Int,
 
   // AutoMQ inject start - request error accumulator
   @volatile var requestErrorAccumulator: RequestErrorAccumulator = _
+  @volatile private var retryStormResponseGate: RetryStormResponseGate = _
   // AutoMQ inject end
 
   metricsGroup.newGauge(requestQueueSizeMetricName, () => {
@@ -467,9 +469,33 @@ class RequestChannel(val queueSize: Int,
     response: AbstractResponse,
     onComplete: Option[Send => Unit]
   ): Unit = {
+    // AutoMQ inject start
+    val gate = retryStormResponseGate
+    val shouldExtract = requestErrorAccumulator != null || (gate != null && !request.isForwarded)
+    val errorView =
+      if (shouldExtract) ResourceErrorExtractor.extractView(request, response)
+      else ResourceErrorExtractor.ResourceErrorView.empty()
+    val sendNow = new Runnable {
+      override def run(): Unit = sendResponseAfterRetryStormGate(request, response, onComplete, errorView)
+    }
+    if (gate != null && !request.isForwarded) {
+      val context = new RetryStormRequestContext(request.header.apiKey, request.context.connectionId, time.milliseconds())
+      gate.sendOrDelay(context, errorView, retryStormDelayCapMs(request, response), sendNow)
+    } else {
+      sendNow.run()
+    }
+  }
+
+  private def sendResponseAfterRetryStormGate(
+    request: RequestChannel.Request,
+    response: AbstractResponse,
+    onComplete: Option[Send => Unit],
+    errorView: ResourceErrorExtractor.ResourceErrorView
+  ): Unit = {
+    // AutoMQ inject end
     updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala)
     // AutoMQ inject start
-    maybeRecordRequestErrors(request, response)
+    maybeRecordRequestErrors(request, errorView)
     // AutoMQ inject end
     sendResponse(new RequestChannel.SendResponse(
       request,
@@ -575,13 +601,32 @@ class RequestChannel(val queueSize: Int,
     requestQueue.take()
 
   // AutoMQ inject start
-  private def maybeRecordRequestErrors(
+  /** Injects the retry storm gate used by the data-plane normal response send path. */
+  def setRetryStormResponseGate(gate: RetryStormResponseGate): Unit = {
+    retryStormResponseGate = gate
+  }
+
+  private def retryStormDelayCapMs(
     request: RequestChannel.Request,
     response: AbstractResponse
+  ): java.util.OptionalLong = {
+    if (!request.header.apiKey.equals(ApiKeys.FETCH) || !response.isInstanceOf[FetchResponse]) {
+      return java.util.OptionalLong.empty()
+    }
+    val fetchRequest = request.body[FetchRequest]
+    val elapsedMs =
+      if (request.requestDequeueTimeNanos < 0) 0L
+      else TimeUnit.NANOSECONDS.toMillis(time.nanoseconds() - request.requestDequeueTimeNanos)
+    java.util.OptionalLong.of(Math.max(fetchRequest.maxWait - elapsedMs, 0L))
+  }
+
+  private def maybeRecordRequestErrors(
+    request: RequestChannel.Request,
+    errorView: ResourceErrorExtractor.ResourceErrorView
   ): Unit = {
     val acc = requestErrorAccumulator
     if (acc == null) return
-    val errors = ResourceErrorExtractor.extract(request, response)
+    val errors = errorView.errors()
     if (errors.isEmpty) return
     val clientIp = request.context.clientAddress.getHostAddress
     val clientId = request.header.clientId

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -22,6 +22,7 @@ import kafka.automq.backpressure.{BackPressureConfig, BackPressureManager, Defau
 import kafka.automq.failover.FailoverListener
 import kafka.automq.kafkalinking.KafkaLinkingManager
 import kafka.automq.interceptor.{NoopTrafficInterceptor, TrafficInterceptor}
+import kafka.automq.retrystorm.{RetryStormBackoffConfig, RetryStormBackoffManager, RetryStormBackoffStateStore}
 import kafka.automq.table.TableManager
 import kafka.automq.zerozone.{ConfirmWALProvider, DefaultClientRackProvider, DefaultConfirmWALProvider, DefaultRouterChannelProvider, DefaultLinkRecordDecoder, RouterChannelProvider, ZeroZoneTrafficInterceptor}
 import kafka.cluster.EndPoint
@@ -33,6 +34,7 @@ import kafka.log.streamaspect.ElasticLogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher}
+import kafka.server.retrystorm.{RetryStormBackoffPolicy, RetryStormDelayedResponseScheduler, RetryStormResponseGate, SampledRetryStormBackoffLogger}
 import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager, FetchListener, PartitionLifecycleListener}
 import kafka.utils.CoreUtils
 import org.apache.kafka.clients.admin.ClusterEventPublisher
@@ -170,6 +172,7 @@ class BrokerServer(
   var trafficInterceptor: TrafficInterceptor = _
 
   var backPressureManager: BackPressureManager = _
+  var retryStormBackoffManager: RetryStormBackoffManager = _
 
   val clientRackProvider = new DefaultClientRackProvider(config)
   // init reconfigurable before startup
@@ -450,6 +453,12 @@ class BrokerServer(
         ))
 
       val fetchManager = new FetchManager(Time.SYSTEM, new FetchSessionCache(fetchSessionCacheShards))
+
+      // AutoMQ inject start
+      val retryStormResponseGate = startupRetryStormBackoffManager()
+      socketServer.dataPlaneRequestChannel.setRetryStormResponseGate(retryStormResponseGate)
+      // AutoMQ inject end
+
 
       // Create the request processor objects.
       val raftSupport = RaftSupport(forwardingManager, metadataCache)
@@ -744,10 +753,14 @@ class BrokerServer(
       }
       lifecycleManager.beginShutdown()
 
-      // AutoMQ for Kafka inject start
+      // AutoMQ inject start
       if (backPressureManager != null) {
         CoreUtils.swallow(backPressureManager.shutdown(), this)
       }
+      if (retryStormBackoffManager != null) {
+        CoreUtils.swallow(retryStormBackoffManager.shutdown(), this)
+      }
+      // AutoMQ inject end
 
       // https://github.com/AutoMQ/automq-for-kafka/issues/540
       // await partition shutdown:
@@ -907,6 +920,25 @@ class BrokerServer(
       zeroZoneRouter
     }
     trafficInterceptor
+  }
+
+  private def startupRetryStormBackoffManager(): RetryStormResponseGate = {
+    val retryStormBackoffConfig = RetryStormBackoffConfig.from(config)
+    val retryStormBackoffStateStore = new RetryStormBackoffStateStore()
+    val retryStormBackoffScheduler = new RetryStormDelayedResponseScheduler()
+    val retryStormBackoffPolicy = new RetryStormBackoffPolicy(retryStormBackoffConfig, retryStormBackoffStateStore)
+    val retryStormBackoffLogger = new SampledRetryStormBackoffLogger()
+    val retryStormResponseGate = new RetryStormResponseGate(retryStormBackoffPolicy, retryStormBackoffScheduler)
+    retryStormBackoffManager = new RetryStormBackoffManager(
+      retryStormBackoffConfig,
+      retryStormBackoffPolicy,
+      retryStormResponseGate,
+      retryStormBackoffScheduler,
+      retryStormBackoffStateStore,
+      retryStormBackoffLogger
+    )
+    retryStormBackoffManager.startup()
+    retryStormResponseGate
   }
 
   // AutoMQ inject start

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import kafka.autobalancer.config.{AutoBalancerControllerConfig, AutoBalancerMetricsReporterConfig}
 import kafka.automq.backpressure.BackPressureConfig
+import kafka.automq.retrystorm.RetryStormBackoffConfig
 
 import java.util
 import java.util.{Collections, Properties}
@@ -103,7 +104,8 @@ object DynamicBrokerConfig {
     DynamicRemoteLogConfig.ReconfigurableConfigs ++
     AutoBalancerControllerConfig.RECONFIGURABLE_CONFIGS.asScala ++
     AutoBalancerMetricsReporterConfig.RECONFIGURABLE_CONFIGS.asScala ++
-    BackPressureConfig.RECONFIGURABLE_CONFIGS.asScala
+    BackPressureConfig.RECONFIGURABLE_CONFIGS.asScala ++
+    RetryStormBackoffConfig.RECONFIGURABLE_CONFIGS.asScala
 
   private val ClusterLevelListenerConfigs = Set(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG, SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG)
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
@@ -275,6 +277,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
     kafkaServer match {
       case brokerServer: BrokerServer =>
         addReconfigurable(brokerServer.backPressureManager)
+        addReconfigurable(brokerServer.retryStormBackoffManager)
       case _ =>
     }
     // AutoMQ inject end

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -795,10 +795,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val s3RefillPeriodMsProp = getInt(AutoMQConfig.S3_NETWORK_REFILL_PERIOD_MS_CONFIG)
   val s3MetricsLevel = getString(AutoMQConfig.S3_TELEMETRY_METRICS_LEVEL_CONFIG)
   val s3ExporterReportIntervalMs = getInt(AutoMQConfig.S3_TELEMETRY_EXPORTER_REPORT_INTERVAL_MS_CONFIG)
-  val tableTopicNamespace = getString(TopicConfig.TABLE_TOPIC_NAMESPACE_CONFIG)
   val s3BackPressureEnabled = getBoolean(AutoMQConfig.S3_BACK_PRESSURE_ENABLED_CONFIG)
   val s3BackPressureCooldownMs = getLong(AutoMQConfig.S3_BACK_PRESSURE_COOLDOWN_MS_CONFIG)
+  val tableTopicNamespace = getString(TopicConfig.TABLE_TOPIC_NAMESPACE_CONFIG)
   val tableTopicSchemaRegistryUrl = getString(AutoMQConfig.TABLE_TOPIC_SCHEMA_REGISTRY_URL_CONFIG)
+  val retryStormBackoffEnabled = getBoolean(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG)
+  val retryStormBackoffMaxDelayMs = getLong(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG)
   // AutoMQ inject end
 
   /** Internal Configurations **/

--- a/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffConfigTest.java
+++ b/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import kafka.automq.AutoMQConfig;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers retry storm static and dynamic configuration parsing semantics.
+ */
+@Tag("S3Unit")
+public class RetryStormBackoffConfigTest {
+
+    /**
+     * Given AutoMQ broker config definitions, retry storm is disabled by default with 1000ms max delay.
+     */
+    @Test
+    public void testConfigDefDefaults() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        Map<String, Object> defaults = configDef.defaultValues();
+        assertEquals(false, defaults.get(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG));
+        assertEquals(1000L, defaults.get(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG));
+    }
+
+    /**
+     * Given a dynamic config update, validation rejects a negative max delay before runtime update.
+     */
+    @Test
+    public void testValidateRejectsNegativeMaxDelayMs() {
+        assertThrows(ConfigException.class, () -> RetryStormBackoffConfig.validate(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, -1L
+        )));
+    }
+
+    /**
+     * Given static broker config parsing, ConfigDef rejects negative max delay values.
+     */
+    @Test
+    public void testConfigDefRejectsNegativeMaxDelayMs() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        assertThrows(ConfigException.class, () -> configDef.parse(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, -1L
+        )));
+    }
+
+    /**
+     * Given retry storm delay has a bounded retention contract, static config rejects values above 10 seconds.
+     */
+    @Test
+    public void testConfigDefRejectsMaxDelayAboveUpperBound() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        assertThrows(ConfigException.class, () -> configDef.parse(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, 10001L
+        )));
+    }
+
+    /**
+     * Given a dynamic config update, validation rejects values above the retry storm delay upper bound.
+     */
+    @Test
+    public void testValidateRejectsMaxDelayAboveUpperBound() {
+        assertThrows(ConfigException.class, () -> RetryStormBackoffConfig.validate(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, 10001L
+        )));
+    }
+
+    /**
+     * Given explicit runtime construction, config snapshots reject values above the delay upper bound.
+     */
+    @Test
+    public void testConstructorRejectsMaxDelayAboveUpperBound() {
+        assertThrows(ConfigException.class, () -> new RetryStormBackoffConfig(true, 10001L));
+    }
+
+    /**
+     * Given partial dynamic updates, only the supplied retry storm key changes at runtime.
+     */
+    @Test
+    public void testPartialDynamicUpdate() {
+        RetryStormBackoffConfig config = RetryStormBackoffConfig.from(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG, true,
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, 1000L
+        ));
+
+        config.update(Map.of(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG, false));
+        assertFalse(config.enabled());
+        assertEquals(1000L, config.maxDelayMs());
+
+        config.update(Map.of(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, "250"));
+        assertFalse(config.enabled());
+        assertEquals(250L, config.maxDelayMs());
+    }
+
+    /**
+     * Given Kafka dynamic config registration, both retry storm keys are exposed as reconfigurable.
+     */
+    @Test
+    public void testReconfigurableConfigKeys() {
+        assertTrue(RetryStormBackoffConfig.RECONFIGURABLE_CONFIGS.contains(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG));
+        assertTrue(RetryStormBackoffConfig.RECONFIGURABLE_CONFIGS.contains(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG));
+        assertEquals(2, RetryStormBackoffConfig.RECONFIGURABLE_CONFIGS.size());
+    }
+}

--- a/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffManagerTest.java
+++ b/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffManagerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import kafka.automq.AutoMQConfig;
+import kafka.server.retrystorm.RetryStormBackoffLogger;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers manager integration with Kafka dynamic broker config callbacks.
+ */
+@Tag("S3Unit")
+public class RetryStormBackoffManagerTest {
+
+    /**
+     * Given a validated dynamic update, reconfigure publishes the new runtime values.
+     */
+    @Test
+    public void testReconfigureUpdatesRuntimeConfig() {
+        RetryStormBackoffConfig config = new RetryStormBackoffConfig(true, 1000L);
+        RetryStormBackoffManager manager = new RetryStormBackoffManager(config);
+
+        manager.reconfigure(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG, false,
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, 250L
+        ));
+
+        assertFalse(config.enabled());
+        assertEquals(250L, config.maxDelayMs());
+    }
+
+    /**
+     * Given an invalid dynamic update, manager validation rejects it before runtime state changes.
+     */
+    @Test
+    public void testValidateRejectsInvalidReconfiguration() {
+        RetryStormBackoffManager manager = new RetryStormBackoffManager(new RetryStormBackoffConfig(true, 1000L));
+
+        assertThrows(ConfigException.class, () -> manager.validateReconfiguration(Map.of(
+            AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, -1L
+        )));
+    }
+
+    /**
+     * Given many old delaying states, one periodic logging scan emits no more than ten snapshots.
+     */
+    @Test
+    public void testPeriodicLogScanLimitsSnapshots() {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(1000L, 60000L, 1000L, 100000);
+        CapturingLogger logger = new CapturingLogger();
+        RetryStormBackoffManager manager = new RetryStormBackoffManager(
+            new RetryStormBackoffConfig(true, 1000L),
+            null,
+            null,
+            null,
+            store,
+            logger
+        );
+        for (int i = 0; i < 16; i++) {
+            RetryStormBackoffStateStore.BackoffKey key =
+                new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-" + i, "connection-1");
+            store.recordAndDecide(key, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 1000L);
+            store.recordAndDecide(key, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1L, 1000L);
+        }
+
+        manager.logDelayedStatesOnce();
+        manager.shutdown();
+
+        assertEquals(1, logger.calls.get());
+        assertEquals(10, logger.lastSize);
+    }
+
+    private static class CapturingLogger implements RetryStormBackoffLogger {
+        private final AtomicInteger calls = new AtomicInteger(0);
+        private int lastSize;
+
+        @Override
+        public void logDelayedStates(List<RetryStormBackoffStateStore.DelayedStateSnapshot> snapshots) {
+            calls.incrementAndGet();
+            lastSize = snapshots.size();
+        }
+    }
+}

--- a/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffStateStoreTest.java
+++ b/core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffStateStoreTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.retrystorm;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers per-resource retry storm state transitions and logical-time eviction.
+ */
+@Tag("S3Unit")
+public class RetryStormBackoffStateStoreTest {
+
+    private static final RetryStormBackoffStateStore.BackoffKey KEY =
+        new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-0", "connection-1");
+
+    /**
+     * Given repeated delayable-transient errors, the first failure is immediate and the second delays.
+     */
+    @Test
+    public void testDelayableTransientThreshold() {
+        RetryStormBackoffStateStore store = newStore();
+
+        RetryStormBackoffStateStore.StateDecision first =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1000L);
+        assertFalse(first.delayed());
+
+        RetryStormBackoffStateStore.StateDecision second =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1001L);
+        assertTrue(second.delayed());
+        assertEquals(1000L, second.delayMs());
+        assertTrue((second.reasonMask() & RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT) != 0);
+    }
+
+    /**
+     * Given a store-level default delay, the three-argument record call returns that delay when delaying.
+     */
+    @Test
+    public void testDefaultDelayComesFromStoreConfiguration() {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(1000L, 1000L, 321L, 100000);
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1000L);
+        RetryStormBackoffStateStore.StateDecision delayed =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1001L);
+
+        assertTrue(delayed.delayed());
+        assertEquals(321L, delayed.delayMs());
+    }
+
+    /**
+     * Given protective-only errors, the sixth error in the sliding window delays and expired windows reset.
+     */
+    @Test
+    public void testProtectiveThresholdAndWindowExpiration() {
+        RetryStormBackoffStateStore store = newStore();
+
+        for (int i = 0; i < 5; i++) {
+            assertFalse(store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.protectiveOnlyError(), 1000L + i).delayed());
+        }
+        assertTrue(store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.protectiveOnlyError(), 1005L).delayed());
+
+        RetryStormBackoffStateStore.BackoffKey nextKey =
+            new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-1", "connection-1");
+        for (int i = 0; i < 5; i++) {
+            assertFalse(store.recordAndDecide(nextKey, RetryStormBackoffStateStore.ErrorClassSet.protectiveOnlyError(), 1000L + i).delayed());
+        }
+        assertFalse(store.recordAndDecide(nextKey, RetryStormBackoffStateStore.ErrorClassSet.protectiveOnlyError(), 2101L).delayed());
+    }
+
+    /**
+     * Given a delaying resource has been quiet past recovery timeout, the next error restarts candidate mode.
+     */
+    @Test
+    public void testQuietTimeoutRecoversToCandidate() {
+        RetryStormBackoffStateStore store = newStore();
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1000L);
+        assertTrue(store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1001L).delayed());
+
+        RetryStormBackoffStateStore.StateDecision recovered =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 3102L);
+        assertFalse(recovered.delayed());
+    }
+
+    /**
+     * Given a delayed response has not had quiet time after its send time, state remains delaying.
+     */
+    @Test
+    public void testDelayingStateSurvivesDelayBeforeQuietTimeout() throws Exception {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(10L, 20L, 30L, 100000);
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 30L);
+        assertTrue(store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1L, 30L).delayed());
+
+        Thread.sleep(25L);
+        RetryStormBackoffStateStore.StateDecision stillDelaying =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 40L, 30L);
+        assertTrue(stillDelaying.delayed());
+    }
+
+    /**
+     * Given dynamic max delay exceeds store defaults, logical eviction does not remove active delaying state.
+     */
+    @Test
+    public void testDelayingStateSurvivesDynamicDelayLargerThanStoreDefault() {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(10L, 20L, 30L, 100000);
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 100L);
+        assertTrue(store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1L, 100L).delayed());
+
+        RetryStormBackoffStateStore.BackoffKey nextKey =
+            new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-next", "connection-1");
+        store.recordAndDecide(nextKey, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 80L, 100L);
+
+        RetryStormBackoffStateStore.StateDecision stillDelaying =
+            store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 90L, 100L);
+        assertTrue(stillDelaying.delayed());
+    }
+
+    /**
+     * Given a quiet state exceeds cache retention, cache cleanup removes it without scanning on insertion.
+     */
+    @Test
+    public void testCacheEvictsQuietStateAfterRetention() throws Exception {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(10L, 20L, 30L, 100000, 5L);
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 30L);
+        assertEquals(1, store.trackedDimensions());
+
+        Thread.sleep(80L);
+        store.evictIfNeeded();
+
+        assertEquals(0, store.trackedDimensions());
+    }
+
+    /**
+     * Given more resources than configured capacity, cache maximum size bounds tracked dimensions.
+     */
+    @Test
+    public void testCacheMaximumSizeBoundsTrackedDimensions() {
+        int maxTrackedDimensions = 4;
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(1000L, 1000L, 1000L, maxTrackedDimensions);
+
+        for (int i = 0; i < 16; i++) {
+            RetryStormBackoffStateStore.BackoffKey key = new RetryStormBackoffStateStore.BackoffKey(
+                ApiKeys.PRODUCE.id,
+                "topic-" + i,
+                "connection-1"
+            );
+            store.recordAndDecide(key, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1000L + i);
+        }
+        store.evictIfNeeded();
+
+        assertTrue(store.trackedDimensions() <= maxTrackedDimensions);
+    }
+
+    /**
+     * Given dimensions in candidate and delaying mode, only old-enough delaying states are returned for periodic logs.
+     */
+    @Test
+    public void testDelayedSnapshotsReturnOnlyStatesDelayingLongerThanMinimumAge() {
+        RetryStormBackoffStateStore store = newStore();
+        RetryStormBackoffStateStore.BackoffKey oldDelaying =
+            new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-old", "connection-1");
+        RetryStormBackoffStateStore.BackoffKey youngDelaying =
+            new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-young", "connection-1");
+        RetryStormBackoffStateStore.BackoffKey candidate =
+            new RetryStormBackoffStateStore.BackoffKey(ApiKeys.PRODUCE.id, "topic-candidate", "connection-1");
+
+        store.recordAndDecide(oldDelaying, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 1000L);
+        store.recordAndDecide(oldDelaying, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1L, 1000L);
+        store.recordAndDecide(youngDelaying, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 9000L, 1000L);
+        store.recordAndDecide(youngDelaying, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 9001L, 1000L);
+        store.recordAndDecide(candidate, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 1000L);
+
+        List<RetryStormBackoffStateStore.DelayedStateSnapshot> snapshots =
+            store.delayedSnapshots(11002L, 10000L, 10);
+
+        assertEquals(1, snapshots.size());
+        assertEquals(oldDelaying, snapshots.get(0).key());
+        assertEquals(1L, snapshots.get(0).delayingSinceMs());
+        assertTrue((snapshots.get(0).reasonMask() & RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT) != 0);
+    }
+
+    /**
+     * Given an idle delaying state near cache expiration, snapshot scanning does not refresh cache access time.
+     */
+    @Test
+    public void testDelayedSnapshotDoesNotTouchCacheAccessTime() throws Exception {
+        RetryStormBackoffStateStore store = new RetryStormBackoffStateStore(10L, 0L, 30L, 100000, 200L);
+
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 0L, 30L);
+        store.recordAndDecide(KEY, RetryStormBackoffStateStore.ErrorClassSet.delayableTransientError(), 1L, 30L);
+        Thread.sleep(50L);
+        assertEquals(1, store.delayedSnapshots(11002L, 10000L, 10).size());
+        Thread.sleep(250L);
+        store.evictIfNeeded();
+
+        assertEquals(0, store.trackedDimensions());
+    }
+
+    private static RetryStormBackoffStateStore newStore() {
+        return new RetryStormBackoffStateStore(1000L, 1000L, 1000L, 100000);
+    }
+}

--- a/core/src/test/java/kafka/network/RequestChannelRetryStormTest.java
+++ b/core/src/test/java/kafka/network/RequestChannelRetryStormTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network;
+
+import kafka.automq.retrystorm.RetryStormBackoffConfig;
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+import kafka.server.retrystorm.RetryStormBackoffPolicy;
+import kafka.server.retrystorm.RetryStormDelayedResponseScheduler;
+import kafka.server.retrystorm.RetryStormResponseGate;
+
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers retry storm response gating at the RequestChannel send boundary.
+ */
+@Tag("S3Unit")
+public class RequestChannelRetryStormTest {
+
+    /**
+     * Given RequestChannel owns retry storm gating, the second all-error response is scheduled before enqueue.
+     */
+    @Test
+    public void testRequestChannelSchedulesRetryStormDelay() throws Exception {
+        CapturingScheduler scheduler = new CapturingScheduler();
+        RetryStormResponseGate gate = new RetryStormResponseGate(
+            new RetryStormBackoffPolicy(
+                new RetryStormBackoffConfig(true, 1000L),
+                new RetryStormBackoffStateStore()
+            ),
+            scheduler
+        );
+        RequestChannel channel = new RequestChannel(
+            10,
+            "",
+            Time.SYSTEM,
+            new RequestChannel.Metrics(scala.jdk.javaapi.CollectionConverters.asScala(List.of(ApiKeys.PRODUCE)))
+        );
+        channel.setRetryStormResponseGate(gate);
+
+        channel.sendResponse(request(), allErrorProduceResponse(), scala.Option.empty());
+        channel.sendResponse(request(), allErrorProduceResponse(), scala.Option.empty());
+
+        assertEquals(1, scheduler.scheduled.get());
+    }
+
+    private static RequestChannel.Request request() throws Exception {
+        ProduceRequest request = new ProduceRequest.Builder(
+            ApiKeys.PRODUCE.latestVersion(),
+            ApiKeys.PRODUCE.latestVersion(),
+            new ProduceRequestData().setAcks((short) 1).setTimeoutMs(1000)
+        ).build();
+        return request(request);
+    }
+
+    private static ProduceResponse allErrorProduceResponse() {
+        ProduceResponseData responseData = new ProduceResponseData();
+        responseData.responses().add(new ProduceResponseData.TopicProduceResponse().setName("topic").setPartitionResponses(List.of(
+            new ProduceResponseData.PartitionProduceResponse().setIndex(0).setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code())
+        )));
+        return new ProduceResponse(responseData);
+    }
+
+    private static RequestChannel.Request request(AbstractRequest request) throws Exception {
+        ByteBuffer buffer = request.serializeWithHeader(new RequestHeader(request.apiKey(), request.version(), "client-id", 1));
+        RequestHeader header = RequestHeader.parse(buffer);
+        RequestContext context = new RequestContext(
+            header,
+            "connection-id",
+            InetAddress.getLoopbackAddress(),
+            Optional.empty(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false,
+            Optional.empty()
+        );
+        return new RequestChannel.Request(
+            1,
+            context,
+            0L,
+            MemoryPool.NONE,
+            buffer,
+            new RequestChannel.Metrics(scala.jdk.javaapi.CollectionConverters.asScala(List.of(ApiKeys.PRODUCE))),
+            scala.Option.apply(null)
+        );
+    }
+
+    private static class CapturingScheduler extends RetryStormDelayedResponseScheduler {
+        private final AtomicInteger scheduled = new AtomicInteger(0);
+
+        private CapturingScheduler() {
+            super(10L);
+        }
+
+        @Override
+        public void schedule(long delayMs, Runnable sendNow) {
+            scheduled.incrementAndGet();
+        }
+    }
+}

--- a/core/src/test/java/kafka/server/ResourceErrorExtractorTest.java
+++ b/core/src/test/java/kafka/server/ResourceErrorExtractorTest.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server;
+
+import kafka.network.RequestChannel;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
+import org.apache.kafka.common.message.ListOffsetsResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.DescribeTopicPartitionsRequest;
+import org.apache.kafka.common.requests.DescribeTopicPartitionsResponse;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
+import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetFetchRequest;
+import org.apache.kafka.common.requests.OffsetFetchResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Covers shared resource error extraction for request error accumulation and retry storm policy.
+ */
+@Tag("S3Unit")
+@SuppressWarnings("ClassDataAbstractionCoupling")
+public class ResourceErrorExtractorTest {
+
+    /**
+     * Given Produce has one success and one error, the error is partition-scoped but not all-error.
+     */
+    @Test
+    public void testProducePartialSuccessReturnsPartitionErrorButNotAllError() throws Exception {
+        ProduceRequest request = new ProduceRequest.Builder(
+            ApiKeys.PRODUCE.latestVersion(),
+            ApiKeys.PRODUCE.latestVersion(),
+            new ProduceRequestData().setAcks((short) 1).setTimeoutMs(1000)
+        ).build();
+        ProduceResponseData responseData = new ProduceResponseData();
+        responseData.responses().add(new ProduceResponseData.TopicProduceResponse().setName("topic").setPartitionResponses(List.of(
+            new ProduceResponseData.PartitionProduceResponse().setIndex(0).setErrorCode(Errors.NONE.code()),
+            new ProduceResponseData.PartitionProduceResponse().setIndex(1).setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code())
+        )));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new ProduceResponse(responseData));
+
+        assertFalse(view.allErrorCandidate());
+        assertEquals(List.of(new ResourceErrorExtractor.ResourceError(Errors.NOT_LEADER_OR_FOLLOWER.code(), "topic-1")), view.errors());
+    }
+
+    /**
+     * Given Produce has only partition errors, the view is an all-error candidate with partition keys.
+     */
+    @Test
+    public void testProduceAllErrorsReturnsAllErrorCandidate() throws Exception {
+        ProduceRequest request = new ProduceRequest.Builder(
+            ApiKeys.PRODUCE.latestVersion(),
+            ApiKeys.PRODUCE.latestVersion(),
+            new ProduceRequestData().setAcks((short) 1).setTimeoutMs(1000)
+        ).build();
+        ProduceResponseData responseData = new ProduceResponseData();
+        responseData.responses().add(new ProduceResponseData.TopicProduceResponse().setName("topic").setPartitionResponses(List.of(
+            new ProduceResponseData.PartitionProduceResponse().setIndex(0).setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code()),
+            new ProduceResponseData.PartitionProduceResponse().setIndex(1).setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+        )));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new ProduceResponse(responseData));
+
+        assertTrue(view.allErrorCandidate());
+        Set<String> resourceKeys = view.errors().stream()
+            .map(ResourceErrorExtractor.ResourceError::resource)
+            .collect(Collectors.toSet());
+        assertEquals(Set.of("topic-0", "topic-1"), resourceKeys);
+    }
+
+    /**
+     * Given Fetch has a NONE partition with empty records and another error, it is not all-error.
+     */
+    @Test
+    public void testFetchNoneEmptyRecordsCountsAsValidResult() throws Exception {
+        FetchRequest request = FetchRequest.Builder
+            .forConsumer(ApiKeys.FETCH.latestVersion(), 100, 1024, FetchRequestDataFixtures.emptyFetchData())
+            .build();
+        FetchResponseData responseData = new FetchResponseData();
+        responseData.responses().add(new FetchResponseData.FetchableTopicResponse().setTopic("topic").setPartitions(List.of(
+            new FetchResponseData.PartitionData().setPartitionIndex(0).setErrorCode(Errors.NONE.code()),
+            new FetchResponseData.PartitionData().setPartitionIndex(1).setErrorCode(Errors.FENCED_LEADER_EPOCH.code())
+        )));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new FetchResponse(responseData));
+
+        assertFalse(view.allErrorCandidate());
+        assertEquals(List.of(new ResourceErrorExtractor.ResourceError(Errors.FENCED_LEADER_EPOCH.code(), "topic-1")), view.errors());
+    }
+
+    /**
+     * Given ListOffsets has a valid offset and another partition error, it is not all-error.
+     */
+    @Test
+    public void testListOffsetsValidOffsetCountsAsValidResult() throws Exception {
+        ListOffsetsRequest request = ListOffsetsRequest.Builder
+            .forConsumer(true, org.apache.kafka.common.IsolationLevel.READ_UNCOMMITTED)
+            .setTargetTimes(List.of(new ListOffsetsRequestData.ListOffsetsTopic()
+                .setName("topic")
+                .setPartitions(List.of(
+                    new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(0).setTimestamp(1000L),
+                    new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(1).setTimestamp(1000L)
+                ))))
+            .build((short) 1);
+        ListOffsetsResponseData responseData = new ListOffsetsResponseData();
+        responseData.topics().add(new ListOffsetsResponseData.ListOffsetsTopicResponse().setName("topic").setPartitions(List.of(
+            new ListOffsetsResponseData.ListOffsetsPartitionResponse()
+                .setPartitionIndex(0)
+                .setErrorCode(Errors.NONE.code())
+                .setOffset(12L),
+            new ListOffsetsResponseData.ListOffsetsPartitionResponse()
+                .setPartitionIndex(1)
+                .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code())
+                .setOffset(ListOffsetsResponse.UNKNOWN_OFFSET)
+        )));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new ListOffsetsResponse(responseData));
+
+        assertFalse(view.allErrorCandidate());
+        assertEquals(List.of(new ResourceErrorExtractor.ResourceError(Errors.NOT_LEADER_OR_FOLLOWER.code(), "topic-1")), view.errors());
+    }
+
+    /**
+     * Given OffsetForLeaderEpoch has only partition errors, the view is an all-error candidate.
+     */
+    @Test
+    public void testOffsetForLeaderEpochAllErrorsReturnsAllErrorCandidate() throws Exception {
+        OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection topics =
+            new OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection();
+        topics.add(new OffsetForLeaderEpochRequestData.OffsetForLeaderTopic()
+            .setTopic("topic")
+            .setPartitions(List.of(new OffsetForLeaderEpochRequestData.OffsetForLeaderPartition()
+                .setPartition(0)
+                .setLeaderEpoch(1))));
+        OffsetsForLeaderEpochRequest request = OffsetsForLeaderEpochRequest.Builder.forConsumer(topics).build((short) 3);
+        OffsetForLeaderEpochResponseData responseData = new OffsetForLeaderEpochResponseData();
+        responseData.topics().add(new OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult()
+            .setTopic("topic")
+            .setPartitions(List.of(new OffsetForLeaderEpochResponseData.EpochEndOffset()
+                .setPartition(0)
+                .setErrorCode(Errors.FENCED_LEADER_EPOCH.code())
+                .setEndOffset(OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET))));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new OffsetsForLeaderEpochResponse(responseData));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(List.of(new ResourceErrorExtractor.ResourceError(Errors.FENCED_LEADER_EPOCH.code(), "topic-0")), view.errors());
+    }
+
+    /**
+     * Given all-topics Metadata includes cluster metadata, broker/controller data makes errors non-all-error.
+     */
+    @Test
+    public void testAllTopicsMetadataClusterDataCountsAsValidResult() throws Exception {
+        MetadataRequest request = MetadataRequest.Builder.allTopics().build((short) 12);
+        MetadataResponseData responseData = metadataWithLeaderUnavailable();
+        responseData.brokers().add(new MetadataResponseData.MetadataResponseBroker()
+            .setNodeId(1)
+            .setHost("localhost")
+            .setPort(9092));
+        responseData.setControllerId(1);
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new MetadataResponse(responseData, (short) 12));
+
+        assertFalse(view.allErrorCandidate());
+        assertTrue(resources(view).contains("topic"));
+        assertTrue(resources(view).contains("topic-0"));
+    }
+
+    /**
+     * Given explicit-topic Metadata has cluster metadata but requested topic errors, cluster data does not mask errors.
+     */
+    @Test
+    public void testExplicitTopicMetadataClusterDataDoesNotMaskTopicErrors() throws Exception {
+        MetadataRequest request = new MetadataRequest.Builder(List.of("topic"), true).build((short) 12);
+        MetadataResponseData responseData = metadataWithLeaderUnavailable();
+        responseData.brokers().add(new MetadataResponseData.MetadataResponseBroker()
+            .setNodeId(1)
+            .setHost("localhost")
+            .setPort(9092));
+        responseData.setControllerId(1);
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new MetadataResponse(responseData, (short) 12));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(Set.of("topic", "topic-0"), resources(view));
+    }
+
+    /**
+     * Given Metadata topic-level NONE with partition errors, topic NONE does not count as a valid result.
+     */
+    @Test
+    public void testMetadataTopicNoneDoesNotMaskPartitionErrors() throws Exception {
+        MetadataRequest request = new MetadataRequest.Builder(List.of("topic"), true).build((short) 12);
+        MetadataResponseData responseData = new MetadataResponseData();
+        responseData.topics().add(new MetadataResponseData.MetadataResponseTopic()
+            .setName("topic")
+            .setErrorCode(Errors.NONE.code())
+            .setPartitions(List.of(new MetadataResponseData.MetadataResponsePartition()
+                .setPartitionIndex(0)
+                .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                .setLeaderId(-1))));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new MetadataResponse(responseData, (short) 12));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(Set.of("topic-0"), resources(view));
+    }
+
+    /**
+     * Given DescribeTopicPartitions topic-level NONE with partition errors, partition errors remain all-error.
+     */
+    @Test
+    public void testDescribeTopicPartitionsTopicNoneDoesNotMaskPartitionErrors() throws Exception {
+        DescribeTopicPartitionsRequest request = new DescribeTopicPartitionsRequest.Builder(List.of("topic")).build((short) 0);
+        DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
+        responseData.topics().add(new DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic()
+            .setName("topic")
+            .setErrorCode(Errors.NONE.code())
+            .setPartitions(List.of(new DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponsePartition()
+                .setPartitionIndex(0)
+                .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                .setLeaderId(-1))));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new DescribeTopicPartitionsResponse(responseData));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(Set.of("topic-0"), resources(view));
+    }
+
+    /**
+     * Given batch FindCoordinator uses a transaction key, resource keys include the coordinator type prefix.
+     */
+    @Test
+    public void testFindCoordinatorBatchResourceKeyIncludesCoordinatorType() throws Exception {
+        FindCoordinatorRequest request = new FindCoordinatorRequest.Builder(
+            new FindCoordinatorRequestData()
+                .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
+                .setCoordinatorKeys(List.of("shared-key"))
+        ).build((short) 4);
+        FindCoordinatorResponseData responseData = new FindCoordinatorResponseData();
+        responseData.coordinators().add(new FindCoordinatorResponseData.Coordinator()
+            .setKey("shared-key")
+            .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code())
+            .setNodeId(-1));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new FindCoordinatorResponse(responseData));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(List.of(new ResourceErrorExtractor.ResourceError(
+            Errors.COORDINATOR_LOAD_IN_PROGRESS.code(),
+            "transaction-shared-key"
+        )), view.errors());
+    }
+
+    /**
+     * Given OffsetFetch v8 batch has two group errors, extractor keeps separate per-group resource keys.
+     */
+    @Test
+    public void testOffsetFetchBatchUsesPerGroupResourceKeys() throws Exception {
+        OffsetFetchRequest request = new OffsetFetchRequest.Builder(Map.of(
+            "group-a", List.of(new TopicPartition("topic", 0)),
+            "group-b", List.of(new TopicPartition("topic", 1))
+        ), false, false).build((short) 8);
+        OffsetFetchResponseData responseData = new OffsetFetchResponseData();
+        responseData.groups().add(offsetFetchGroup("group-a", Errors.COORDINATOR_LOAD_IN_PROGRESS));
+        responseData.groups().add(offsetFetchGroup("group-b", Errors.NOT_COORDINATOR));
+
+        ResourceErrorExtractor.ResourceErrorView view =
+            ResourceErrorExtractor.extractView(request(request), new OffsetFetchResponse(responseData, (short) 8));
+
+        assertTrue(view.allErrorCandidate());
+        assertEquals(Set.of("group-group-a", "group-group-b"), resources(view));
+    }
+
+    private static RequestChannel.Request request(AbstractRequest request) throws Exception {
+        ByteBuffer buffer = request.serializeWithHeader(new RequestHeader(request.apiKey(), request.version(), "client-id", 1));
+        RequestHeader header = RequestHeader.parse(buffer);
+        RequestContext context = new RequestContext(
+            header,
+            "connection-id",
+            InetAddress.getLoopbackAddress(),
+            Optional.empty(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false,
+            Optional.empty()
+        );
+        return new RequestChannel.Request(
+            1,
+            context,
+            0L,
+            MemoryPool.NONE,
+            buffer,
+            mock(RequestChannel.Metrics.class),
+            scala.Option.apply(null)
+        );
+    }
+
+    private static MetadataResponseData metadataWithLeaderUnavailable() {
+        MetadataResponseData responseData = new MetadataResponseData();
+        responseData.topics().add(new MetadataResponseData.MetadataResponseTopic()
+            .setName("topic")
+            .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+            .setPartitions(List.of(new MetadataResponseData.MetadataResponsePartition()
+                .setPartitionIndex(0)
+                .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                .setLeaderId(-1))));
+        return responseData;
+    }
+
+    private static OffsetFetchResponseData.OffsetFetchResponseGroup offsetFetchGroup(String groupId, Errors error) {
+        return new OffsetFetchResponseData.OffsetFetchResponseGroup()
+            .setGroupId(groupId)
+            .setErrorCode(error.code())
+            .setTopics(List.of(new OffsetFetchResponseData.OffsetFetchResponseTopics()
+                .setName("topic")
+                .setPartitions(List.of(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                    .setPartitionIndex(0)
+                    .setErrorCode(error.code())
+                    .setCommittedOffset(OffsetFetchResponse.INVALID_OFFSET)))));
+    }
+
+    private static Set<String> resources(ResourceErrorExtractor.ResourceErrorView view) {
+        return view.errors().stream()
+            .map(ResourceErrorExtractor.ResourceError::resource)
+            .collect(Collectors.toSet());
+    }
+
+    private static final class FetchRequestDataFixtures {
+        private static Map<TopicPartition, FetchRequest.PartitionData> emptyFetchData() {
+            return new HashMap<>();
+        }
+    }
+}

--- a/core/src/test/java/kafka/server/ResourceErrorExtractorTest.java
+++ b/core/src/test/java/kafka/server/ResourceErrorExtractorTest.java
@@ -161,14 +161,14 @@ public class ResourceErrorExtractorTest {
     @Test
     public void testListOffsetsValidOffsetCountsAsValidResult() throws Exception {
         ListOffsetsRequest request = ListOffsetsRequest.Builder
-            .forConsumer(true, org.apache.kafka.common.IsolationLevel.READ_UNCOMMITTED)
+            .forConsumer(true, org.apache.kafka.common.IsolationLevel.READ_UNCOMMITTED, false)
             .setTargetTimes(List.of(new ListOffsetsRequestData.ListOffsetsTopic()
                 .setName("topic")
                 .setPartitions(List.of(
                     new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(0).setTimestamp(1000L),
                     new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(1).setTimestamp(1000L)
                 ))))
-            .build((short) 1);
+            .build();
         ListOffsetsResponseData responseData = new ListOffsetsResponseData();
         responseData.topics().add(new ListOffsetsResponseData.ListOffsetsTopicResponse().setName("topic").setPartitions(List.of(
             new ListOffsetsResponseData.ListOffsetsPartitionResponse()

--- a/core/src/test/java/kafka/server/retrystorm/RetryStormBackoffPolicyTest.java
+++ b/core/src/test/java/kafka/server/retrystorm/RetryStormBackoffPolicyTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.automq.AutoMQConfig;
+import kafka.automq.retrystorm.RetryStormBackoffConfig;
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+import kafka.server.ResourceErrorExtractor;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Covers response-level retry storm policy decisions and resource aggregation semantics. */
+@Tag("S3Unit")
+public class RetryStormBackoffPolicyTest {
+
+    /** Given backoff is disabled, errors return immediately and do not seed later enabled decisions. */
+    @Test
+    public void testDisabledConfigReturnsImmediateWithoutStateUpdate() {
+        RetryStormBackoffConfig config = new RetryStormBackoffConfig(false, 1000L);
+        RetryStormBackoffPolicy policy = newPolicy(config);
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L).action());
+
+        config.update(Map.of(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG, true));
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1001L).action());
+    }
+
+    /** Given state is error-driven, skipped success or partial-success responses do not clear delaying state. */
+    @Test
+    public void testSkippedValidResultDoesNotClearState() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L).action());
+        assertEquals(BackoffAction.DELAYED, evaluate(policy, ApiKeys.PRODUCE, errors, 1001L).action());
+        BackoffDecision stillDelayed = evaluate(policy, ApiKeys.PRODUCE, errors, 1003L);
+        assertEquals(BackoffAction.DELAYED, stillDelayed.action());
+    }
+
+    /** Given resource errors, policy derives retry storm classifications from api key and error code. */
+    @Test
+    public void testPolicyClassifiesResourceErrors() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L).action());
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, errors, 1001L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertTrue((decision.reasonMask() & RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT) != 0);
+    }
+
+    /** Given repeated delayable-transient errors for one resource, the second failure delays. */
+    @Test
+    public void testDelayableTransientSecondFailureDelays() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L).action());
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, errors, 1001L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(1000L, decision.delayMs());
+        assertTrue((decision.reasonMask() & RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT) != 0);
+    }
+
+    /** Given protective-only errors for one resource, the sixth failure in the window delays. */
+    @Test
+    public void testProtectiveSixthFailureDelays() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors =
+            List.of(error(Errors.UNKNOWN_TOPIC_OR_PARTITION, "topic-0"));
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L + i).action());
+        }
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, errors, 1005L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertTrue((decision.reasonMask() & RetryStormBackoffStateStore.REASON_PROTECTIVE_ERROR) != 0);
+    }
+
+    /** Given a batch with one resource already delaying, response-level delay uses that resource decision. */
+    @Test
+    public void testBatchAggregatesDelayedResources() {
+        RetryStormBackoffPolicy policy = newPolicy(new RetryStormBackoffConfig(true, 250L));
+        evaluate(policy, ApiKeys.PRODUCE, leaderErrors("topic-0"), 1000L);
+
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, List.of(
+            error(Errors.NOT_LEADER_OR_FOLLOWER, "topic-0"),
+            error(Errors.NOT_LEADER_OR_FOLLOWER, "topic-1")
+        ), 1001L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(250L, decision.delayMs());
+        assertTrue((decision.reasonMask() & RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT) != 0);
+    }
+
+    /**
+     * Given mixed transient and non-transient errors, each resource uses its own error class and
+     * response delay aggregates the strictest resource decision.
+     */
+    @Test
+    public void testMixedTransientAndNonTransientBatchAggregatesPerResourceDecisions() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = List.of(
+            error(Errors.NOT_LEADER_OR_FOLLOWER, "topic-0"),
+            error(Errors.UNKNOWN_TOPIC_OR_PARTITION, "topic-1")
+        );
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, errors, 1000L).action());
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, errors, 1001L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(RetryStormBackoffStateStore.REASON_DELAYABLE_TRANSIENT, decision.reasonMask());
+    }
+
+    /** Given separate protective-only resources reach threshold, response-level delay uses the delayed resource. */
+    @Test
+    public void testBatchAggregatesProtectiveResourceReasons() {
+        RetryStormBackoffPolicy policy = newPolicy(new RetryStormBackoffConfig(true, 500L));
+        List<ResourceErrorExtractor.ResourceError> seeded =
+            List.of(error(Errors.UNKNOWN_TOPIC_OR_PARTITION, "topic-1"));
+        for (int i = 0; i < 5; i++) {
+            assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.PRODUCE, seeded, 1000L + i).action());
+        }
+
+        BackoffDecision decision = evaluate(policy, ApiKeys.PRODUCE, List.of(
+            error(Errors.UNKNOWN_TOPIC_OR_PARTITION, "topic-0"),
+            error(Errors.UNKNOWN_TOPIC_OR_PARTITION, "topic-1")
+        ), 1006L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(500L, decision.delayMs());
+        assertEquals(RetryStormBackoffStateStore.REASON_PROTECTIVE_ERROR, decision.reasonMask());
+    }
+
+    /** Given an extractor delay cap, response delay is bounded below the configured maximum. */
+    @Test
+    public void testResponseDelayCapLimitsDecisionDelay() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluateFetch(policy, errors, OptionalLong.of(25L), 1000L).action());
+        BackoffDecision decision = evaluateFetch(policy, errors, OptionalLong.of(25L), 1001L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(25L, decision.delayMs());
+    }
+
+    /** Given a zero delay cap, policy updates state but returns immediate until an uncapped response arrives. */
+    @Test
+    public void testZeroResponseDelayCapUpdatesStateButReturnsImmediate() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors = leaderErrors("topic-0");
+
+        assertEquals(BackoffAction.IMMEDIATE, evaluateFetch(policy, errors, OptionalLong.of(0L), 1000L).action());
+        assertEquals(BackoffAction.IMMEDIATE, evaluateFetch(policy, errors, OptionalLong.of(0L), 1001L).action());
+        BackoffDecision decision = evaluateFetch(policy, errors, OptionalLong.empty(), 1002L);
+        assertEquals(BackoffAction.DELAYED, decision.action());
+        assertEquals(1000L, decision.delayMs());
+    }
+
+    /** Given an unsupported API has resource errors, policy does not update state or delay. */
+    @Test
+    public void testUnsupportedApiReturnsImmediateWithoutStateUpdate() {
+        RetryStormBackoffPolicy policy = newPolicy();
+        List<ResourceErrorExtractor.ResourceError> errors =
+            List.of(error(Errors.COORDINATOR_NOT_AVAILABLE, "group-a"));
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals(BackoffAction.IMMEDIATE, evaluate(policy, ApiKeys.HEARTBEAT, errors, 1000L + i).action());
+        }
+    }
+
+    private static BackoffDecision evaluate(RetryStormBackoffPolicy policy,
+                                            ApiKeys apiKey,
+                                            List<ResourceErrorExtractor.ResourceError> errors,
+                                            long nowMs) {
+        return policy.evaluate(apiKey, errors, new BackoffContext("connection-1", nowMs), OptionalLong.empty());
+    }
+
+    private static BackoffDecision evaluateFetch(RetryStormBackoffPolicy policy,
+                                                 List<ResourceErrorExtractor.ResourceError> errors,
+                                                 OptionalLong delayCapMs,
+                                                 long nowMs) {
+        return policy.evaluate(ApiKeys.FETCH, errors, new BackoffContext("connection-1", nowMs), delayCapMs);
+    }
+
+    private static List<ResourceErrorExtractor.ResourceError> leaderErrors(String resource) {
+        return List.of(error(Errors.NOT_LEADER_OR_FOLLOWER, resource));
+    }
+
+    private static ResourceErrorExtractor.ResourceError error(Errors error, String resource) {
+        return new ResourceErrorExtractor.ResourceError(error.code(), resource);
+    }
+
+    private static RetryStormBackoffPolicy newPolicy() {
+        return newPolicy(new RetryStormBackoffConfig(true, 1000L));
+    }
+
+    private static RetryStormBackoffPolicy newPolicy(RetryStormBackoffConfig config) {
+        return new RetryStormBackoffPolicy(config, new RetryStormBackoffStateStore());
+    }
+}

--- a/core/src/test/java/kafka/server/retrystorm/RetryStormDelayedResponseSchedulerTest.java
+++ b/core/src/test/java/kafka/server/retrystorm/RetryStormDelayedResponseSchedulerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Covers delayed response scheduler timing, shutdown, and exactly-once send behavior. */
+@Tag("S3Unit")
+public class RetryStormDelayedResponseSchedulerTest {
+
+    /** Given zero delay, scheduler executes the send callback synchronously. */
+    @Test
+    public void testDelayMsZeroSendsImmediately() {
+        RetryStormDelayedResponseScheduler scheduler = new RetryStormDelayedResponseScheduler(10L);
+        AtomicInteger sends = new AtomicInteger(0);
+        try {
+            scheduler.schedule(0L, sends::incrementAndGet);
+            assertEquals(1, sends.get());
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+    /** Given positive delay, scheduler defers the callback until the timer fires. */
+    @Test
+    public void testPositiveDelaySendsLater() throws Exception {
+        RetryStormDelayedResponseScheduler scheduler = new RetryStormDelayedResponseScheduler(10L);
+        AtomicInteger sends = new AtomicInteger(0);
+        try {
+            scheduler.schedule(30L, sends::incrementAndGet);
+            assertEquals(0, sends.get());
+            eventually(1000L, () -> assertEquals(1, sends.get()));
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+    /** Given pending delayed responses at shutdown, scheduler sends each pending callback once. */
+    @Test
+    public void testShutdownSendsPendingResponsesOnce() throws Exception {
+        RetryStormDelayedResponseScheduler scheduler = new RetryStormDelayedResponseScheduler(1000L);
+        AtomicInteger sends = new AtomicInteger(0);
+        scheduler.schedule(10000L, sends::incrementAndGet);
+
+        scheduler.shutdown();
+        assertEquals(1, sends.get());
+
+        Thread.sleep(50L);
+        assertEquals(1, sends.get());
+    }
+
+    /** Given scheduler is already shut down, later schedules fall back to immediate send. */
+    @Test
+    public void testScheduleAfterShutdownSendsImmediately() {
+        RetryStormDelayedResponseScheduler scheduler = new RetryStormDelayedResponseScheduler(1000L);
+        AtomicInteger sends = new AtomicInteger(0);
+
+        scheduler.shutdown();
+        scheduler.schedule(10000L, sends::incrementAndGet);
+
+        assertEquals(1, sends.get());
+    }
+
+    private static void eventually(long timeoutMs, CheckedAssertion assertion) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        AssertionError lastError = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                assertion.run();
+                return;
+            } catch (AssertionError e) {
+                lastError = e;
+                Thread.sleep(10L);
+            }
+        }
+        if (lastError != null) {
+            throw lastError;
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedAssertion {
+        void run() throws Exception;
+    }
+}

--- a/core/src/test/java/kafka/server/retrystorm/RetryStormResponseGateTest.java
+++ b/core/src/test/java/kafka/server/retrystorm/RetryStormResponseGateTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.retrystorm;
+
+import kafka.automq.retrystorm.RetryStormBackoffConfig;
+import kafka.automq.retrystorm.RetryStormBackoffStateStore;
+import kafka.server.ResourceErrorExtractor;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Covers response gate integration across extracted error view, policy, logger, scheduler, and final send callback. */
+@Tag("S3Unit")
+public class RetryStormResponseGateTest {
+
+    /** Given an empty error view, gate bypasses policy and sends immediately. */
+    @Test
+    public void testImmediatePathSendsNow() {
+        AtomicInteger sends = new AtomicInteger(0);
+        CapturingScheduler scheduler = new CapturingScheduler();
+        RetryStormResponseGate gate = newGate(scheduler, RetryStormBackoffLogger.NOOP);
+
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1000L),
+            ResourceErrorExtractor.ResourceErrorView.empty(), OptionalLong.empty(), sends::incrementAndGet);
+
+        assertEquals(1, sends.get());
+        assertEquals(0, scheduler.scheduled.get());
+    }
+
+    /** Given repeated transient all-error views, gate schedules the second response while first is immediate. */
+    @Test
+    public void testDelayedPathSchedules() {
+        AtomicInteger sends = new AtomicInteger(0);
+        CapturingScheduler scheduler = new CapturingScheduler();
+        RetryStormResponseGate gate = newGate(scheduler, RetryStormBackoffLogger.NOOP);
+        ResourceErrorExtractor.ResourceErrorView allError = allErrorView();
+
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1000L),
+            allError, OptionalLong.empty(), sends::incrementAndGet);
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1001L),
+            allError, OptionalLong.empty(), sends::incrementAndGet);
+
+        assertEquals(1, sends.get());
+        assertEquals(1, scheduler.scheduled.get());
+    }
+
+    /** Given partial success has errors but is not all-error, gate sends immediately without updating state. */
+    @Test
+    public void testNonAllErrorViewDoesNotUpdatePolicyState() {
+        AtomicInteger sends = new AtomicInteger(0);
+        CapturingScheduler scheduler = new CapturingScheduler();
+        RetryStormResponseGate gate = newGate(scheduler, RetryStormBackoffLogger.NOOP);
+        ResourceErrorExtractor.ResourceErrorView partial =
+            new ResourceErrorExtractor.ResourceErrorView(false, List.of(
+                new ResourceErrorExtractor.ResourceError(Errors.NOT_LEADER_OR_FOLLOWER.code(), "topic-0")
+            ));
+        ResourceErrorExtractor.ResourceErrorView allError = allErrorView();
+
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1000L),
+            partial, OptionalLong.empty(), sends::incrementAndGet);
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1001L),
+            allError, OptionalLong.empty(), sends::incrementAndGet);
+
+        assertEquals(2, sends.get());
+        assertEquals(0, scheduler.scheduled.get());
+    }
+
+    /** Given policy evaluation fails, gate falls back to immediate send without scheduling. */
+    @Test
+    public void testPolicyFailureFallsBackToImmediateSend() {
+        AtomicInteger sends = new AtomicInteger(0);
+        CapturingScheduler scheduler = new CapturingScheduler();
+        RetryStormResponseGate gate = newGate(scheduler, RetryStormBackoffLogger.NOOP);
+        ResourceErrorExtractor.ResourceErrorView invalidErrorView =
+            new ResourceErrorExtractor.ResourceErrorView(true, List.of(
+                new ResourceErrorExtractor.ResourceError(Short.MIN_VALUE, "topic-0")
+            ));
+
+        gate.sendOrDelay(new RetryStormRequestContext(ApiKeys.PRODUCE, "connection-1", 1000L),
+            invalidErrorView, OptionalLong.empty(), sends::incrementAndGet);
+
+        assertEquals(1, sends.get());
+        assertEquals(0, scheduler.scheduled.get());
+    }
+
+    private static RetryStormResponseGate newGate(CapturingScheduler scheduler,
+                                                  RetryStormBackoffLogger ignoredLogger) {
+        RetryStormBackoffPolicy policy = new RetryStormBackoffPolicy(
+            new RetryStormBackoffConfig(true, 1000L),
+            new RetryStormBackoffStateStore()
+        );
+        return new RetryStormResponseGate(policy, scheduler);
+    }
+
+    private static ResourceErrorExtractor.ResourceErrorView allErrorView() {
+        return new ResourceErrorExtractor.ResourceErrorView(true, List.of(
+            new ResourceErrorExtractor.ResourceError(Errors.NOT_LEADER_OR_FOLLOWER.code(), "topic-0")
+        ));
+    }
+
+    private static class CapturingScheduler extends RetryStormDelayedResponseScheduler {
+        private final AtomicInteger scheduled = new AtomicInteger(0);
+
+        private CapturingScheduler() {
+            super(10L);
+        }
+
+        @Override
+        public void schedule(long delayMs, Runnable sendNow) {
+            scheduled.incrementAndGet();
+        }
+    }
+}

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -22,6 +22,7 @@ import java.util.{Properties, Map => JMap}
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.atomic.AtomicReference
 import kafka.controller.KafkaController
+import kafka.automq.AutoMQConfig
 import kafka.log.LogManager
 import kafka.log.remote.RemoteLogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
@@ -45,6 +46,7 @@ import org.apache.kafka.server.util.KafkaScheduler
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, ProducerStateManagerConfig}
 import org.apache.kafka.test.MockMetricsReporter
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
@@ -55,6 +57,14 @@ import scala.jdk.CollectionConverters._
 import scala.collection.Set
 
 class DynamicBrokerConfigTest {
+
+  /** Given retry storm configs are dynamic broker configs, registry exposes both keys for AdminClient updates. */
+  @Test
+  @Tag("S3Unit")
+  def testRetryStormBackoffConfigsAreDynamic(): Unit = {
+    assertTrue(DynamicBrokerConfig.AllDynamicConfigs.contains(AutoMQConfig.RETRY_STORM_BACKOFF_ENABLED_CONFIG))
+    assertTrue(DynamicBrokerConfig.AllDynamicConfigs.contains(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG))
+  }
 
   @Test
   def testConfigUpdate(): Unit = {

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -639,6 +639,15 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     <Match>
         <Package name="~com\.automq\.events"/>
     </Match>
+    <!-- Suppress singleton-constructor warnings for immutable retry-storm value types that expose public constructors. -->
+    <Match>
+        <Or>
+            <Class name="kafka.automq.retrystorm.RetryStormBackoffStateStore$StateDecision"/>
+            <Class name="kafka.server.ResourceErrorExtractor$ResourceErrorView"/>
+            <Class name="kafka.server.retrystorm.BackoffDecision"/>
+        </Or>
+        <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
+    </Match>
     <!-- AutoMQ inject end -->
 
     <Match>

--- a/tests/kafkatest/automq/retry_storm_backoff_test.py
+++ b/tests/kafkatest/automq/retry_storm_backoff_test.py
@@ -1,0 +1,127 @@
+"""
+Copyright 2026, AutoMQ HK Limited. Licensed under Apache-2.0.
+"""
+
+import re
+
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+
+from kafkatest.automq.automq_e2e_util import S3_WAL
+from kafkatest.services.kafka import KafkaService
+
+
+class RetryStormBackoffTest(Test):
+    """
+    End-to-end validation for retry storm delayed response behavior.
+    """
+
+    PROBE_CLASS = "org.apache.kafka.tools.automq.RetryStormBackoffProbe"
+
+    def __init__(self, test_context):
+        super(RetryStormBackoffTest, self).__init__(test_context)
+        self.kafka = None
+
+    def create_kafka(self):
+        """
+        Create a small AutoMQ Kafka cluster with retry storm backoff using its default disabled state.
+        """
+        log_size = 256 * 1024 * 1024
+        server_prop_overrides = [
+            ["s3.wal.cache.size", str(log_size)],
+            ["s3.wal.capacity", str(log_size)],
+            ["s3.wal.upload.threshold", str(log_size // 4)],
+            ["s3.block.cache.size", str(log_size)],
+            ["s3.wal.path", S3_WAL],
+        ]
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=3,
+            zk=None,
+            kafka_heap_opts="-Xmx1024m -Xms1024m",
+            server_prop_overrides=server_prop_overrides,
+            topics={},
+        )
+
+    def alter_retry_storm_config(self, enabled, max_delay_ms=None):
+        """
+        Dynamically alter retry storm config on every broker so clients can hit any connection target.
+        """
+        config = "automq.retry.storm.backoff.enabled=%s" % str(enabled).lower()
+        if max_delay_ms is not None:
+            config += ",automq.retry.storm.backoff.max.delay.ms=%d" % max_delay_ms
+
+        node = self.kafka.nodes[0]
+        for broker in self.kafka.nodes:
+            cmd = "%s --alter --add-config %s --entity-type brokers --entity-name %s" % (
+                self.kafka.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection=False),
+                config,
+                self.kafka.idx(broker),
+            )
+            node.account.ssh(cmd)
+
+    def run_probe(self, topic, iterations=8):
+        """
+        Run a Java AdminClient probe that keeps one connection while repeatedly describing a missing topic.
+        """
+        node = self.kafka.nodes[0]
+        bootstrap_servers = self.kafka.bootstrap_servers()
+        run_cmd = (
+            "KAFKA_HEAP_OPTS='-Xms64m -Xmx128m' KAFKA_JVM_PERFORMANCE_OPTS='' "
+            "%s %s '%s' '%s' %d" %
+            (
+                self.kafka.path.script("kafka-run-class.sh", node),
+                self.PROBE_CLASS,
+                bootstrap_servers,
+                topic,
+                iterations,
+            )
+        )
+        output = list(node.account.ssh_capture(run_cmd))
+        return self.parse_elapsed_ms(output)
+
+    def parse_elapsed_ms(self, output):
+        """
+        Parse probe stdout into per-request elapsed milliseconds.
+        """
+        elapsed = []
+        for line in output:
+            match = re.search(r"elapsedMs=(\d+)", line)
+            if match:
+                elapsed.append(int(match.group(1)))
+        if not elapsed:
+            raise AssertionError("Probe did not return elapsed timings. Output: %s" % "".join(output))
+        self.logger.info("Retry storm probe elapsed times: %s", elapsed)
+        return elapsed
+
+    def assert_no_protective_delay(self, elapsed):
+        """
+        Assert that protective-threshold requests are not delayed by retry storm backoff.
+        """
+        assert max(elapsed[5:]) < 300, "Expected no retry storm delay, but got timings %s" % elapsed
+
+    def assert_protective_delay(self, elapsed, min_delay_ms):
+        """
+        Assert that the sixth and later same-connection missing-topic metadata requests are delayed.
+        """
+        assert max(elapsed[1:5]) < 300, "Expected requests two through five to return quickly, but got %s" % elapsed
+        assert min(elapsed[5:]) >= min_delay_ms, "Expected protective delay from sixth request, but got %s" % elapsed
+
+    @cluster(num_nodes=3)
+    def test_metadata_protective_backoff_dynamic_config(self):
+        """
+        Verify default-disabled, dynamic-enable, and dynamic-disable behavior for Metadata protective backoff.
+        """
+        self.create_kafka()
+        self.kafka.start()
+
+        disabled_elapsed = self.run_probe("retry-storm-default-disabled-topic", iterations=8)
+        self.assert_no_protective_delay(disabled_elapsed)
+
+        self.alter_retry_storm_config(enabled=True, max_delay_ms=500)
+        enabled_elapsed = self.run_probe("retry-storm-enabled-topic", iterations=8)
+        self.assert_protective_delay(enabled_elapsed, min_delay_ms=350)
+
+        self.alter_retry_storm_config(enabled=False)
+        disabled_again_elapsed = self.run_probe("retry-storm-disabled-again-topic", iterations=8)
+        self.assert_no_protective_delay(disabled_again_elapsed)

--- a/tests/suites/automq_test_suite1.yml
+++ b/tests/suites/automq_test_suite1.yml
@@ -17,3 +17,4 @@
 automq_test_suite:
   included:
     - ../kafkatest/automq/automq_zerozone_test.py
+    - ../kafkatest/automq/retry_storm_backoff_test.py

--- a/tools/src/main/java/org/apache/kafka/tools/automq/RetryStormBackoffProbe.java
+++ b/tools/src/main/java/org/apache/kafka/tools/automq/RetryStormBackoffProbe.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools.automq;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.tools.TerseException;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * System-test probe that repeatedly describes one topic through a single AdminClient connection.
+ *
+ * <p>The probe is intentionally small and prints one timing line per request so ducktape tests can
+ * validate retry storm delayed-response behavior without compiling ad-hoc Java on remote nodes.
+ */
+public class RetryStormBackoffProbe {
+
+    /**
+     * Runs the probe and exits with a process status that reflects argument or client failures.
+     *
+     * @param args bootstrap servers, topic name, and iteration count
+     */
+    public static void main(String[] args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    static int mainNoExit(String[] args) {
+        try {
+            execute(args);
+            return 0;
+        } catch (TerseException e) {
+            System.err.println(e.getMessage());
+            return 1;
+        } catch (Throwable e) {
+            System.err.println(e.getMessage());
+            System.err.println(Utils.stackTrace(e));
+            return 1;
+        }
+    }
+
+    private static void execute(String[] args) throws Exception {
+        if (args.length != 3) {
+            throw new TerseException("USAGE: " + RetryStormBackoffProbe.class.getName()
+                + " bootstrap_servers topic iterations");
+        }
+
+        String bootstrapServers = args[0];
+        String topic = args[1];
+        int iterations = Integer.parseInt(args[2]);
+        if (iterations <= 0) {
+            throw new TerseException("iterations must be positive");
+        }
+
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(AdminClientConfig.CLIENT_ID_CONFIG, "retry-storm-e2e-probe");
+        props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
+
+        try (Admin admin = Admin.create(props)) {
+            for (int i = 1; i <= iterations; i++) {
+                long start = System.nanoTime();
+                String result = "ok";
+                try {
+                    admin.describeTopics(List.of(topic)).allTopicNames().get();
+                } catch (ExecutionException e) {
+                    result = e.getCause().getClass().getSimpleName();
+                }
+                long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+                System.out.println(i + " elapsedMs=" + elapsedMs + " result=" + result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds AutoMQ retry storm backoff for broker data-plane responses.

It introduces a broker-side response gate that can delay all-error responses when a client is repeatedly receiving retryable/transient failures, or when the same request dimension is returning errors fast enough to become protective-load risk. The feature is disabled by default and can be enabled dynamically with
`automq.retry.storm.backoff.enabled`.

The strategy is intentionally conservative:

- Scope: delay only selected broker responses after the response has already been built. The original Kafka error code, response schema, quota throttle semantics, and business semantics are preserved.
- Decision input: `ResourceErrorExtractor` builds a reusable `ResourceErrorView` from the response, including per-resource key, error code, and whether the response is an all-error candidate. This is shared with existing request error accumulation instead of re-parsing for retry storm only.
- Tracking dimension: `apiKey + resourceKey + connectionId`. This keeps different resources and client connections isolated.
- Fast transient protection: delayable transient errors use a low threshold. The first failure is immediate; the second failure in the same dimension can be delayed.
- Protective protection: non-transient or mixed all-error responses can enter a higher threshold protective path. The sixth error within the 1s window can be delayed.
- Batch handling: partial success or any valid result returns immediately and does not update retry storm state. For all-error batches, each resource updates and decides independently, and the response-level delay uses the maximum delay from delayed resource decisions.
- Recovery: state recovery is based on quiet timeout, not successful responses, so success-heavy paths avoid extra state mutation work.
- State management: retry storm state is held in a bounded Guava cache with TTL and maximum tracked dimensions. Delaying-state logging scans cache entries without refreshing access time.
- Observability: a periodic sampled logger prints at most 10 dimensions per minute that have been delaying for more than 10s, including API key, resource key, client scope, reason bitmask as strings, delayingSinceMs, and lastFailureMs.
- Safety: the response gate fails open. If retry storm evaluation throws, the original response is sent immediately.

Configuration:

- `automq.retry.storm.backoff.enabled`: dynamic broker config, default `false`.
- `automq.retry.storm.backoff.max.delay.ms`: dynamic broker config, default `1000`, valid range `[0, 10000]`. `0` means decisions may update state but responses are not scheduled for delay.

Suggested review order:

1. Config and lifecycle
   - `core/src/main/java/kafka/automq/AutoMQConfig.java` -
`core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffConfig.java` -
`core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffManager.java`
   - `core/src/main/scala/kafka/server/BrokerServer.scala`
   - `core/src/main/scala/kafka/server/KafkaConfig.scala`
   - `core/src/main/scala/kafka/server/DynamicBrokerConfig.scala`

2. Response extraction and existing request error accumulator integration
   - `core/src/main/java/kafka/server/ResourceErrorExtractor.java`
   - `core/src/main/scala/kafka/network/RequestChannel.scala`

3. Backoff decision and state machine -
`core/src/main/java/kafka/automq/retrystorm/RetryStormBackoffStateStore.java` -
`core/src/main/java/kafka/server/retrystorm/RetryStormBackoffPolicy.java`
   - `core/src/main/java/kafka/server/retrystorm/BackoffDecision.java`
   - `core/src/main/java/kafka/server/retrystorm/BackoffContext.java`

4. Response scheduling/gating and fail-open behavior -
`core/src/main/java/kafka/server/retrystorm/RetryStormResponseGate.java` -
`core/src/main/java/kafka/server/retrystorm/RetryStormDelayedResponseScheduler.java`
   - `core/src/main/scala/kafka/server/RequestHandlerHelper.scala`
- `core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala`

5. Periodic sampled logging -
`core/src/main/java/kafka/server/retrystorm/SampledRetryStormBackoffLogger.java` -
`core/src/main/java/kafka/server/retrystorm/RetryStormBackoffLogger.java`

6. Tests and E2E
   - `core/src/test/java/kafka/server/ResourceErrorExtractorTest.java` -
`core/src/test/java/kafka/server/retrystorm/RetryStormBackoffPolicyTest.java` -
`core/src/test/java/kafka/automq/retrystorm/RetryStormBackoffStateStoreTest.java`
- `core/src/test/java/kafka/network/RequestChannelRetryStormTest.java`
   - `tests/kafkatest/automq/retry_storm_backoff_test.py` -
`tools/src/main/java/org/apache/kafka/tools/automq/RetryStormBackoffProbe.java`

Reviewer focus areas:

- Confirm all successful or partially successful responses remain immediate and do not update retry storm state.
- Confirm mixed all-error batches use per-resource decisions and response-level max delay aggregation.
- Confirm retry storm state is bounded and quiet-time recovery does not rely on success-path updates.
- Confirm quota/throttle behavior and shutdown behavior remain compatible with existing Kafka response handling.
- Confirm default-off compatibility is acceptable for the 1.7 branch.

Fresh local checks before opening this PR:

- `git diff --check origin/1.7...HEAD` passed.
- `python3 -m py_compile tests/kafkatest/automq/retry_storm_backoff_test.py` passed.
- `./gradlew tools:compileJava` passed.
- `./gradlew core:S3UnitTest --tests kafka.automq.retrystorm.RetryStormBackoffConfigTest --tests kafka.automq.retrystorm.RetryStormBackoffStateStoreTest --tests kafka.automq.retrystorm.RetryStormBackoffManagerTest --tests kafka.server.DynamicBrokerConfigTest.testRetryStormBackoffConfigsAreDynamic --tests kafka.server.ResourceErrorExtractorTest --tests kafka.network.RequestChannelRetryStormTest --tests kafka.server.retrystorm.RetryStormBackoffPolicyTest --tests kafka.server.retrystorm.RetryStormDelayedResponseSchedulerTest --tests kafka.server.retrystorm.RetryStormResponseGateTest` passed.

Previous broader validation recorded during the change:

- `./gradlew --build-cache metadata:S3UnitTest core:S3UnitTest s3stream:test` passed after the main implementation and review-gate fixes.
- Devkit validation passed with dynamic enable/disable and max-delay update behavior.
- E2E test was added to `tests/suites/automq_test_suite1.yml`; full ducktape execution was prepared but not run locally in this session.