### PR TITLE
fix(auth): add authorization for AutoMQ API keys

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/s3/AutomqUpdateGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/s3/AutomqUpdateGroupRequest.java
@@ -41,6 +41,7 @@ public class AutomqUpdateGroupRequest extends AbstractRequest {
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ApiError apiError = ApiError.fromThrowable(e);
         AutomqUpdateGroupResponseData response = new AutomqUpdateGroupResponseData()
+            .setGroupId(data.groupId())
             .setErrorCode(apiError.error().code())
             .setThrottleTimeMs(throttleTimeMs);
         return new AutomqUpdateGroupResponse(response);

--- a/clients/src/main/java/org/apache/kafka/common/requests/s3/DescribeLicenseRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/s3/DescribeLicenseRequest.java
@@ -61,7 +61,7 @@ public class DescribeLicenseRequest extends AbstractRequest {
         ApiError apiError = ApiError.fromThrowable(e);
         DescribeLicenseResponseData response = new DescribeLicenseResponseData()
             .setErrorCode(apiError.error().code())
-            .setErrorMessage(apiError.message())
+            .setErrorMessage(apiError.message() == null ? apiError.error().message() : apiError.message())
             .setThrottleTimeMs(throttleTimeMs);
         return new DescribeLicenseResponse(response);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/s3/DescribeStreamsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/s3/DescribeStreamsRequest.java
@@ -20,10 +20,12 @@
 package org.apache.kafka.common.requests.s3;
 
 import org.apache.kafka.common.message.DescribeStreamsRequestData;
+import org.apache.kafka.common.message.DescribeStreamsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.ApiError;
 
 import java.nio.ByteBuffer;
 
@@ -58,7 +60,11 @@ public class DescribeStreamsRequest extends AbstractRequest {
 
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        return null;
+        ApiError apiError = ApiError.fromThrowable(e);
+        DescribeStreamsResponseData response = new DescribeStreamsResponseData()
+            .setErrorCode(apiError.error().code())
+            .setThrottleTimeMs(throttleTimeMs);
+        return new DescribeStreamsResponse(response);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/s3/UpdateLicenseRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/s3/UpdateLicenseRequest.java
@@ -61,7 +61,7 @@ public class UpdateLicenseRequest extends AbstractRequest {
         ApiError apiError = ApiError.fromThrowable(e);
         UpdateLicenseResponseData response = new UpdateLicenseResponseData()
             .setErrorCode(apiError.error().code())
-            .setErrorMessage(apiError.message())
+            .setErrorMessage(apiError.message() == null ? apiError.error().message() : apiError.message())
             .setThrottleTimeMs(throttleTimeMs);
         return new UpdateLicenseResponse(response);
     }

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticControllerApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticControllerApis.scala
@@ -5,12 +5,14 @@ import kafka.raft.RaftManager
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.{ApiVersionManager, ControllerApis, KafkaConfig, RequestLocal}
-import org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION
+import org.apache.kafka.common.acl.AclOperation.{ALTER_CONFIGS, CLUSTER_ACTION, DESCRIBE_CONFIGS}
 import org.apache.kafka.common.errors.{ApiException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.message.{DeleteKVsResponseData, GetKVsResponseData, GetNextNodeIdResponseData, PutKVsResponseData}
 import org.apache.kafka.common.protocol.Errors.{NONE, UNKNOWN_SERVER_ERROR}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
+import org.apache.kafka.common.resource.ResourceType.CLUSTER
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse}
 import org.apache.kafka.common.requests.s3._
 import org.apache.kafka.common.utils.Time
@@ -39,6 +41,12 @@ class ElasticControllerApis(
 
   def handleExtensionRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     try {
+      // AutoMQ inject start
+      if (!authorizeExtensionRequest(request)) {
+        return
+      }
+      // AutoMQ inject end
+
       val handlerFuture: CompletableFuture[Unit] = request.header.apiKey match {
         case ApiKeys.CREATE_STREAMS => handleCreateStream(request)
         case ApiKeys.OPEN_STREAMS => handleOpenStream(request)
@@ -89,6 +97,25 @@ class ElasticControllerApis(
     }
   }
 
+  // AutoMQ inject start
+  private def authorizeExtensionRequest(request: RequestChannel.Request): Boolean = {
+    val operation = request.header.apiKey match {
+      case ApiKeys.DESCRIBE_LICENSE
+           | ApiKeys.EXPORT_CLUSTER_MANIFEST => DESCRIBE_CONFIGS
+      case ApiKeys.UPDATE_LICENSE => ALTER_CONFIGS
+      case _ => CLUSTER_ACTION
+    }
+    if (!authHelper.authorize(request.context, operation, CLUSTER, CLUSTER_NAME)) {
+      requestHelper.sendMaybeThrottle(request, request.body[AbstractRequest].getErrorResponse(
+        0,
+        Errors.CLUSTER_AUTHORIZATION_FAILED.exception))
+      false
+    } else {
+      true
+    }
+  }
+  // AutoMQ inject end
+
   override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     request.header.apiKey match {
       case ApiKeys.CREATE_STREAMS
@@ -118,7 +145,6 @@ class ElasticControllerApis(
 
   private def handleGetNextNodeId(request: RequestChannel.Request): CompletableFuture[Unit] = {
     val getNextNodeIdRequest = request.body[GetNextNodeIdRequest]
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     controller.getNextNodeId(context, getNextNodeIdRequest.data()).handle[Unit] { (reply, e) =>

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -29,9 +29,9 @@ import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.s3.{AutomqGetPartitionSnapshotRequest, AutomqUpdateGroupRequest, AutomqUpdateGroupResponse, AutomqZoneRouterRequest}
-import org.apache.kafka.common.requests.{AbstractResponse, DeleteTopicsRequest, DeleteTopicsResponse, FetchMetadata => JFetchMetadata, FetchRequest, FetchResponse, ProduceRequest, ProduceResponse, RequestUtils}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, DeleteTopicsRequest, DeleteTopicsResponse, FetchMetadata => JFetchMetadata, FetchRequest, FetchResponse, ProduceRequest, ProduceResponse, RequestUtils}
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
-import org.apache.kafka.common.resource.ResourceType.{CLUSTER, TOPIC, TRANSACTIONAL_ID}
+import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC, TRANSACTIONAL_ID}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupCoordinator
@@ -452,6 +452,13 @@ class ElasticKafkaApis(
 
   def handleUpdateGroupRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     val updateGroupsRequest = request.body[AutomqUpdateGroupRequest]
+    // AutoMQ inject start
+    if (!authHelper.authorize(request.context, READ, GROUP, updateGroupsRequest.data().groupId())) {
+      requestHelper.sendMaybeThrottle(request, updateGroupsRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
+      return
+    }
+    // AutoMQ inject end
+
     groupCoordinator.updateGroup(request.context, updateGroupsRequest.data(), requestLocal.bufferSupplier)
         .whenComplete((response, ex) => {
           if (ex != null) {
@@ -464,6 +471,12 @@ class ElasticKafkaApis(
 
   def handleZoneRouterRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     val zoneRouterRequest = request.body[AutomqZoneRouterRequest]
+    // AutoMQ inject start
+    if (!authorizeClusterActionForAutoMQRequest(request)) {
+      return
+    }
+    // AutoMQ inject end
+
     trafficInterceptor.handleZoneRouterRequest(zoneRouterRequest.data()).thenAccept(response => {
       requestChannel.sendResponse(request, response, None)
     }).exceptionally(ex => {
@@ -471,6 +484,19 @@ class ElasticKafkaApis(
       null
     })
   }
+
+  // AutoMQ inject start
+  private def authorizeClusterActionForAutoMQRequest(request: RequestChannel.Request): Boolean = {
+    if (!authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {
+      requestHelper.sendMaybeThrottle(request, request.body[AbstractRequest].getErrorResponse(
+        0,
+        Errors.CLUSTER_AUTHORIZATION_FAILED.exception))
+      false
+    } else {
+      true
+    }
+  }
+  // AutoMQ inject end
 
   def handleProduceAppendJavaCompatible(
     args: ProduceRequestArgs,
@@ -888,6 +914,12 @@ class ElasticKafkaApis(
 
   def handleGetPartitionSnapshotRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     val req = request.body[AutomqGetPartitionSnapshotRequest]
+    // AutoMQ inject start
+    if (!authorizeClusterActionForAutoMQRequest(request)) {
+      return
+    }
+    // AutoMQ inject end
+
     replicaManager.asInstanceOf[ElasticReplicaManager].handleGetPartitionSnapshotRequest(req)
       .thenAccept(resp => requestHelper.sendMaybeThrottle(request, resp))
       .exceptionally(ex => {

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticControllerApisTest.scala
@@ -5,11 +5,12 @@ import kafka.server.streamaspect.ElasticControllerApis
 import kafka.server.{ControllerApisTest, KafkaConfig, RequestLocal, SimpleApiVersionManager}
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
-import org.apache.kafka.common.message.{UpdateLicenseRequestData, UpdateLicenseResponseData}
+import org.apache.kafka.common.message.{CreateStreamsRequestData, DescribeLicenseRequestData, DescribeStreamsRequestData, ExportClusterManifestRequestData, GetNextNodeIdRequestData, UpdateLicenseRequestData, UpdateLicenseResponseData}
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, MessageUtil}
-import org.apache.kafka.common.requests.s3.{UpdateLicenseRequest, UpdateLicenseResponse}
+import org.apache.kafka.common.requests.s3.{CreateStreamsRequest, CreateStreamsResponse, DescribeLicenseRequest, DescribeLicenseResponse, DescribeStreamsRequest, DescribeStreamsResponse, ExportClusterManifestRequest, ExportClusterManifestResponse, GetNextNodeIdRequest, GetNextNodeIdResponse, UpdateLicenseRequest, UpdateLicenseResponse}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.resource.Resource
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.controller.Controller
 import org.apache.kafka.controller.ControllerRequestContext
@@ -21,11 +22,13 @@ import org.apache.kafka.server.config.KRaftConfigs
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{Tag, Test, Timeout}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.mockito.Mockito.{mock, verify, when}
+import org.mockito.Mockito.{mock, never, verify, when}
 
 import java.net.InetAddress
+import java.util
 import java.util.Properties
 import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 @Timeout(60)
 @Tag("S3Unit")
@@ -71,6 +74,125 @@ class ElasticControllerApisTest extends ControllerApisTest {
 
     val response = captureResponse[UpdateLicenseResponse](request)
     assertEquals(Errors.UNSUPPORTED_VERSION.code, response.data.errorCode)
+  }
+
+  @Test
+  def shouldRejectCreateStreamsWhenClusterActionIsDenied(): Unit = {
+    // Given a stream mutation API, when ClusterAction is denied, then the controller handler is not invoked.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new CreateStreamsRequest.Builder(new CreateStreamsRequestData()
+      .setNodeId(1)
+      .setNodeEpoch(2L)).build(ApiKeys.CREATE_STREAMS.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[CreateStreamsResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).createStreams(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.any(classOf[CreateStreamsRequestData]))
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION)
+  }
+
+  @Test
+  def shouldRejectUpdateLicenseWhenAlterConfigsIsDenied(): Unit = {
+    // Given a license mutation API, when AlterConfigs is denied, then the extension handler is not invoked.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new UpdateLicenseRequest.Builder(new UpdateLicenseRequestData()).build(ApiKeys.UPDATE_LICENSE.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[UpdateLicenseResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.UPDATE_LICENSE),
+      ArgumentMatchers.any())
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS)
+  }
+
+  @Test
+  def shouldRejectDescribeLicenseWhenDescribeConfigsIsDenied(): Unit = {
+    // Given a license describe API, when DescribeConfigs is denied, then the extension handler is not invoked.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new DescribeLicenseRequest.Builder(new DescribeLicenseRequestData()).build(ApiKeys.DESCRIBE_LICENSE.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[DescribeLicenseResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.DESCRIBE_LICENSE),
+      ArgumentMatchers.any())
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS)
+  }
+
+  @Test
+  def shouldRejectExportClusterManifestWhenDescribeConfigsIsDenied(): Unit = {
+    // Given a cluster manifest export API, when DescribeConfigs is denied, then the extension handler is not invoked.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new ExportClusterManifestRequest.Builder(
+      new ExportClusterManifestRequestData()).build(ApiKeys.EXPORT_CLUSTER_MANIFEST.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[ExportClusterManifestResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).handleExtensionRequest(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.eq(ApiKeys.EXPORT_CLUSTER_MANIFEST),
+      ArgumentMatchers.any())
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS)
+  }
+
+  @Test
+  def shouldRejectDescribeStreamsWhenClusterActionIsDenied(): Unit = {
+    // Given a stream describe API, when ClusterAction is denied, then a valid authorization error is returned.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new DescribeStreamsRequest.Builder(new DescribeStreamsRequestData()).build(ApiKeys.DESCRIBE_STREAMS.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[DescribeStreamsResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).describeStreams(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.any(classOf[DescribeStreamsRequestData]))
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION)
+  }
+
+  @Test
+  def shouldRejectGetNextNodeIdWithSingleClusterActionAuthorization(): Unit = {
+    // Given GetNextNodeId is authorized by the unified extension gate, when denied, then the controller is not invoked.
+    val controller = mock(classOf[Controller])
+    val authorizer = createDenyAllAuthorizer()
+    when(controller.getNextNodeId(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.any(classOf[GetNextNodeIdRequestData])))
+      .thenReturn(CompletableFuture.completedFuture(1))
+    controllerApis = createControllerApis(Some(authorizer), controller)
+    val request = buildRequest(new GetNextNodeIdRequest.Builder(new GetNextNodeIdRequestData())
+      .build(ApiKeys.GET_NEXT_NODE_ID.latestVersion))
+
+    controllerApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[GetNextNodeIdResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(controller, never()).getNextNodeId(
+      ArgumentMatchers.any(classOf[ControllerRequestContext]),
+      ArgumentMatchers.any(classOf[GetNextNodeIdRequestData]))
+    assertSingleClusterAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION)
   }
 
   override def createControllerApis(authorizer: Option[Authorizer],
@@ -141,5 +263,21 @@ class ElasticControllerApisTest extends ControllerApisTest {
       buffer,
       request.context.header.apiVersion,
     ).asInstanceOf[T]
+  }
+
+  private def assertSingleClusterAuthorization(
+    authorizer: Authorizer,
+    operation: org.apache.kafka.common.acl.AclOperation
+  ): Unit = {
+    val capturedActions: ArgumentCaptor[util.List[org.apache.kafka.server.authorizer.Action]] =
+      ArgumentCaptor.forClass(classOf[util.List[org.apache.kafka.server.authorizer.Action]])
+    verify(authorizer).authorize(
+      ArgumentMatchers.any(),
+      capturedActions.capture())
+    val actions = capturedActions.getValue.asScala
+    assertEquals(1, actions.size)
+    assertEquals(operation, actions.head.operation)
+    assertEquals(org.apache.kafka.common.resource.ResourceType.CLUSTER, actions.head.resourcePattern.resourceType)
+    assertEquals(Resource.CLUSTER_NAME, actions.head.resourcePattern.name)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
@@ -9,16 +9,18 @@ import kafka.server.streamaspect.{ElasticKafkaApis, ElasticReplicaManager, Fetch
 import kafka.utils.TestUtils
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
-import org.apache.kafka.common.message.{FetchRequestData, UpdateLicenseRequestData}
+import org.apache.kafka.common.message.{AutomqGetPartitionSnapshotRequestData, AutomqUpdateGroupRequestData, AutomqZoneRouterRequestData, FetchRequestData, UpdateLicenseRequestData}
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, MessageUtil}
-import org.apache.kafka.common.requests.s3.UpdateLicenseRequest
+import org.apache.kafka.common.requests.s3.{AutomqGetPartitionSnapshotRequest, AutomqGetPartitionSnapshotResponse, AutomqUpdateGroupRequest, AutomqUpdateGroupResponse, AutomqZoneRouterRequest, AutomqZoneRouterResponse, UpdateLicenseRequest}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, FetchRequest, FetchResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.resource.Resource
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion}
+import org.apache.kafka.server.authorizer.{Action, AuthorizationResult}
+import org.apache.kafka.server.common.{FinalizedFeatures, KRaftVersion, MetadataVersion}
 import org.apache.kafka.server.config.KRaftConfigs
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertSame, assertTrue}
 import org.junit.jupiter.api.{Tag, Test, Timeout}
@@ -26,9 +28,10 @@ import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.Mockito.{doReturn, mock, never, spy, verify, when}
 
 import java.net.InetAddress
+import java.util
 import java.util.{Collections, Optional}
 import scala.collection.Map
-import scala.jdk.CollectionConverters.SetHasAsScala
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava, SetHasAsScala}
 
 @Timeout(60)
 @Tag("S3Unit")
@@ -140,6 +143,69 @@ class ElasticKafkaApisTest extends KafkaApisTest {
     }
 
     assertSame(facade, capturedContext.enterpriseFacade())
+  }
+
+  @Test
+  def shouldRejectUpdateGroupWhenGroupReadIsDenied(): Unit = {
+    // Given a group update API, when Read on the target group is denied, then the coordinator is not invoked.
+    val groupId = "group-denied"
+    val requestData = new AutomqUpdateGroupRequestData()
+      .setLinkId("link")
+      .setGroupId(groupId)
+      .setPromoted(true)
+    val request = buildRequest(new AutomqUpdateGroupRequest.Builder(requestData).build(ApiKeys.AUTOMQ_UPDATE_GROUP.latestVersion))
+    val authorizer = denyAllAuthorizer()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId, () => KRaftVersion.KRAFT_VERSION_0)
+    kafkaApis = createKafkaApis(authorizer = Some(authorizer), raftSupport = true)
+
+    kafkaApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[AutomqUpdateGroupResponse](request)
+    assertEquals(groupId, response.data.groupId)
+    assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(groupCoordinator, never()).updateGroup(
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(classOf[AutomqUpdateGroupRequestData]),
+      ArgumentMatchers.any())
+    assertSingleAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.READ,
+      org.apache.kafka.common.resource.ResourceType.GROUP, groupId)
+  }
+
+  @Test
+  def shouldRejectZoneRouterWhenClusterActionIsDenied(): Unit = {
+    // Given a zone router API, when ClusterAction is denied, then a valid authorization error is returned.
+    val request = buildRequest(new AutomqZoneRouterRequest.Builder(new AutomqZoneRouterRequestData()
+      .setMetadata(Array.emptyByteArray)).build(ApiKeys.AUTOMQ_ZONE_ROUTER.latestVersion))
+    val authorizer = denyAllAuthorizer()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId, () => KRaftVersion.KRAFT_VERSION_0)
+    kafkaApis = createKafkaApis(authorizer = Some(authorizer), raftSupport = true)
+
+    kafkaApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[AutomqZoneRouterResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    assertSingleAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION,
+      org.apache.kafka.common.resource.ResourceType.CLUSTER, Resource.CLUSTER_NAME)
+  }
+
+  @Test
+  def shouldRejectGetPartitionSnapshotWhenClusterActionIsDenied(): Unit = {
+    // Given a partition snapshot API, when ClusterAction is denied, then the replica manager is not invoked.
+    val request = buildRequest(new AutomqGetPartitionSnapshotRequest.Builder(new AutomqGetPartitionSnapshotRequestData()
+      .setSessionId(1)
+      .setSessionEpoch(2)).build(ApiKeys.AUTOMQ_GET_PARTITION_SNAPSHOT.latestVersion))
+    val authorizer = denyAllAuthorizer()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId, () => KRaftVersion.KRAFT_VERSION_0)
+    kafkaApis = createKafkaApis(authorizer = Some(authorizer), raftSupport = true)
+
+    kafkaApis.handle(request, RequestLocal.NoCaching)
+
+    val response = captureResponse[AutomqGetPartitionSnapshotResponse](request)
+    assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED.code, response.data.errorCode)
+    verify(replicaManager, never()).handleGetPartitionSnapshotRequest(
+      ArgumentMatchers.any(classOf[AutomqGetPartitionSnapshotRequest]))
+    assertSingleAuthorization(authorizer, org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION,
+      org.apache.kafka.common.resource.ResourceType.CLUSTER, Resource.CLUSTER_NAME)
   }
 
   override def createKafkaApis(interBrokerProtocolVersion: MetadataVersion = MetadataVersion.latestTesting,
@@ -292,5 +358,31 @@ class ElasticKafkaApisTest extends KafkaApisTest {
       buffer,
       request.context.header.apiVersion,
     ).asInstanceOf[T]
+  }
+
+  private def denyAllAuthorizer(): Authorizer = {
+    val authorizer = mock(classOf[Authorizer])
+    when(authorizer.authorize(
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(classOf[util.List[Action]])))
+      .thenAnswer(invocation => invocation.getArgument[util.List[Action]](1).asScala.toSeq.map(_ => AuthorizationResult.DENIED).asJava)
+    authorizer
+  }
+
+  private def assertSingleAuthorization(
+    authorizer: Authorizer,
+    operation: org.apache.kafka.common.acl.AclOperation,
+    resourceType: org.apache.kafka.common.resource.ResourceType,
+    resourceName: String
+  ): Unit = {
+    val capturedActions: ArgumentCaptor[util.List[Action]] = ArgumentCaptor.forClass(classOf[util.List[Action]])
+    verify(authorizer).authorize(
+      ArgumentMatchers.any(),
+      capturedActions.capture())
+    val actions = capturedActions.getValue.asScala
+    assertEquals(1, actions.size)
+    assertEquals(operation, actions.head.operation)
+    assertEquals(resourceType, actions.head.resourcePattern.resourceType)
+    assertEquals(resourceName, actions.head.resourcePattern.name)
   }
 }


### PR DESCRIPTION
## Summary
- Add authorization checks for AutoMQ controller extension and broker-local API keys.
- Map license/config-style APIs to `ALTER_CONFIGS` / `DESCRIBE_CONFIGS`, group update to group `READ`, and other AutoMQ extension APIs to cluster `CLUSTER_ACTION`.
- Add focused authorization tests and fix extension error responses needed by denied paths.
