### PR TITLE
fix(package): declare proto source jar dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1883,6 +1883,7 @@ project(':clients') {
   compileJava.dependsOn 'processMessages'
   // AutoMQ inject start: ensure proto sources are generated before compilation
   compileJava.dependsOn 'generateProto'
+  srcJar.dependsOn 'generateProto'
   // AutoMQ inject end
   srcJar.dependsOn 'processMessages'
 


### PR DESCRIPTION
## Summary

- declare `:clients:srcJar` dependency on `generateProto`
- fix Gradle implicit dependency validation when publishing source jars with generated protobuf sources

## Verification

- `./gradlew --build-cache :clients:srcJar -PskipSigning=true`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`

Related failure: https://github.com/AutoMQ/automq/actions/runs/26952811949/job/80015750009