### PR TITLE
perf(failover): optimize failover to reduce latency.

### DIFF
--- a/core/src/main/java/kafka/automq/controller/DefaultQuorumControllerExtension.java
+++ b/core/src/main/java/kafka/automq/controller/DefaultQuorumControllerExtension.java
@@ -74,4 +74,9 @@ public class DefaultQuorumControllerExtension implements QuorumControllerExtensi
             BrokerHeartbeatRequestData request, long registerBrokerRecordOffset) {
         return Optional.empty();
     }
+
+    @Override
+    public void onBrokerFenced(int brokerId) {
+        failoverControlManager.triggerFailover();
+    }
 }

--- a/core/src/main/java/kafka/automq/failover/FailoverControlManager.java
+++ b/core/src/main/java/kafka/automq/failover/FailoverControlManager.java
@@ -82,6 +82,14 @@ public class FailoverControlManager implements AutoCloseable {
         this.scheduler.scheduleWithFixedDelay(this::runFailoverTask, 1, 1, TimeUnit.SECONDS);
     }
 
+    public void triggerFailover() {
+        try {
+            scheduler.execute(this::runFailoverTask);
+        } catch (Throwable e) {
+            LOGGER.error("Trigger failover task failed", e);
+        }
+    }
+
     void runFailoverTask() {
         if (!quorumController.isActive()) {
             return;

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -650,5 +650,8 @@ public interface Controller extends AclMutator, AutoCloseable {
             BrokerHeartbeatRequestData request, long registerBrokerRecordOffset) {
         return Optional.empty();
     }
+
+    default void onBrokerFenced(int brokerId) {
+    }
     // AutoMQ for Kafka inject end
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2845,6 +2845,11 @@ public final class QuorumController implements Controller {
             BrokerHeartbeatRequestData request, long registerBrokerRecordOffset) {
         return extension.maybeHandleBlockedBroker(request, registerBrokerRecordOffset);
     }
+
+    @Override
+    public void onBrokerFenced(int brokerId) {
+        extension.onBrokerFenced(brokerId);
+    }
     // AutoMQ for Kafka inject end
 
     // VisibleForTesting

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerExtension.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerExtension.java
@@ -80,6 +80,9 @@ public interface QuorumControllerExtension {
     Optional<ControllerResult<BrokerHeartbeatReply>> maybeHandleBlockedBroker(
         BrokerHeartbeatRequestData request, long registerBrokerRecordOffset);
 
+    default void onBrokerFenced(int brokerId) {
+    }
+
     /**
      * Called when this controller becomes the active leader.
      */

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1463,6 +1463,11 @@ public class ReplicationControlManager {
                     setId(brokerId).setEpoch(brokerRegistration.epoch()),
                     (short) 0));
         }
+        // AutoMQ for Kafka inject start
+        if (quorumController != null) {
+            quorumController.onBrokerFenced(brokerId);
+        }
+        // AutoMQ for Kafka inject end
     }
 
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -240,9 +240,11 @@ public class S3Storage implements Storage {
      */
     void recover0(WriteAheadLog deltaWAL, StreamManager streamManager, ObjectManager objectManager,
         Logger logger) throws InterruptedException, ExecutionException {
-        List<StreamMetadata> streams = streamManager.getOpeningStreams().get();
-        Map<Long, Long> streamEndOffsets = streams.stream().collect(Collectors.toMap(StreamMetadata::streamId, StreamMetadata::endOffset));
+        CompletableFuture<List<StreamMetadata>> streamsCf = streamManager.getOpeningStreams();
         Iterator<RecoverResult> iterator = deltaWAL.recover();
+
+        List<StreamMetadata> streams = streamsCf.get();
+        Map<Long, Long> streamEndOffsets = streams.stream().collect(Collectors.toMap(StreamMetadata::streamId, StreamMetadata::endOffset));
 
         WALRecovery.recover(iterator, streamEndOffsets, 1 << 29, logger, cacheBlock -> {
             try {
@@ -252,8 +254,9 @@ public class S3Storage implements Storage {
             }
         });
 
-        deltaWAL.reset().get();
+        CompletableFuture<Void> resetCf = deltaWAL.reset();
         closeStreams(streamManager, streams, streamEndOffsets, logger);
+        resetCf.get();
     }
 
     private void uploadRecoveredRecords(ObjectManager objectManager, LogCache.LogCacheBlock cacheBlock, Logger logger)

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -251,7 +251,9 @@ public class DefaultWriter implements Writer {
             }
             bufferedDataBytes.addAndGet(dataSize);
             activeBulk.add(record);
-            if (activeBulk.size > config.maxBytesInBatch()) {
+            // In FAILOVER mode, the only append is the fake record from trim to persist trimOffset.
+            // Upload immediately to avoid the batch delay (~250ms) when failover recover.
+            if (activeBulk.size > config.maxBytesInBatch() || config.openMode() == OpenMode.FAILOVER) {
                 uploadActiveBulk();
             }
         } finally {


### PR DESCRIPTION
The failover detection and recovery path is too slow, caused by three compounding issues:
* Polling-only detection with high latency
The FailoverControlManager relies  a periodic scheduled task running every 1 second to detect fenced brokers and trigger failover. There is no event-driven mechanism — when a broker is fenced by the controller, the failover system doesn't know about it until the next polling cycle. #3406 that it attempts to compensate for detection latency with high-frequency polling, but the polling itself is blocking and consumes the controller's shared event queue — which in turn slows down all operations, including the failover task itself. The correct approach, as this optimization does, is to replace high-frequency polling with event-driven triggering and reduce the periodic scan to a low-frequency safety net (60 seconds).



* Sequential I/O during WAL recovery
In `S3Storage.recover0()`, `streamManager.getOpeningStreams()` (a remote call) and `deltaWAL.recover()`, `deltaWAL.reset` and `closeStreams` can be executed in parallel instead of sequentially.

* Batch delay in FAILOVER WAL write mode
During failover recovery, the only write to the WAL is a fake record from `trim()` to persist the trimOffset. In `DefaultWriter`, this record is subject to the normal batching logic (default batchInterval = 250ms), meaning the trim-offset-persisting record sits in the batch for up to 250ms before being uploaded. This delay directly adds to the total failover recovery time.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
