### PR TITLE
feat(s3stream): add etag conditional object reservation writes

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/exceptions/ObjectStorageConditionNotMetException.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/exceptions/ObjectStorageConditionNotMetException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.exceptions;
+
+public class ObjectStorageConditionNotMetException extends AutoMQException {
+
+    public ObjectStorageConditionNotMetException(String msg) {
+        super(msg);
+    }
+
+    public ObjectStorageConditionNotMetException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -61,13 +61,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.HashedWheelTimer;
-import io.netty.util.ReferenceCounted;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -210,7 +208,16 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
 
     @Override
     public CompletableFuture<ByteBuf> rangeRead(ReadOptions options, String objectPath, long start, long end) {
-        CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
+        return rangeReadResult(options, objectPath, start, end).thenApply(ReadResult::data);
+    }
+
+    @Override
+    public CompletableFuture<ReadResult> readWithMetadata(ReadOptions options, String objectPath) {
+        return rangeReadResult(options, objectPath, 0, RANGE_READ_TO_END);
+    }
+
+    private CompletableFuture<ReadResult> rangeReadResult(ReadOptions options, String objectPath, long start, long end) {
+        CompletableFuture<ReadResult> cf = new CompletableFuture<>();
         if (!bucketCheck(options.bucket(), cf)) {
             return cf;
         }
@@ -220,12 +227,9 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             cf.completeExceptionally(ex);
             return cf;
         } else if (start == end) {
-            cf.complete(Unpooled.EMPTY_BUFFER);
+            cf.complete(ReadResult.of(Unpooled.EMPTY_BUFFER));
             return cf;
         }
-
-        BiFunction<ThrottleStrategy, Long, CompletableFuture<Void>> networkInboundBandwidthLimiterFunction =
-            networkInboundBandwidthLimiter::consume;
 
         long acquiredSize = end - start;
 
@@ -234,14 +238,14 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             acquiredSize = 1;
 
             // when read complete use bypass to forceConsume limiter token.
-            cf.whenComplete((data, ex) -> {
-                if (ex == null && data.readableBytes() - 1 > 0) {
-                    networkInboundBandwidthLimiterFunction.apply(ThrottleStrategy.BYPASS, (long) (data.readableBytes() - 1));
+            cf.whenComplete((result, ex) -> {
+                if (ex == null && result.data().readableBytes() - 1 > 0) {
+                    networkInboundBandwidthLimiter.consume(ThrottleStrategy.BYPASS, (long) (result.data().readableBytes() - 1));
                 }
             });
         }
 
-        networkInboundBandwidthLimiterFunction.apply(options.throttleStrategy(), acquiredSize).whenComplete((v, ex) -> {
+        networkInboundBandwidthLimiter.consume(options.throttleStrategy(), acquiredSize).whenComplete((v, ex) -> {
             if (ex != null) {
                 cf.completeExceptionally(ex);
             } else {
@@ -255,12 +259,27 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             logger.warn("rangeRead {} {}-{} timeout", objectPath, start, end);
             // The return CompletableFuture will be completed with TimeoutException,
             // so we need to release the ByteBuf if the read complete later.
-            cf.thenAccept(ReferenceCounted::release);
+            cf.thenAccept(result -> result.data().release());
         });
     }
 
     @Override
     public CompletableFuture<WriteResult> write(WriteOptions options, String objectPath, ByteBuf data) {
+        return write(options, objectPath, data, null);
+    }
+
+    @Override
+    public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath, ByteBuf data,
+        WriteCondition condition) {
+        if (condition == null) {
+            data.release();
+            return FutureUtil.failedFuture(new IllegalArgumentException("condition cannot be null"));
+        }
+        return write(options, objectPath, data, condition);
+    }
+
+    private CompletableFuture<WriteResult> write(WriteOptions options, String objectPath, ByteBuf data,
+        WriteCondition condition) {
         CompletableFuture<Void> cf = new CompletableFuture<>();
         CompletableFuture<WriteResult> retCf = acquireWritePermit(cf).thenApply(nil -> new WriteResult(bucketURI.bucketId()));
         if (retCf.isDone()) {
@@ -279,7 +298,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
                     data.release();
                     return;
                 }
-                queuedWrite0(options, objectPath, data, cf);
+                queuedWrite0(options, objectPath, data, condition, cf);
             }, writeLimiterCallbackExecutor);
         return retCf;
     }
@@ -303,7 +322,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
      * @param attemptCf the CompletableFuture to complete when a single attempt is done
      * @param finalCf   the CompletableFuture to complete when the write operation is done
      */
-    private void write0(WriteOptions options, String path, ByteBuf data, CompletableFuture<Void> attemptCf,
+    private void write0(WriteOptions options, String path, ByteBuf data, WriteCondition condition, CompletableFuture<Void> attemptCf,
         CompletableFuture<Void> finalCf) {
         TimerUtil timerUtil = new TimerUtil();
         long objectSize = data.readableBytes();
@@ -314,7 +333,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             return;
         }
 
-        CompletableFuture<Void> writeCf = doWrite(options, path, data);
+        CompletableFuture<Void> writeCf = doWrite(options, path, data, condition);
         FutureUtil.propagate(writeCf, attemptCf);
         AtomicBoolean completedFlag = new AtomicBoolean(false);
         WriteOptions retryOptions = options.copy().retry(true);
@@ -328,7 +347,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
                 if (writeCf != null && !writeCf.isDone() && fastRetryPermit.tryAcquire()) {
                     TimerUtil retryTimerUtil = new TimerUtil();
 
-                    doWrite(retryOptions, path, data).thenAccept(nil -> {
+                    doWrite(retryOptions, path, data, condition).thenAccept(nil -> {
                         recordWriteStats(path, objectSize, retryTimerUtil);
 
                         data.release();
@@ -394,28 +413,28 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             if (isThrottled(cause, retryCount)) {
                 failedWriteMonitor.record(objectSize);
                 logger.warn("PutObject for object {} fail, retry count {}, queued and retry later", path, retryCount, cause);
-                queuedWrite0(retryOptions, path, data, finalCf);
+                queuedWrite0(retryOptions, path, data, condition, finalCf);
             } else {
                 int delay = retryDelay(S3Operation.PUT_OBJECT, retryCount);
                 logger.warn("PutObject for object {} fail, retry count {}, retry in {}ms", path, retryCount, delay, cause);
-                delayedWrite0(retryOptions, path, data, finalCf, delay);
+                delayedWrite0(retryOptions, path, data, condition, finalCf, delay);
             }
             return null;
         });
     }
 
-    private void delayedWrite0(WriteOptions options, String path, ByteBuf data, CompletableFuture<Void> cf,
+    private void delayedWrite0(WriteOptions options, String path, ByteBuf data, WriteCondition condition, CompletableFuture<Void> cf,
         int delayMs) {
         CompletableFuture<Void> ignored = new CompletableFuture<>();
-        scheduler.schedule(() -> write0(options, path, data, ignored, cf), delayMs, TimeUnit.MILLISECONDS);
+        scheduler.schedule(() -> write0(options, path, data, condition, ignored, cf), delayMs, TimeUnit.MILLISECONDS);
     }
 
-    private void queuedWrite0(WriteOptions options, String path, ByteBuf data, CompletableFuture<Void> cf) {
+    private void queuedWrite0(WriteOptions options, String path, ByteBuf data, WriteCondition condition, CompletableFuture<Void> cf) {
         CompletableFuture<Void> attemptCf = new CompletableFuture<>();
         AsyncTask task = new AsyncTask(
             options.requestTime(),
             options.throttleStrategy(),
-            () -> write0(options, path, data, attemptCf, cf),
+            () -> write0(options, path, data, condition, attemptCf, cf),
             attemptCf,
             () -> (long) data.readableBytes()
         );
@@ -685,9 +704,9 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         doClose();
     }
 
-    abstract CompletableFuture<ByteBuf> doRangeRead(ReadOptions options, String path, long start, long end);
+    abstract CompletableFuture<ReadResult> doRangeRead(ReadOptions options, String path, long start, long end);
 
-    abstract CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data);
+    abstract CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data, WriteCondition condition);
 
     abstract CompletableFuture<String> doCreateMultipartUpload(WriteOptions options, String path);
 
@@ -773,7 +792,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
                         mergedReadTask.end - mergedReadTask.start, mergedReadTask.dataSparsityRate);
                 }
                 mergedRangeRead(mergedReadTask.readTasks.get(0).options, path, mergedReadTask.start, mergedReadTask.end)
-                    .whenComplete((rst, ex) -> FutureUtil.suppress(() -> mergedReadTask.handleReadCompleted(rst, ex), logger));
+                    .whenComplete((result, ex) -> FutureUtil.suppress(() -> mergedReadTask.handleReadCompleted(result, ex), logger));
             }
         );
     }
@@ -782,9 +801,9 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         return inflightReadLimiter.availablePermits();
     }
 
-    CompletableFuture<ByteBuf> mergedRangeRead(ReadOptions options, String path, long start, long end) {
-        CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
-        CompletableFuture<ByteBuf> retCf = acquireReadPermit(cf);
+    CompletableFuture<ReadResult> mergedRangeRead(ReadOptions options, String path, long start, long end) {
+        CompletableFuture<ReadResult> cf = new CompletableFuture<>();
+        CompletableFuture<ReadResult> retCf = acquireReadPermit(cf);
         if (retCf.isDone()) {
             return retCf;
         }
@@ -793,10 +812,11 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
     }
 
     private void mergedRangeRead0(ReadOptions options, String path, long start, long end,
-        CompletableFuture<ByteBuf> cf) {
+        CompletableFuture<ReadResult> cf) {
         TimerUtil timerUtil = new TimerUtil();
         long size = end - start;
-        doRangeRead(options, path, start, end).thenAccept(buf -> {
+        doRangeRead(options, path, start, end).thenAccept(result -> {
+            ByteBuf buf = result.data();
             // the end may be RANGE_READ_TO_END (-1) for read all object
             long dataSize = buf.readableBytes();
             if (logger.isDebugEnabled()) {
@@ -805,7 +825,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             }
             S3OperationStats.getInstance().downloadSizeTotalStats.add(MetricsLevel.INFO, dataSize);
             S3OperationStats.getInstance().getObjectStats(dataSize, true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-            cf.complete(buf);
+            cf.complete(result);
         }).exceptionally(ex -> {
             Pair<RetryStrategy, Throwable> strategyAndCause = toRetryStrategyAndCause(ex, S3Operation.GET_OBJECT);
             RetryStrategy retryStrategy = strategyAndCause.getLeft();
@@ -1061,26 +1081,27 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
                 end != RANGE_READ_TO_END;
         }
 
-        void handleReadCompleted(ByteBuf rst, Throwable ex) {
-            handleReadCompleted(this.readTasks, this.start, rst, ex);
+        void handleReadCompleted(ReadResult result, Throwable ex) {
+            handleReadCompleted(this.readTasks, this.start, result, ex);
         }
 
-        static void handleReadCompleted(List<ReadTask> readTasks, long mergeReadStart, ByteBuf rst, Throwable ex) {
+        static void handleReadCompleted(List<ReadTask> readTasks, long mergeReadStart, ReadResult result, Throwable ex) {
             if (ex != null) {
                 readTasks.forEach(readTask -> readTask.cf.completeExceptionally(ex));
             } else {
-                ArrayList<ByteBuf> sliceByteBufList = new ArrayList<>();
+                ByteBuf rst = result.data();
+                ArrayList<ReadResult> sliceReadResultList = new ArrayList<>();
                 for (AbstractObjectStorage.ReadTask readTask : readTasks) {
                     int sliceStart = (int) (readTask.start - mergeReadStart);
                     if (readTask.end == RANGE_READ_TO_END) {
-                        sliceByteBufList.add(rst.retainedSlice(sliceStart, rst.readableBytes() - sliceStart));
+                        sliceReadResultList.add(ReadResult.of(rst.retainedSlice(sliceStart, rst.readableBytes() - sliceStart), result.metadata()));
                     } else {
-                        sliceByteBufList.add(rst.retainedSlice(sliceStart, (int) (readTask.end - readTask.start)));
+                        sliceReadResultList.add(ReadResult.of(rst.retainedSlice(sliceStart, (int) (readTask.end - readTask.start)), result.metadata()));
                     }
                 }
                 rst.release();
                 for (int i = 0; i < readTasks.size(); i++) {
-                    readTasks.get(i).cf.complete(sliceByteBufList.get(i));
+                    readTasks.get(i).cf.complete(sliceReadResultList.get(i));
                 }
 
             }
@@ -1092,9 +1113,9 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         private final String objectPath;
         private final long start;
         private final long end;
-        private final CompletableFuture<ByteBuf> cf;
+        private final CompletableFuture<ReadResult> cf;
 
-        ReadTask(ReadOptions options, String objectPath, long start, long end, CompletableFuture<ByteBuf> cf) {
+        ReadTask(ReadOptions options, String objectPath, long start, long end, CompletableFuture<ReadResult> cf) {
             this.options = options;
             this.objectPath = objectPath;
             this.start = start;
@@ -1118,7 +1139,7 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
             return end;
         }
 
-        public CompletableFuture<ByteBuf> cf() {
+        public CompletableFuture<ReadResult> cf() {
             return cf;
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -108,6 +108,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     private static final int HTTP_STATUS_PRECONDITION_FAILED = 412;
     public static final String PATH_STYLE_KEY = "pathStyle";
     public static final String CHECKSUM_ALGORITHM_KEY = "checksumAlgorithm";
+    public static final String CONDITIONAL_WRITE_KEY = "conditionalWrite";
 
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     // The maximum number of keys that can be deleted in a single request is 1000.
@@ -119,6 +120,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     private final S3AsyncClient writeS3Client;
 
     private final ChecksumAlgorithm checksumAlgorithm;
+    private final boolean conditionalWrite;
 
     public AwsObjectStorage(BucketURI bucketURI, Map<String, String> tagging,
         NetworkBandwidthLimiter networkInboundBandwidthLimiter, NetworkBandwidthLimiter networkOutboundBandwidthLimiter,
@@ -126,6 +128,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         super(bucketURI, networkInboundBandwidthLimiter, networkOutboundBandwidthLimiter, readWriteIsolate, checkMode, threadPrefix);
         this.bucket = bucketURI.bucket();
         this.tagging = tagging(tagging);
+        this.conditionalWrite = bucketURI.extensionBool(CONDITIONAL_WRITE_KEY, false);
         List<AwsCredentialsProvider> credentialsProviders = credentialsProviders();
 
         String checksumAlgorithmStr = bucketURI.extensionString(CHECKSUM_ALGORITHM_KEY);
@@ -155,6 +158,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         this.readS3Client = s3Client;
         this.tagging = null;
         this.checksumAlgorithm = ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION;
+        this.conditionalWrite = false;
     }
 
     public static Builder builder() {
@@ -265,6 +269,11 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         PutObjectRequest request = builder.build();
         AsyncRequestBody body = AsyncRequestBody.fromByteBuffersUnsafe(data.nioBuffers());
         return writeS3Client.putObject(request, body).thenApply(rst -> null);
+    }
+
+    @Override
+    public boolean supportsConditionalWrite() {
+        return conditionalWrite;
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -43,7 +43,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -104,6 +103,8 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     private static final Set<String> RETRIABLE_DELETE_OBJECT_ERROR_CODES = Set.of(
         "InternalError", "ServiceUnavailable", "SlowDown", "RequestTimeout", "OperationAborted");
     private static final int DELETE_OBJECT_ERROR_LOG_SAMPLE_LIMIT = 10;
+    // S3 conditional writes return HTTP 412 Precondition Failed when If-Match/If-None-Match is not satisfied.
+    // See https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html
     private static final int HTTP_STATUS_PRECONDITION_FAILED = 412;
     public static final String PATH_STYLE_KEY = "pathStyle";
     public static final String CHECKSUM_ALGORITHM_KEY = "checksumAlgorithm";
@@ -263,17 +264,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
 
         PutObjectRequest request = builder.build();
         AsyncRequestBody body = AsyncRequestBody.fromByteBuffersUnsafe(data.nioBuffers());
-        return writeS3Client.putObject(request, body).handle((rst, ex) -> {
-            Throwable cause = cause(ex);
-            if (condition != null && cause instanceof S3Exception s3Ex
-                && s3Ex.statusCode() == HTTP_STATUS_PRECONDITION_FAILED) {
-                throw new CompletionException(new ObjectStorageConditionNotMetException(cause));
-            }
-            if (ex != null) {
-                throw new CompletionException(ex);
-            }
-            return null;
-        });
+        return writeS3Client.putObject(request, body).thenApply(rst -> null);
     }
 
     @Override
@@ -430,6 +421,12 @@ public class AwsObjectStorage extends AbstractObjectStorage {
             switch (s3Ex.statusCode()) {
                 case HttpStatusCode.NOT_FOUND:
                     strategy = RetryStrategy.ABORT;
+                    break;
+                case HTTP_STATUS_PRECONDITION_FAILED:
+                    if (operation == S3Operation.PUT_OBJECT) {
+                        strategy = RetryStrategy.ABORT;
+                        cause = new ObjectStorageConditionNotMetException(cause);
+                    }
                     break;
                 default:
                     strategy = RetryStrategy.RETRY;

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -20,6 +20,7 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.exceptions.ObjectNotExistException;
+import com.automq.stream.s3.exceptions.ObjectStorageConditionNotMetException;
 import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.utils.FutureUtil;
@@ -42,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -102,6 +104,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     private static final Set<String> RETRIABLE_DELETE_OBJECT_ERROR_CODES = Set.of(
         "InternalError", "ServiceUnavailable", "SlowDown", "RequestTimeout", "OperationAborted");
     private static final int DELETE_OBJECT_ERROR_LOG_SAMPLE_LIMIT = 10;
+    private static final int HTTP_STATUS_PRECONDITION_FAILED = 412;
     public static final String PATH_STYLE_KEY = "pathStyle";
     public static final String CHECKSUM_ALGORITHM_KEY = "checksumAlgorithm";
 
@@ -209,14 +212,14 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     }
 
     @Override
-    CompletableFuture<ByteBuf> doRangeRead(ReadOptions options, String path, long start, long end) {
+    CompletableFuture<ReadResult> doRangeRead(ReadOptions options, String path, long start, long end) {
         GetObjectRequest.Builder builder = GetObjectRequest.builder().bucket(bucket).key(path).range(range(start, end));
 
         if (checksumAlgorithm != ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION) {
             builder.checksumMode(ChecksumMode.ENABLED);
         }
 
-        CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
+        CompletableFuture<ReadResult> cf = new CompletableFuture<>();
         readS3Client.getObject(builder.build(), AsyncResponseTransformer.toPublisher())
             .thenAccept(responsePublisher -> {
                 // Set maxNumComponents to Integer.MAX_VALUE to avoid #consolidateIfNeeded causing a GC issue.
@@ -229,7 +232,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
                         buf.release();
                         cf.completeExceptionally(ex);
                     } else {
-                        cf.complete(buf);
+                        cf.complete(ReadResult.of(buf, ObjectMetadata.of(new Etag(responsePublisher.response().eTag()))));
                     }
                 });
             })
@@ -241,7 +244,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     }
 
     @Override
-    CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data) {
+    CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data, WriteCondition condition) {
         PutObjectRequest.Builder builder = PutObjectRequest.builder().bucket(bucket).key(path);
         if (null != tagging) {
             builder.tagging(tagging);
@@ -250,10 +253,27 @@ public class AwsObjectStorage extends AbstractObjectStorage {
         if (checksumAlgorithm != ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION) {
             builder.checksumAlgorithm(checksumAlgorithm);
         }
+        if (condition instanceof WriteCondition.IfMatch ifMatch) {
+            builder.ifMatch(ifMatch.etag().value());
+        } else if (condition instanceof WriteCondition.IfAbsent) {
+            builder.ifNoneMatch("*");
+        } else if (condition != null) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("unsupported write condition: " + condition.getClass().getName()));
+        }
 
         PutObjectRequest request = builder.build();
         AsyncRequestBody body = AsyncRequestBody.fromByteBuffersUnsafe(data.nioBuffers());
-        return writeS3Client.putObject(request, body).thenApply(rst -> null);
+        return writeS3Client.putObject(request, body).handle((rst, ex) -> {
+            Throwable cause = cause(ex);
+            if (condition != null && cause instanceof S3Exception s3Ex
+                && s3Ex.statusCode() == HTTP_STATUS_PRECONDITION_FAILED) {
+                throw new CompletionException(new ObjectStorageConditionNotMetException(cause));
+            }
+            if (ex != null) {
+                throw new CompletionException(ex);
+            }
+            return null;
+        });
     }
 
     @Override
@@ -403,7 +423,9 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     Pair<RetryStrategy, Throwable> toRetryStrategyAndCause(Throwable ex, S3Operation operation) {
         Throwable cause = cause(ex);
         RetryStrategy strategy = RetryStrategy.RETRY;
-        if (cause instanceof S3Exception) {
+        if (cause instanceof ObjectStorageConditionNotMetException) {
+            strategy = RetryStrategy.ABORT;
+        } else if (cause instanceof S3Exception) {
             S3Exception s3Ex = (S3Exception) cause;
             switch (s3Ex.statusCode()) {
                 case HttpStatusCode.NOT_FOUND:
@@ -555,7 +577,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
 
             try {
                 byte[] content = new Date().toString().getBytes(StandardCharsets.UTF_8);
-                doWrite(new WriteOptions(), normalPath, Unpooled.wrappedBuffer(content)).get();
+                doWrite(new WriteOptions(), normalPath, Unpooled.wrappedBuffer(content), null).get();
             } catch (Throwable e) {
                 Throwable cause = FutureUtil.cause(e);
                 if (cause instanceof S3Exception && ((S3Exception) cause).statusCode() == HttpStatusCode.NOT_FOUND) {
@@ -581,7 +603,8 @@ public class AwsObjectStorage extends AbstractObjectStorage {
                 ObjectStorageCompletedPart part = doUploadPart(options, multiPartPath, uploadId, 1, Unpooled.wrappedBuffer(content)).get();
                 doCompleteMultipartUpload(options, multiPartPath, uploadId, List.of(part)).get();
 
-                ByteBuf buf = doRangeRead(new ReadOptions(), multiPartPath, 0, -1L).get();
+                ReadResult result = doRangeRead(new ReadOptions(), multiPartPath, 0, -1L).get();
+                ByteBuf buf = result.data();
                 byte[] readContent = new byte[buf.readableBytes()];
                 buf.readBytes(readContent);
                 buf.release();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
@@ -21,6 +21,7 @@ package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.exceptions.ObjectNotExistException;
+import com.automq.stream.s3.exceptions.ObjectStorageConditionNotMetException;
 import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.metrics.operations.S3Operation;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
@@ -37,6 +38,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
@@ -44,8 +47,9 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 
 public class MemoryObjectStorage extends AbstractObjectStorage {
-    private final Map<String, ByteBuf> storage = new ConcurrentHashMap<>();
+    private final Map<String, StoredObject> storage = new ConcurrentHashMap<>();
     private final Set<String> deleteObjectKeys = new ConcurrentSkipListSet<>();
+    private final AtomicLong etag = new AtomicLong();
     private long delay = 0;
     private final short bucketId;
 
@@ -76,32 +80,56 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     }
 
     @Override
-    CompletableFuture<ByteBuf> doRangeRead(ReadOptions options, String path, long start, long end) {
-        ByteBuf value = storage.get(path);
-        if (value == null) {
+    CompletableFuture<ReadResult> doRangeRead(ReadOptions options, String path, long start, long end) {
+        StoredObject object = storage.get(path);
+        if (object == null) {
             return FutureUtil.failedFuture(new ObjectNotExistException("object not exist"));
         }
+        ByteBuf value = object.data;
         int length = end != -1L ? (int) (end - start) : (int) (value.readableBytes() - start);
         ByteBuf rst = value.retainedSlice(value.readerIndex() + (int) start, length);
         CompositeByteBuf buf = ByteBufAlloc.compositeByteBuffer();
         buf.addComponent(true, rst);
+        ReadResult result = ReadResult.of(buf, ObjectMetadata.of(new Etag(Long.toString(object.etag))));
         if (delay == 0) {
-            return CompletableFuture.completedFuture(buf);
+            return CompletableFuture.completedFuture(result);
         } else {
-            CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
-            Threads.COMMON_SCHEDULER.schedule(() -> cf.complete(buf), delay, TimeUnit.MILLISECONDS);
+            CompletableFuture<ReadResult> cf = new CompletableFuture<>();
+            Threads.COMMON_SCHEDULER.schedule(() -> cf.complete(result), delay, TimeUnit.MILLISECONDS);
             return cf;
         }
     }
 
     @Override
-    CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data) {
+    CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data, WriteCondition condition) {
         if (data == null) {
             return FutureUtil.failedFuture(new IllegalArgumentException("data to write cannot be null"));
         }
         ByteBuf buf = Unpooled.buffer(data.readableBytes());
         buf.writeBytes(data.duplicate());
-        storage.put(path, buf);
+        AtomicReference<ObjectStorageConditionNotMetException> conditionFailure = new AtomicReference<>();
+        storage.compute(path, (key, current) -> {
+            if (condition instanceof WriteCondition.IfMatch ifMatch) {
+                if (current == null || !Long.toString(current.etag).equals(ifMatch.etag().value())) {
+                    conditionFailure.set(new ObjectStorageConditionNotMetException("object etag does not match"));
+                    return current;
+                }
+            } else if (condition instanceof WriteCondition.IfAbsent) {
+                if (current != null) {
+                    conditionFailure.set(new ObjectStorageConditionNotMetException("object already exists"));
+                    return current;
+                }
+            }
+            if (current != null) {
+                current.data.release();
+            }
+            return new StoredObject(buf, etag.incrementAndGet());
+        });
+        ObjectStorageConditionNotMetException failure = conditionFailure.get();
+        if (failure != null) {
+            buf.release();
+            return FutureUtil.failedFuture(failure);
+        }
         return CompletableFuture.completedFuture(null);
     }
 
@@ -113,7 +141,10 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     public Writer writer(WriteOptions writeOptions, String path) {
         ByteBuf buf = Unpooled.buffer();
-        storage.put(path, buf);
+        StoredObject old = storage.put(path, new StoredObject(buf, etag.incrementAndGet()));
+        if (old != null) {
+            old.data.release();
+        }
         return new Writer() {
             @Override
             public CompletableFuture<Void> write(ByteBuf part) {
@@ -135,10 +166,11 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
 
             @Override
             public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-                ByteBuf source = storage.get(s3ObjectMetadata.key());
-                if (source == null) {
+                StoredObject sourceObject = storage.get(s3ObjectMetadata.key());
+                if (sourceObject == null) {
                     throw new IllegalArgumentException("object not exist");
                 }
+                ByteBuf source = sourceObject.data;
                 buf.writeBytes(source.slice(source.readerIndex() + (int) start, (int) (end - start)));
             }
 
@@ -185,8 +217,9 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     CompletableFuture<Void> doDeleteObjects(List<String> objectKeys) {
         for (String objectKey : objectKeys) {
-            if (storage.containsKey(objectKey)) {
-                storage.remove(objectKey);
+            StoredObject object = storage.remove(objectKey);
+            if (object != null) {
+                object.data.release();
                 deleteObjectKeys.add(objectKey);
             }
         }
@@ -201,13 +234,15 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     Pair<RetryStrategy, Throwable> toRetryStrategyAndCause(Throwable ex, S3Operation operation) {
         Throwable cause = FutureUtil.cause(ex);
-        RetryStrategy strategy = (cause instanceof UnsupportedOperationException || cause instanceof IllegalArgumentException || cause instanceof ObjectNotExistException)
+        RetryStrategy strategy = (cause instanceof UnsupportedOperationException || cause instanceof IllegalArgumentException
+            || cause instanceof ObjectNotExistException || cause instanceof ObjectStorageConditionNotMetException)
             ? RetryStrategy.ABORT : RetryStrategy.RETRY;
         return Pair.of(strategy, cause);
     }
 
     @Override
     void doClose() {
+        storage.values().forEach(object -> object.data.release());
         storage.clear();
     }
 
@@ -216,7 +251,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         return CompletableFuture.completedFuture(storage.entrySet()
             .stream()
             .filter(entry -> entry.getKey().startsWith(prefix))
-            .map(entry -> new ObjectInfo((short) 0, entry.getKey(), 0L, entry.getValue().readableBytes()))
+            .map(entry -> new ObjectInfo((short) 0, entry.getKey(), 0L, entry.getValue().data.readableBytes()))
             .collect(Collectors.toList()));
     }
 
@@ -229,7 +264,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         if (storage.size() != 1) {
             throw new IllegalStateException("expect only one object in storage");
         }
-        return storage.values().iterator().next();
+        return storage.values().iterator().next().data;
     }
 
     public boolean contains(String path) {
@@ -246,5 +281,15 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
 
     public NetworkBandwidthLimiter getNetworkOutboundBandwidthLimiter() {
         return this.networkOutboundBandwidthLimiter;
+    }
+
+    private static class StoredObject {
+        private final ByteBuf data;
+        private final long etag;
+
+        private StoredObject(ByteBuf data, long etag) {
+            this.data = data;
+            this.etag = etag;
+        }
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
@@ -139,6 +139,11 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     }
 
     @Override
+    public boolean supportsConditionalWrite() {
+        return true;
+    }
+
+    @Override
     public boolean readinessCheck() {
         return true;
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
@@ -84,12 +84,12 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     CompletableFuture<ReadResult> doRangeRead(ReadOptions options, String path, long start, long end) {
         AtomicReference<ReadResult> readResult = new AtomicReference<>();
         storage.computeIfPresent(path, (key, object) -> {
-            ByteBuf value = object.data;
+            ByteBuf value = object.data();
             int length = end != -1L ? (int) (end - start) : (int) (value.readableBytes() - start);
             ByteBuf rst = value.retainedSlice(value.readerIndex() + (int) start, length);
             CompositeByteBuf buf = ByteBufAlloc.compositeByteBuffer();
             buf.addComponent(true, rst);
-            readResult.set(ReadResult.of(buf, ObjectMetadata.of(new Etag(Long.toString(object.etag)))));
+            readResult.set(ReadResult.of(buf, ObjectMetadata.of(new Etag(Long.toString(object.etag())))));
             return object;
         });
         ReadResult result = readResult.get();
@@ -115,7 +115,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         AtomicReference<ObjectStorageConditionNotMetException> conditionFailure = new AtomicReference<>();
         storage.compute(path, (key, current) -> {
             if (condition instanceof WriteCondition.IfMatch ifMatch) {
-                if (current == null || !Long.toString(current.etag).equals(ifMatch.etag().value())) {
+                if (current == null || !Long.toString(current.etag()).equals(ifMatch.etag().value())) {
                     conditionFailure.set(new ObjectStorageConditionNotMetException("object etag does not match"));
                     return current;
                 }
@@ -126,7 +126,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
                 }
             }
             if (current != null) {
-                current.data.release();
+                current.data().release();
             }
             return new StoredObject(buf, etag.incrementAndGet());
         });
@@ -148,7 +148,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         ByteBuf buf = Unpooled.buffer();
         storage.compute(path, (key, old) -> {
             if (old != null) {
-                old.data.release();
+                old.data().release();
             }
             return new StoredObject(buf, etag.incrementAndGet());
         });
@@ -175,7 +175,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
             public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
                 AtomicBoolean copied = new AtomicBoolean();
                 storage.computeIfPresent(s3ObjectMetadata.key(), (key, sourceObject) -> {
-                    ByteBuf source = sourceObject.data;
+                    ByteBuf source = sourceObject.data();
                     buf.writeBytes(source.slice(source.readerIndex() + (int) start, (int) (end - start)));
                     copied.set(true);
                     return sourceObject;
@@ -229,7 +229,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     CompletableFuture<Void> doDeleteObjects(List<String> objectKeys) {
         for (String objectKey : objectKeys) {
             storage.computeIfPresent(objectKey, (key, object) -> {
-                object.data.release();
+                object.data().release();
                 deleteObjectKeys.add(objectKey);
                 return null;
             });
@@ -254,7 +254,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     void doClose() {
         storage.keySet().forEach(key -> storage.computeIfPresent(key, (ignored, object) -> {
-            object.data.release();
+            object.data().release();
             return null;
         }));
     }
@@ -264,7 +264,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         return CompletableFuture.completedFuture(storage.entrySet()
             .stream()
             .filter(entry -> entry.getKey().startsWith(prefix))
-            .map(entry -> new ObjectInfo((short) 0, entry.getKey(), 0L, entry.getValue().data.readableBytes()))
+            .map(entry -> new ObjectInfo((short) 0, entry.getKey(), 0L, entry.getValue().data().readableBytes()))
             .collect(Collectors.toList()));
     }
 
@@ -277,7 +277,7 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         if (storage.size() != 1) {
             throw new IllegalStateException("expect only one object in storage");
         }
-        return storage.values().iterator().next().data;
+        return storage.values().iterator().next().data();
     }
 
     public boolean contains(String path) {
@@ -296,13 +296,6 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
         return this.networkOutboundBandwidthLimiter;
     }
 
-    private static class StoredObject {
-        private final ByteBuf data;
-        private final long etag;
-
-        private StoredObject(ByteBuf data, long etag) {
-            this.data = data;
-            this.etag = etag;
-        }
+    private record StoredObject(ByteBuf data, long etag) {
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MemoryObjectStorage.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -81,16 +82,20 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
 
     @Override
     CompletableFuture<ReadResult> doRangeRead(ReadOptions options, String path, long start, long end) {
-        StoredObject object = storage.get(path);
-        if (object == null) {
+        AtomicReference<ReadResult> readResult = new AtomicReference<>();
+        storage.computeIfPresent(path, (key, object) -> {
+            ByteBuf value = object.data;
+            int length = end != -1L ? (int) (end - start) : (int) (value.readableBytes() - start);
+            ByteBuf rst = value.retainedSlice(value.readerIndex() + (int) start, length);
+            CompositeByteBuf buf = ByteBufAlloc.compositeByteBuffer();
+            buf.addComponent(true, rst);
+            readResult.set(ReadResult.of(buf, ObjectMetadata.of(new Etag(Long.toString(object.etag)))));
+            return object;
+        });
+        ReadResult result = readResult.get();
+        if (result == null) {
             return FutureUtil.failedFuture(new ObjectNotExistException("object not exist"));
         }
-        ByteBuf value = object.data;
-        int length = end != -1L ? (int) (end - start) : (int) (value.readableBytes() - start);
-        ByteBuf rst = value.retainedSlice(value.readerIndex() + (int) start, length);
-        CompositeByteBuf buf = ByteBufAlloc.compositeByteBuffer();
-        buf.addComponent(true, rst);
-        ReadResult result = ReadResult.of(buf, ObjectMetadata.of(new Etag(Long.toString(object.etag))));
         if (delay == 0) {
             return CompletableFuture.completedFuture(result);
         } else {
@@ -141,10 +146,12 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     public Writer writer(WriteOptions writeOptions, String path) {
         ByteBuf buf = Unpooled.buffer();
-        StoredObject old = storage.put(path, new StoredObject(buf, etag.incrementAndGet()));
-        if (old != null) {
-            old.data.release();
-        }
+        storage.compute(path, (key, old) -> {
+            if (old != null) {
+                old.data.release();
+            }
+            return new StoredObject(buf, etag.incrementAndGet());
+        });
         return new Writer() {
             @Override
             public CompletableFuture<Void> write(ByteBuf part) {
@@ -166,12 +173,16 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
 
             @Override
             public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-                StoredObject sourceObject = storage.get(s3ObjectMetadata.key());
-                if (sourceObject == null) {
+                AtomicBoolean copied = new AtomicBoolean();
+                storage.computeIfPresent(s3ObjectMetadata.key(), (key, sourceObject) -> {
+                    ByteBuf source = sourceObject.data;
+                    buf.writeBytes(source.slice(source.readerIndex() + (int) start, (int) (end - start)));
+                    copied.set(true);
+                    return sourceObject;
+                });
+                if (!copied.get()) {
                     throw new IllegalArgumentException("object not exist");
                 }
-                ByteBuf source = sourceObject.data;
-                buf.writeBytes(source.slice(source.readerIndex() + (int) start, (int) (end - start)));
             }
 
             @Override
@@ -217,11 +228,11 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
     @Override
     CompletableFuture<Void> doDeleteObjects(List<String> objectKeys) {
         for (String objectKey : objectKeys) {
-            StoredObject object = storage.remove(objectKey);
-            if (object != null) {
+            storage.computeIfPresent(objectKey, (key, object) -> {
                 object.data.release();
                 deleteObjectKeys.add(objectKey);
-            }
+                return null;
+            });
         }
 
         return CompletableFuture.completedFuture(null);
@@ -242,8 +253,10 @@ public class MemoryObjectStorage extends AbstractObjectStorage {
 
     @Override
     void doClose() {
-        storage.values().forEach(object -> object.data.release());
-        storage.clear();
+        storage.keySet().forEach(key -> storage.computeIfPresent(key, (ignored, object) -> {
+            object.data.release();
+            return null;
+        }));
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -153,13 +153,10 @@ public interface ObjectStorage {
         }
     }
 
-    class ReadResult {
-        private final ByteBuf data;
-        private final ObjectMetadata metadata;
-
-        public ReadResult(ByteBuf data, ObjectMetadata metadata) {
-            this.data = Objects.requireNonNull(data, "data");
-            this.metadata = Objects.requireNonNull(metadata, "metadata");
+    record ReadResult(ByteBuf data, ObjectMetadata metadata) {
+        public ReadResult {
+            Objects.requireNonNull(data, "data");
+            Objects.requireNonNull(metadata, "metadata");
         }
 
         public static ReadResult of(ByteBuf data) {
@@ -169,22 +166,13 @@ public interface ObjectStorage {
         public static ReadResult of(ByteBuf data, ObjectMetadata metadata) {
             return new ReadResult(data, metadata);
         }
-
-        public ByteBuf data() {
-            return data;
-        }
-
-        public ObjectMetadata metadata() {
-            return metadata;
-        }
     }
 
-    class ObjectMetadata {
+    record ObjectMetadata(Etag etag) {
         private static final ObjectMetadata EMPTY = new ObjectMetadata(new Etag(null));
-        private final Etag etag;
 
-        public ObjectMetadata(Etag etag) {
-            this.etag = Objects.requireNonNull(etag, "etag");
+        public ObjectMetadata {
+            Objects.requireNonNull(etag, "etag");
         }
 
         public static ObjectMetadata empty() {
@@ -193,10 +181,6 @@ public interface ObjectStorage {
 
         public static ObjectMetadata of(Etag etag) {
             return new ObjectMetadata(etag);
-        }
-
-        public Etag etag() {
-            return etag;
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -95,6 +95,10 @@ public interface ObjectStorage {
         return FutureUtil.failedFuture(new UnsupportedOperationException("conditional write is not supported"));
     }
 
+    default boolean supportsConditionalWrite() {
+        return false;
+    }
+
     CompletableFuture<List<ObjectInfo>> list(String prefix);
 
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -22,8 +22,10 @@ package com.automq.stream.s3.operator;
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.exceptions.ObjectNotExistException;
 import com.automq.stream.s3.network.ThrottleStrategy;
+import com.automq.stream.utils.FutureUtil;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
@@ -53,6 +55,15 @@ public interface ObjectStorage {
     }
 
     /**
+     * Read whole object data with object metadata.
+     * The {@link ReadResult#data()} buffer ownership is the same as {@link #read(ReadOptions, String)}.
+     */
+    default CompletableFuture<ReadResult> readWithMetadata(ReadOptions options, String objectPath) {
+        return rangeRead(options, objectPath, 0, RANGE_READ_TO_END)
+            .thenApply(ReadResult::of);
+    }
+
+    /**
      * Range read object from the object storage.
      * It will failFuture with {@link ObjectNotExistException} if the object not found.
      * @param options {@link ReadOptions}
@@ -68,6 +79,20 @@ public interface ObjectStorage {
         Writer writer = writer(options, objectPath);
         writer.write(buf);
         return writer.close().thenApply(nil -> new WriteResult(bucketId()));
+    }
+
+    /**
+     * Write an object only when the given condition is satisfied.
+     * Implementations must execute the condition or fail; this method must not fall back to ordinary write.
+     */
+    default CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath, ByteBuf buf,
+        WriteCondition condition) {
+        if (condition == null) {
+            buf.release();
+            return FutureUtil.failedFuture(new IllegalArgumentException("condition cannot be null"));
+        }
+        buf.release();
+        return FutureUtil.failedFuture(new UnsupportedOperationException("conditional write is not supported"));
     }
 
     CompletableFuture<List<ObjectInfo>> list(String prefix);
@@ -125,6 +150,85 @@ public interface ObjectStorage {
 
         public long size() {
             return size;
+        }
+    }
+
+    class ReadResult {
+        private final ByteBuf data;
+        private final ObjectMetadata metadata;
+
+        public ReadResult(ByteBuf data, ObjectMetadata metadata) {
+            this.data = Objects.requireNonNull(data, "data");
+            this.metadata = Objects.requireNonNull(metadata, "metadata");
+        }
+
+        public static ReadResult of(ByteBuf data) {
+            return of(data, ObjectMetadata.empty());
+        }
+
+        public static ReadResult of(ByteBuf data, ObjectMetadata metadata) {
+            return new ReadResult(data, metadata);
+        }
+
+        public ByteBuf data() {
+            return data;
+        }
+
+        public ObjectMetadata metadata() {
+            return metadata;
+        }
+    }
+
+    class ObjectMetadata {
+        private static final ObjectMetadata EMPTY = new ObjectMetadata(new Etag(null));
+        private final Etag etag;
+
+        public ObjectMetadata(Etag etag) {
+            this.etag = Objects.requireNonNull(etag, "etag");
+        }
+
+        public static ObjectMetadata empty() {
+            return EMPTY;
+        }
+
+        public static ObjectMetadata of(Etag etag) {
+            return new ObjectMetadata(etag);
+        }
+
+        public Etag etag() {
+            return etag;
+        }
+    }
+
+    class Etag {
+        private final String value;
+
+        public Etag(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+
+    abstract class WriteCondition {
+        private WriteCondition() {
+        }
+
+        public static final class IfMatch extends WriteCondition {
+            private final Etag etag;
+
+            public IfMatch(Etag etag) {
+                this.etag = Objects.requireNonNull(etag, "etag");
+            }
+
+            public Etag etag() {
+                return etag;
+            }
+        }
+
+        public static final class IfAbsent extends WriteCondition {
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -184,16 +184,7 @@ public interface ObjectStorage {
         }
     }
 
-    class Etag {
-        private final String value;
-
-        public Etag(String value) {
-            this.value = value;
-        }
-
-        public String value() {
-            return value;
-        }
+    record Etag(String value) {
     }
 
     abstract class WriteCondition {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
@@ -164,6 +164,11 @@ public class ObjectReservationService implements ReservationService {
             return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("Failover acquire cannot create missing reservation, nodeId=%s, epoch=%s", nodeId, epoch)));
         }
+        if (!objectStorage.supportsConditionalWrite()) {
+            LOGGER.warn("Create reservation without object conditional write protection, nodeId={}, epoch={}",
+                nodeId, epoch);
+            return objectStorage.write(options.copy(), path, reservationBody(nodeId, epoch, false)).thenApply(rst -> null);
+        }
         return objectStorage.conditionalWrite(options.copy(), path, reservationBody(nodeId, epoch, false),
             new ObjectStorage.WriteCondition.IfAbsent()).thenApply(rst -> null);
     }
@@ -199,12 +204,12 @@ public class ObjectReservationService implements ReservationService {
     private CompletableFuture<Void> writeReservationWithObservedEtag(ObjectStorage.WriteOptions options, String path,
         long nodeId, long epoch, boolean failover, ObjectStorage.Etag etag) {
         ByteBuf body = reservationBody(nodeId, epoch, failover);
-        if (etag.value() != null) {
+        if (objectStorage.supportsConditionalWrite() && etag.value() != null) {
             return objectStorage.conditionalWrite(options.copy(), path, body,
                 new ObjectStorage.WriteCondition.IfMatch(etag)).thenApply(rst -> null);
         }
-        LOGGER.warn("Acquire reservation without object etag CAS protection, nodeId={}, epoch={}, failover={}",
-            nodeId, epoch, failover);
+        LOGGER.warn("Acquire reservation without object conditional write protection, nodeId={}, epoch={}, failover={}, etagPresent={}",
+            nodeId, epoch, failover, etag.value() != null);
         return objectStorage.write(options.copy(), path, body).thenApply(rst -> null);
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
@@ -107,14 +107,19 @@ public class ObjectReservationService implements ReservationService {
 
     private CompletableFuture<Void> acquire0(ObjectStorage.WriteOptions options, long nodeId, long epoch,
         boolean failover, int conflictReevaluationCount) {
+        return withConditionConflictReread(acquireOnce(options, nodeId, epoch, failover),
+            options, nodeId, epoch, failover, conflictReevaluationCount);
+    }
+
+    private CompletableFuture<Void> acquireOnce(ObjectStorage.WriteOptions options, long nodeId, long epoch,
+        boolean failover) {
         String path = path(nodeId);
         return objectStorage.readWithMetadata(new ObjectStorage.ReadOptions().throttleStrategy(ThrottleStrategy.BYPASS).bucket(bucketId), path)
-            .handle((result, ex) -> {
+            .<CompletableFuture<Void>>handle((result, ex) -> {
                 if (ex != null) {
                     Throwable cause = FutureUtil.cause(ex);
                     if (cause instanceof ObjectNotExistException) {
-                        return withConditionConflictReread(handleMissingReservation(options, path, nodeId, epoch, failover),
-                            options, nodeId, epoch, failover, conflictReevaluationCount);
+                        return createMissingReservation(options, path, nodeId, epoch, failover);
                     }
                     return FutureUtil.<Void>failedFuture(cause);
                 }
@@ -132,8 +137,10 @@ public class ObjectReservationService implements ReservationService {
                 } catch (Throwable decisionEx) {
                     return FutureUtil.<Void>failedFuture(decisionEx);
                 }
-                return withConditionConflictReread(executeDecision(options, path, decision, nodeId, epoch, failover),
-                    options, nodeId, epoch, failover, conflictReevaluationCount);
+                if (decision.noop) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return writeReservationWithObservedEtag(options, path, nodeId, epoch, failover, decision.etag);
             }).thenCompose(cf -> cf);
     }
 
@@ -151,7 +158,7 @@ public class ObjectReservationService implements ReservationService {
         });
     }
 
-    private CompletableFuture<Void> handleMissingReservation(ObjectStorage.WriteOptions options, String path,
+    private CompletableFuture<Void> createMissingReservation(ObjectStorage.WriteOptions options, String path,
         long nodeId, long epoch, boolean failover) {
         if (failover) {
             return FutureUtil.failedFuture(new IllegalStateException(
@@ -189,15 +196,7 @@ public class ObjectReservationService implements ReservationService {
                 nodeId, current.epoch, epoch, current.failover));
     }
 
-    private CompletableFuture<Void> executeDecision(ObjectStorage.WriteOptions options, String path,
-        AcquireDecision decision, long nodeId, long epoch, boolean failover) {
-        if (decision.noop) {
-            return CompletableFuture.completedFuture(null);
-        }
-        return writeReservation(options, path, nodeId, epoch, failover, decision.etag);
-    }
-
-    private CompletableFuture<Void> writeReservation(ObjectStorage.WriteOptions options, String path,
+    private CompletableFuture<Void> writeReservationWithObservedEtag(ObjectStorage.WriteOptions options, String path,
         long nodeId, long epoch, boolean failover, ObjectStorage.Etag etag) {
         ByteBuf body = reservationBody(nodeId, epoch, failover);
         if (etag.value() != null) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
@@ -21,9 +21,12 @@ package com.automq.stream.s3.wal.impl.object;
 
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.Constants;
+import com.automq.stream.s3.exceptions.ObjectNotExistException;
+import com.automq.stream.s3.exceptions.ObjectStorageConditionNotMetException;
 import com.automq.stream.s3.network.ThrottleStrategy;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.wal.ReservationService;
+import com.automq.stream.utils.FutureUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,7 @@ public class ObjectReservationService implements ReservationService {
                                                               + 8  // node id
                                                               + 8  // node epoch
                                                               + 1; // failover flag
+    private static final int MAX_CONFLICT_REEVALUATION = 1;
 
     private final String clusterId;
     private final ObjectStorage objectStorage;
@@ -97,12 +101,173 @@ public class ObjectReservationService implements ReservationService {
     @Override
     public CompletableFuture<Void> acquire(long nodeId, long epoch, boolean failover) {
         LOGGER.info("Acquire permission for node: {}, epoch: {}, failover: {}", nodeId, epoch, failover);
+        ObjectStorage.WriteOptions options = new ObjectStorage.WriteOptions().throttleStrategy(ThrottleStrategy.BYPASS);
+        return acquire0(options, nodeId, epoch, failover, 0);
+    }
+
+    private CompletableFuture<Void> acquire0(ObjectStorage.WriteOptions options, long nodeId, long epoch,
+        boolean failover, int conflictReevaluationCount) {
+        String path = path(nodeId);
+        return objectStorage.readWithMetadata(new ObjectStorage.ReadOptions().throttleStrategy(ThrottleStrategy.BYPASS).bucket(bucketId), path)
+            .handle((result, ex) -> {
+                if (ex != null) {
+                    Throwable cause = FutureUtil.cause(ex);
+                    if (cause instanceof ObjectNotExistException) {
+                        return withConditionConflictReread(handleMissingReservation(options, path, nodeId, epoch, failover),
+                            options, nodeId, epoch, failover, conflictReevaluationCount);
+                    }
+                    return FutureUtil.<Void>failedFuture(cause);
+                }
+                ReservationRecord current;
+                try {
+                    current = parseReservation(nodeId, result);
+                } catch (Throwable parseEx) {
+                    return FutureUtil.<Void>failedFuture(parseEx);
+                } finally {
+                    result.data().release();
+                }
+                AcquireDecision decision;
+                try {
+                    decision = decide(current, nodeId, epoch, failover);
+                } catch (Throwable decisionEx) {
+                    return FutureUtil.<Void>failedFuture(decisionEx);
+                }
+                return withConditionConflictReread(executeDecision(options, path, decision, nodeId, epoch, failover),
+                    options, nodeId, epoch, failover, conflictReevaluationCount);
+            }).thenCompose(cf -> cf);
+    }
+
+    private CompletableFuture<Void> withConditionConflictReread(CompletableFuture<Void> cf,
+        ObjectStorage.WriteOptions options, long nodeId, long epoch, boolean failover, int conflictReevaluationCount) {
+        return cf.exceptionallyCompose(ex -> {
+            Throwable cause = FutureUtil.cause(ex);
+            if (cause instanceof ObjectStorageConditionNotMetException
+                && conflictReevaluationCount < MAX_CONFLICT_REEVALUATION) {
+                LOGGER.info("Reservation conditional write conflict, node: {}, epoch: {}, failover: {}, retry: {}",
+                    nodeId, epoch, failover, conflictReevaluationCount + 1);
+                return acquire0(options.copy(), nodeId, epoch, failover, conflictReevaluationCount + 1);
+            }
+            return FutureUtil.failedFuture(cause);
+        });
+    }
+
+    private CompletableFuture<Void> handleMissingReservation(ObjectStorage.WriteOptions options, String path,
+        long nodeId, long epoch, boolean failover) {
+        if (failover) {
+            return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("Failover acquire cannot create missing reservation, nodeId=%s, epoch=%s", nodeId, epoch)));
+        }
+        return objectStorage.conditionalWrite(options.copy(), path, reservationBody(nodeId, epoch, false),
+            new ObjectStorage.WriteCondition.IfAbsent()).thenApply(rst -> null);
+    }
+
+    private AcquireDecision decide(ReservationRecord current, long nodeId, long epoch, boolean failover) {
+        if (current.nodeId != nodeId) {
+            throw new IllegalStateException(
+                String.format("Reservation node id mismatch, expect=%s, actual=%s", nodeId, current.nodeId));
+        }
+        if (failover) {
+            if (current.epoch == epoch && current.failover) {
+                return AcquireDecision.noop();
+            }
+            if (current.epoch == epoch && !current.failover) {
+                return AcquireDecision.write(current.etag);
+            }
+            throw new IllegalStateException(
+                String.format("Failover acquire rejected, nodeId=%s, currentEpoch=%s, requestEpoch=%s, currentFailover=%s",
+                    nodeId, current.epoch, epoch, current.failover));
+        }
+
+        if (current.epoch == epoch && !current.failover) {
+            return AcquireDecision.noop();
+        }
+        if (current.epoch < epoch) {
+            return AcquireDecision.write(current.etag);
+        }
+        throw new IllegalStateException(
+            String.format("Normal acquire rejected, nodeId=%s, currentEpoch=%s, requestEpoch=%s, currentFailover=%s",
+                nodeId, current.epoch, epoch, current.failover));
+    }
+
+    private CompletableFuture<Void> executeDecision(ObjectStorage.WriteOptions options, String path,
+        AcquireDecision decision, long nodeId, long epoch, boolean failover) {
+        if (decision.noop) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return writeReservation(options, path, nodeId, epoch, failover, decision.etag);
+    }
+
+    private CompletableFuture<Void> writeReservation(ObjectStorage.WriteOptions options, String path,
+        long nodeId, long epoch, boolean failover, ObjectStorage.Etag etag) {
+        ByteBuf body = reservationBody(nodeId, epoch, failover);
+        if (etag.value() != null) {
+            return objectStorage.conditionalWrite(options.copy(), path, body,
+                new ObjectStorage.WriteCondition.IfMatch(etag)).thenApply(rst -> null);
+        }
+        LOGGER.warn("Acquire reservation without object etag CAS protection, nodeId={}, epoch={}, failover={}",
+            nodeId, epoch, failover);
+        return objectStorage.write(options.copy(), path, body).thenApply(rst -> null);
+    }
+
+    private ReservationRecord parseReservation(long nodeId, ObjectStorage.ReadResult result) {
+        ByteBuf bytes = result.data();
+        if (bytes.readableBytes() != S3_RESERVATION_OBJECT_LENGTH) {
+            throw new IllegalStateException(String.format("Invalid reservation length, nodeId=%s, length=%s",
+                nodeId, bytes.readableBytes()));
+        }
+        ByteBuf slice = bytes.slice();
+        int magic = slice.readInt();
+        if (magic != S3_RESERVATION_OBJECT_MAGIC_CODE) {
+            throw new IllegalStateException(String.format("Invalid reservation magic code, nodeId=%s, magic=%s",
+                nodeId, magic));
+        }
+        long reservedNodeId = slice.readLong();
+        long epoch = slice.readLong();
+        boolean failover = slice.readBoolean();
+        return new ReservationRecord(reservedNodeId, epoch, failover, result.metadata().etag());
+    }
+
+    private ByteBuf reservationBody(long nodeId, long epoch, boolean failover) {
         ByteBuf target = ByteBufAlloc.byteBuffer(S3_RESERVATION_OBJECT_LENGTH);
         target.writeInt(S3_RESERVATION_OBJECT_MAGIC_CODE);
         target.writeLong(nodeId);
         target.writeLong(epoch);
         target.writeBoolean(failover);
-        ObjectStorage.WriteOptions options = new ObjectStorage.WriteOptions().throttleStrategy(ThrottleStrategy.BYPASS);
-        return objectStorage.write(options, path(nodeId), target).thenApply(rst -> null);
+        return target;
+    }
+
+    private static class ReservationRecord {
+        private final long nodeId;
+        private final long epoch;
+        private final boolean failover;
+        private final ObjectStorage.Etag etag;
+
+        private ReservationRecord(long nodeId, long epoch, boolean failover,
+            ObjectStorage.Etag etag) {
+            this.nodeId = nodeId;
+            this.epoch = epoch;
+            this.failover = failover;
+            this.etag = etag;
+        }
+    }
+
+    private static class AcquireDecision {
+        private static final AcquireDecision NOOP = new AcquireDecision(true, new ObjectStorage.Etag(null));
+
+        private final boolean noop;
+        private final ObjectStorage.Etag etag;
+
+        private AcquireDecision(boolean noop, ObjectStorage.Etag etag) {
+            this.noop = noop;
+            this.etag = etag;
+        }
+
+        private static AcquireDecision noop() {
+            return NOOP;
+        }
+
+        private static AcquireDecision write(ObjectStorage.Etag etag) {
+            return new AcquireDecision(false, etag);
+        }
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/AbstractObjectStorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/AbstractObjectStorageTest.java
@@ -151,14 +151,14 @@ class AbstractObjectStorageTest {
     @Test
     void testHandleReadCompleted() throws Throwable {
         ByteBuf data = TestUtils.random(4096);
-        CompletableFuture<ByteBuf> readToEndCf = new CompletableFuture<>();
-        CompletableFuture<ByteBuf> readRangeCf = new CompletableFuture<>();
+        CompletableFuture<ObjectStorage.ReadResult> readToEndCf = new CompletableFuture<>();
+        CompletableFuture<ObjectStorage.ReadResult> readRangeCf = new CompletableFuture<>();
         AbstractObjectStorage.MergedReadTask.handleReadCompleted(List.of(
             new AbstractObjectStorage.ReadTask(new ReadOptions(), "fake", 3000, -1, readToEndCf),
             new AbstractObjectStorage.ReadTask(new ReadOptions(), "fake", 2000, 4096, readRangeCf)
-        ), 2000, data.slice(2000, 4096 - 2000), null);
-        assertEquals(data.slice(3000, 4096 - 3000), readToEndCf.get());
-        assertEquals(data.slice(2000, 4096 - 2000), readRangeCf.get());
+        ), 2000, ObjectStorage.ReadResult.of(data.slice(2000, 4096 - 2000)), null);
+        assertEquals(data.slice(3000, 4096 - 3000), readToEndCf.get().data());
+        assertEquals(data.slice(2000, 4096 - 2000), readRangeCf.get().data());
     }
 
     @Test
@@ -196,7 +196,7 @@ class AbstractObjectStorageTest {
         // Track doWrite() calls: first call hangs, second completes immediately
         AtomicInteger callCount = new AtomicInteger();
         CompletableFuture<Void> firstFuture = new CompletableFuture<>();
-        when(objectStorage.doWrite(any(), anyString(), any())).thenAnswer(inv -> {
+        when(objectStorage.doWrite(any(), anyString(), any(), any())).thenAnswer(inv -> {
             int count = callCount.getAndIncrement();
             return (count == 0) ? firstFuture : CompletableFuture.completedFuture(null);
         });
@@ -228,7 +228,7 @@ class AbstractObjectStorageTest {
 
         // Mock hanging write operation
         AtomicInteger callCount = new AtomicInteger();
-        when(objectStorage.doWrite(any(), anyString(), any())).thenAnswer(inv -> {
+        when(objectStorage.doWrite(any(), anyString(), any(), any())).thenAnswer(inv -> {
             int count = callCount.getAndIncrement();
             if (count < 12) {
                 CompletableFuture<Void> future = new CompletableFuture<>();
@@ -269,7 +269,7 @@ class AbstractObjectStorageTest {
         CompletableFuture<Void> barrierFuture = new CompletableFuture<>();
         AtomicInteger callCount = new AtomicInteger();
 
-        when(objectStorage.doWrite(any(), anyString(), any())).thenAnswer(inv -> {
+        when(objectStorage.doWrite(any(), anyString(), any(), any())).thenAnswer(inv -> {
             int count = callCount.getAndIncrement();
             return (count < maxConcurrency)
                 ? barrierFuture // Block first 5 calls
@@ -321,7 +321,7 @@ class AbstractObjectStorageTest {
         CompletableFuture<Void> blockingFuture = new CompletableFuture<>();
         AtomicInteger callCount = new AtomicInteger();
 
-        when(objectStorage.doWrite(any(), anyString(), any())).thenAnswer(inv -> {
+        when(objectStorage.doWrite(any(), anyString(), any(), any())).thenAnswer(inv -> {
             callCount.incrementAndGet();
             return blockingFuture; // Always return blocking future for first call
         });

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
@@ -64,4 +64,11 @@ public class AwsObjectStorageTest {
         Assertions.assertTrue(ex.getRetriableKeys().containsKey("retry"));
         Assertions.assertTrue(ex.getFailedKeyErrors().containsKey("fail"));
     }
+
+    @Test
+    void testConditionalWriteDisabledByDefault() {
+        AwsObjectStorage storage = new AwsObjectStorage(null, "bucket");
+
+        Assertions.assertFalse(storage.supportsConditionalWrite());
+    }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
@@ -167,19 +167,25 @@ class ObjectReservationServiceTest {
     }
 
     @Test
-    void missingReservationIfAbsentUnsupportedFailsClosed() {
+    void missingReservationDowngradesWhenConditionalWriteUnsupported() {
         ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public boolean supportsConditionalWrite() {
+                return false;
+            }
+
             @Override
             public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
                 ByteBuf buf, WriteCondition condition) {
                 buf.release();
-                return FutureUtil.failedFuture(new UnsupportedOperationException("conditional write is not supported"));
+                return FutureUtil.failedFuture(new AssertionError("conditionalWrite should not be used when unsupported"));
             }
         };
         ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
 
-        assertThrows(CompletionException.class, () -> service.acquire(1, 2, false).join());
-        assertFalse(service.verify(1, 2, false).join());
+        service.acquire(1, 2, false).join();
+
+        assertTrue(service.verify(1, 2, false).join());
     }
 
     @Test
@@ -212,6 +218,29 @@ class ObjectReservationServiceTest {
                     return FutureUtil.failedFuture(new AssertionError("IfMatch should not be used without etag"));
                 }
                 return super.conditionalWrite(options, objectPath, buf, condition);
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
+
+        service.acquire(1, 2, false).join();
+        service.acquire(1, 2, true).join();
+
+        assertTrue(service.verify(1, 2, true).join());
+    }
+
+    @Test
+    void existingReservationDowngradesWhenConditionalWriteUnsupported() {
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public boolean supportsConditionalWrite() {
+                return false;
+            }
+
+            @Override
+            public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
+                ByteBuf buf, WriteCondition condition) {
+                buf.release();
+                return FutureUtil.failedFuture(new AssertionError("conditionalWrite should not be used when unsupported"));
             }
         };
         ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
@@ -19,16 +19,24 @@
 
 package com.automq.stream.s3.wal.impl.object;
 
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.exceptions.ObjectStorageConditionNotMetException;
+import com.automq.stream.s3.network.ThrottleStrategy;
 import com.automq.stream.s3.operator.MemoryObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorage;
+import com.automq.stream.utils.FutureUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObjectReservationServiceTest {
@@ -42,7 +50,7 @@ class ObjectReservationServiceTest {
     }
 
     @Test
-    void verify() {
+    void verifyKeepsBodyCompareSemantics() {
         reservationService.acquire(1, 2, false).join();
         assertTrue(reservationService.verify(1, 2, false).join());
         assertFalse(reservationService.verify(1, 2, true).join());
@@ -50,48 +58,184 @@ class ObjectReservationServiceTest {
         assertFalse(reservationService.verify(1, 1, false).join());
         assertFalse(reservationService.verify(1, 3, false).join());
         assertFalse(reservationService.verify(2, 2, false).join());
+    }
+
+    @Test
+    void staleFailoverCannotFenceNewerOwner() {
+        reservationService.acquire(1, 3, false).join();
+
+        assertThrows(CompletionException.class, () -> reservationService.acquire(1, 2, true).join());
+
+        assertTrue(reservationService.verify(1, 3, false).join());
+        assertFalse(reservationService.verify(1, 2, true).join());
+    }
+
+    @Test
+    void validFailoverFencesSameEpochNormalOwnerOnce() {
+        reservationService.acquire(1, 2, false).join();
 
         reservationService.acquire(1, 2, true).join();
+        reservationService.acquire(1, 2, true).join();
+
+        assertTrue(reservationService.verify(1, 2, true).join());
         assertFalse(reservationService.verify(1, 2, false).join());
+    }
+
+    @Test
+    void normalOwnerMovesEpochForwardButNeverBackward() {
+        reservationService.acquire(1, 2, false).join();
+        reservationService.acquire(1, 2, true).join();
+
+        reservationService.acquire(1, 3, false).join();
+        assertTrue(reservationService.verify(1, 3, false).join());
+
+        assertThrows(CompletionException.class, () -> reservationService.acquire(1, 2, false).join());
+        assertTrue(reservationService.verify(1, 3, false).join());
+    }
+
+    @Test
+    void sameEpochNormalAcquireIsIdempotentAndDoesNotClearFailover() {
+        reservationService.acquire(1, 2, false).join();
+        reservationService.acquire(1, 2, false).join();
+        assertTrue(reservationService.verify(1, 2, false).join());
+
+        reservationService.acquire(1, 2, true).join();
+        assertThrows(CompletionException.class, () -> reservationService.acquire(1, 2, false).join());
         assertTrue(reservationService.verify(1, 2, true).join());
     }
 
     @Test
-    void acquire() {
-        ByteBuf target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeLong(Long.MAX_VALUE);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(false);
-        target.writeLong(Long.MAX_VALUE);
-        target.readerIndex(Long.BYTES);
-        target.writerIndex(Long.BYTES + ObjectReservationService.S3_RESERVATION_OBJECT_LENGTH);
+    void missingReservationOnlyNormalAcquireCanCreate() {
+        assertThrows(CompletionException.class, () -> reservationService.acquire(1, 2, true).join());
+
         reservationService.acquire(1, 2, false).join();
-        assertTrue(reservationService.verify(1, target).join());
+        assertTrue(reservationService.verify(1, 2, false).join());
+    }
 
-        target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(false);
-        reservationService.acquire(1, 2, true).join();
-        assertFalse(reservationService.verify(1, target).join());
+    @Test
+    void missingReservationIfAbsentConflictTriggersBoundedReread() {
+        AtomicBoolean conflictInjected = new AtomicBoolean();
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
+                ByteBuf buf, WriteCondition condition) {
+                if (condition instanceof WriteCondition.IfAbsent && conflictInjected.compareAndSet(false, true)) {
+                    buf.release();
+                    write(options, objectPath, reservationBody(1, 2, false)).join();
+                    return FutureUtil.failedFuture(new ObjectStorageConditionNotMetException("injected if-absent conflict"));
+                }
+                return super.conditionalWrite(options, objectPath, buf, condition);
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
 
-        target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(true);
-        reservationService.acquire(1, 2, true).join();
-        assertTrue(reservationService.verify(1, target).join());
+        service.acquire(1, 2, false).join();
 
-        target = Unpooled.buffer(Long.BYTES * 10);
+        assertTrue(service.verify(1, 2, false).join());
+    }
+
+    @Test
+    void malformedNodeIdFailsClosed() {
+        objectStorage.write(new ObjectStorage.WriteOptions().throttleStrategy(ThrottleStrategy.BYPASS),
+            path(1), reservationBody(2, 2, false)).join();
+
+        assertThrows(CompletionException.class, () -> reservationService.acquire(1, 3, false).join());
+        assertTrue(verifyBody(1, 2, 2, false).join());
+    }
+
+    @Test
+    void conditionalWriteConflictTriggersBoundedReread() {
+        AtomicBoolean conflictInjected = new AtomicBoolean();
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
+                ByteBuf buf, WriteCondition condition) {
+                if (condition instanceof WriteCondition.IfMatch && conflictInjected.compareAndSet(false, true)) {
+                    buf.release();
+                    write(options, objectPath, reservationBody(1, 2, true)).join();
+                    return FutureUtil.failedFuture(new ObjectStorageConditionNotMetException("injected condition conflict"));
+                }
+                return super.conditionalWrite(options, objectPath, buf, condition);
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
+
+        service.acquire(1, 2, false).join();
+        service.acquire(1, 2, true).join();
+
+        assertTrue(service.verify(1, 2, true).join());
+    }
+
+    @Test
+    void missingReservationIfAbsentUnsupportedFailsClosed() {
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
+                ByteBuf buf, WriteCondition condition) {
+                buf.release();
+                return FutureUtil.failedFuture(new UnsupportedOperationException("conditional write is not supported"));
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
+
+        assertThrows(CompletionException.class, () -> service.acquire(1, 2, false).join());
+        assertFalse(service.verify(1, 2, false).join());
+    }
+
+    @Test
+    void readWithMetadataUnexpectedFailureFailsAcquire() {
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public CompletableFuture<ReadResult> readWithMetadata(ReadOptions options, String objectPath) {
+                return FutureUtil.failedFuture(new IllegalStateException("metadata read failed"));
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
+
+        assertThrows(CompletionException.class, () -> service.acquire(1, 2, false).join());
+    }
+
+    @Test
+    void etagEmptyDowngradesExistingReservationModification() {
+        ObjectStorage storage = new MemoryObjectStorage() {
+            @Override
+            public CompletableFuture<ReadResult> readWithMetadata(ReadOptions options, String objectPath) {
+                return rangeRead(options, objectPath, 0, RANGE_READ_TO_END)
+                    .thenApply(ReadResult::of);
+            }
+
+            @Override
+            public CompletableFuture<WriteResult> conditionalWrite(WriteOptions options, String objectPath,
+                ByteBuf buf, WriteCondition condition) {
+                if (condition instanceof WriteCondition.IfMatch) {
+                    buf.release();
+                    return FutureUtil.failedFuture(new AssertionError("IfMatch should not be used without etag"));
+                }
+                return super.conditionalWrite(options, objectPath, buf, condition);
+            }
+        };
+        ObjectReservationService service = new ObjectReservationService("cluster", storage, (short) 0);
+
+        service.acquire(1, 2, false).join();
+        service.acquire(1, 2, true).join();
+
+        assertTrue(service.verify(1, 2, true).join());
+    }
+
+    private CompletableFuture<Boolean> verifyBody(long pathNodeId, long bodyNodeId, long epoch, boolean failover) {
+        return reservationService.verify(pathNodeId, reservationBody(bodyNodeId, epoch, failover));
+    }
+
+    private static ByteBuf reservationBody(long nodeId, long epoch, boolean failover) {
+        ByteBuf target = ByteBufAlloc.byteBuffer(ObjectReservationService.S3_RESERVATION_OBJECT_LENGTH);
         target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(true);
-        reservationService.acquire(1, 2, false).join();
-        assertFalse(reservationService.verify(1, target).join());
+        target.writeLong(nodeId);
+        target.writeLong(epoch);
+        target.writeBoolean(failover);
+        return target;
+    }
+
+    private static String path(long nodeId) {
+        return "reservation/_kafka_cluster/" + nodeId;
     }
 }


### PR DESCRIPTION
## Summary
- add read metadata and ETag-based conditional write support to object storage
- use conditional writes in object WAL reservation acquire with bounded reread on conflicts
- keep internal read pipeline based on ReadResult and unwrap ByteBuf only at public rangeRead boundary

## Tests
- ./gradlew :s3stream:test --tests "com.automq.stream.s3.operator.AbstractObjectStorageTest" --tests "com.automq.stream.s3.wal.impl.object.ObjectReservationServiceTest"
- just gradlew :enterprise-core:compileJava