### PR TITLE
fix(s3stream): validate object WAL reservation before acquire write

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectReservationService.java
@@ -21,9 +21,11 @@ package com.automq.stream.s3.wal.impl.object;
 
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.Constants;
+import com.automq.stream.s3.exceptions.ObjectNotExistException;
 import com.automq.stream.s3.network.ThrottleStrategy;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.wal.ReservationService;
+import com.automq.stream.utils.FutureUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,12 +99,132 @@ public class ObjectReservationService implements ReservationService {
     @Override
     public CompletableFuture<Void> acquire(long nodeId, long epoch, boolean failover) {
         LOGGER.info("Acquire permission for node: {}, epoch: {}, failover: {}", nodeId, epoch, failover);
+        String path = path(nodeId);
+        ObjectStorage.ReadOptions readOptions = new ObjectStorage.ReadOptions().throttleStrategy(ThrottleStrategy.BYPASS).bucket(bucketId);
+        ObjectStorage.WriteOptions writeOptions = new ObjectStorage.WriteOptions().throttleStrategy(ThrottleStrategy.BYPASS);
+        CompletableFuture<Void> acquireCf = new CompletableFuture<>();
+        objectStorage.rangeRead(readOptions, path, 0, S3_RESERVATION_OBJECT_LENGTH)
+            .whenComplete((bytes, ex) -> {
+                try {
+                    CompletableFuture<Void> next = ex == null
+                        ? acquireFromExistingReservation(bytes, writeOptions, path, nodeId, epoch, failover)
+                        : acquireFromReadFailure(ex, writeOptions, path, nodeId, epoch, failover);
+                    FutureUtil.propagate(next, acquireCf);
+                } catch (Throwable t) {
+                    acquireCf.completeExceptionally(t);
+                }
+            });
+        return acquireCf;
+    }
+
+    private CompletableFuture<Void> acquireFromReadFailure(Throwable ex, ObjectStorage.WriteOptions options, String path,
+        long nodeId, long epoch, boolean failover) {
+        Throwable cause = FutureUtil.cause(ex);
+        if (cause instanceof ObjectNotExistException) {
+            return acquireFromMissingReservation(options, path, nodeId, epoch, failover);
+        }
+        return FutureUtil.failedFuture(cause);
+    }
+
+    private CompletableFuture<Void> acquireFromExistingReservation(ByteBuf bytes, ObjectStorage.WriteOptions options,
+        String path, long nodeId, long epoch, boolean failover) {
+        AcquireDecision decision = AcquireDecision.allow();
+        try {
+            decision = evaluateAcquireAction(parseReservation(nodeId, bytes), nodeId, epoch, failover);
+        } catch (IllegalStateException ex) {
+            LOGGER.warn("Overwrite invalid reservation object, nodeId={}, epoch={}, failover={}", nodeId, epoch, failover, ex);
+        } finally {
+            bytes.release();
+        }
+        if (!decision.allowed()) {
+            return FutureUtil.failedFuture(new IllegalStateException(decision.rejectReason()));
+        }
+        return writeReservation(options, path, nodeId, epoch, failover);
+    }
+
+    private CompletableFuture<Void> acquireFromMissingReservation(ObjectStorage.WriteOptions options, String path,
+        long nodeId, long epoch, boolean failover) {
+        if (failover) {
+            return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("Failover acquire cannot create missing reservation, nodeId=%s, epoch=%s", nodeId, epoch)));
+        }
+        return writeReservation(options, path, nodeId, epoch, false);
+    }
+
+    private AcquireDecision evaluateAcquireAction(ReservationRecord current, long nodeId, long epoch, boolean failover) {
+        if (current.nodeId() != nodeId) {
+            LOGGER.warn("Overwrite reservation object with mismatched node id, expect={}, actual={}", nodeId, current.nodeId());
+            return AcquireDecision.allow();
+        }
+
+        // Existing reservation transition table:
+        // - failover acquire: same/newer epoch -> WRITE, otherwise REJECT.
+        // - normal acquire: same-epoch failover -> REJECT, same/newer epoch -> WRITE, otherwise REJECT.
+        if (failover) {
+            if (current.epoch() <= epoch) {
+                return AcquireDecision.allow();
+            }
+            return AcquireDecision.reject(String.format(
+                "Failover acquire rejected, nodeId=%s, currentEpoch=%s, requestEpoch=%s, currentFailover=%s",
+                nodeId, current.epoch(), epoch, current.failover()));
+        }
+
+        if (current.epoch() == epoch) {
+            if (current.failover()) {
+                return AcquireDecision.reject(String.format(
+                    "Normal acquire rejected, nodeId=%s, currentEpoch=%s, requestEpoch=%s, currentFailover=%s",
+                    nodeId, current.epoch(), epoch, current.failover()));
+            }
+            return AcquireDecision.allow();
+        }
+        if (current.epoch() < epoch) {
+            return AcquireDecision.allow();
+        }
+        return AcquireDecision.reject(String.format(
+            "Normal acquire rejected, nodeId=%s, currentEpoch=%s, requestEpoch=%s, currentFailover=%s",
+            nodeId, current.epoch(), epoch, current.failover()));
+    }
+
+    private CompletableFuture<Void> writeReservation(ObjectStorage.WriteOptions options, String path,
+        long nodeId, long epoch, boolean failover) {
+        // Use plain write for object-storage compatibility. This is not storage-level CAS;
+        // ownership still depends on the caller verifying the final reservation content.
+        return objectStorage.write(options.copy(), path, reservationBody(nodeId, epoch, failover)).thenApply(rst -> null);
+    }
+
+    private ReservationRecord parseReservation(long nodeId, ByteBuf bytes) {
+        if (bytes.readableBytes() != S3_RESERVATION_OBJECT_LENGTH) {
+            throw new IllegalStateException(String.format("Invalid reservation length, nodeId=%s, length=%s",
+                nodeId, bytes.readableBytes()));
+        }
+        ByteBuf slice = bytes.slice();
+        int magic = slice.readInt();
+        if (magic != S3_RESERVATION_OBJECT_MAGIC_CODE) {
+            throw new IllegalStateException(String.format("Invalid reservation magic code, nodeId=%s, magic=%s",
+                nodeId, magic));
+        }
+        return new ReservationRecord(slice.readLong(), slice.readLong(), slice.readBoolean());
+    }
+
+    private ByteBuf reservationBody(long nodeId, long epoch, boolean failover) {
         ByteBuf target = ByteBufAlloc.byteBuffer(S3_RESERVATION_OBJECT_LENGTH);
         target.writeInt(S3_RESERVATION_OBJECT_MAGIC_CODE);
         target.writeLong(nodeId);
         target.writeLong(epoch);
         target.writeBoolean(failover);
-        ObjectStorage.WriteOptions options = new ObjectStorage.WriteOptions().throttleStrategy(ThrottleStrategy.BYPASS);
-        return objectStorage.write(options, path(nodeId), target).thenApply(rst -> null);
+        return target;
+    }
+
+    private record ReservationRecord(long nodeId, long epoch, boolean failover) {
+    }
+
+    private record AcquireDecision(boolean allowed, String rejectReason) {
+        private static AcquireDecision allow() {
+            return new AcquireDecision(true, null);
+        }
+
+        private static AcquireDecision reject(String rejectReason) {
+            return new AcquireDecision(false, rejectReason);
+        }
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectReservationServiceTest.java
@@ -25,10 +25,14 @@ import com.automq.stream.s3.operator.ObjectStorage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObjectReservationServiceTest {
@@ -57,7 +61,7 @@ class ObjectReservationServiceTest {
     }
 
     @Test
-    void acquire() {
+    void writeBody() {
         ByteBuf target = Unpooled.buffer(Long.BYTES * 10);
         target.writeLong(Long.MAX_VALUE);
         target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
@@ -69,29 +73,103 @@ class ObjectReservationServiceTest {
         target.writerIndex(Long.BYTES + ObjectReservationService.S3_RESERVATION_OBJECT_LENGTH);
         reservationService.acquire(1, 2, false).join();
         assertTrue(reservationService.verify(1, target).join());
+    }
 
-        target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(false);
-        reservationService.acquire(1, 2, true).join();
-        assertFalse(reservationService.verify(1, target).join());
-
-        target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(true);
-        reservationService.acquire(1, 2, true).join();
-        assertTrue(reservationService.verify(1, target).join());
-
-        target = Unpooled.buffer(Long.BYTES * 10);
-        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
-        target.writeLong(1);
-        target.writeLong(2);
-        target.writeBoolean(true);
+    @Test
+    void failoverTakesNormal() {
+        ByteBuf normal = reservationRecord(1, 2, false);
         reservationService.acquire(1, 2, false).join();
-        assertFalse(reservationService.verify(1, target).join());
+        reservationService.acquire(1, 2, true).join();
+
+        assertFalse(reservationService.verify(1, normal).join());
+        assertTrue(reservationService.verify(1, 2, true).join());
+    }
+
+    @Test
+    void failoverTakesOlderReservation() {
+        reservationService.acquire(1, 2, false).join();
+
+        reservationService.acquire(1, 3, true).join();
+
+        assertTrue(reservationService.verify(1, 3, true).join());
+    }
+
+    @Test
+    void normalRejectsFailover() {
+        reservationService.acquire(1, 2, false).join();
+        reservationService.acquire(1, 2, true).join();
+        assertAcquireRejected(1, 2, false, "Normal acquire rejected");
+
+        assertTrue(reservationService.verify(1, 2, true).join());
+    }
+
+    @Test
+    void stateMachine() {
+        reservationService.acquire(1, 2, false).join();
+        assertTrue(reservationService.verify(1, 2, false).join());
+
+        reservationService.acquire(1, 2, false).join();
+        assertTrue(reservationService.verify(1, 2, false).join());
+
+        reservationService.acquire(1, 2, true).join();
+        assertTrue(reservationService.verify(1, 2, true).join());
+
+        assertAcquireRejected(1, 2, false, "Normal acquire rejected");
+        assertTrue(reservationService.verify(1, 2, true).join());
+
+        reservationService.acquire(1, 3, false).join();
+        assertTrue(reservationService.verify(1, 3, false).join());
+    }
+
+    @Test
+    void failoverCannotCreateMissingReservation() {
+        assertAcquireRejected(2, 1, true, "Failover acquire cannot create missing reservation");
+        assertFalse(reservationService.verify(2, 1, true).join());
+    }
+
+    @Test
+    void overwriteInvalid() {
+        ObjectStorage.WriteOptions options = new ObjectStorage.WriteOptions();
+        objectStorage.write(options, reservationPath(3), invalidReservationRecord(3, 1, false)).join();
+
+        reservationService.acquire(3, 1, false).join();
+
+        assertTrue(reservationService.verify(3, 1, false).join());
+    }
+
+    @Test
+    void overwriteMismatchedNode() {
+        ObjectStorage.WriteOptions options = new ObjectStorage.WriteOptions();
+        objectStorage.write(options, reservationPath(4), reservationRecord(5, 1, false)).join();
+
+        reservationService.acquire(4, 1, false).join();
+
+        assertTrue(reservationService.verify(4, 1, false).join());
+    }
+
+    private void assertAcquireRejected(long nodeId, long epoch, boolean failover, String messagePart) {
+        CompletionException ex = assertThrows(CompletionException.class,
+            () -> reservationService.acquire(nodeId, epoch, failover).join());
+        assertInstanceOf(IllegalStateException.class, ex.getCause());
+        assertTrue(ex.getCause().getMessage().contains(messagePart));
+    }
+
+    private ByteBuf reservationRecord(long nodeId, long epoch, boolean failover) {
+        ByteBuf target = Unpooled.buffer(ObjectReservationService.S3_RESERVATION_OBJECT_LENGTH);
+        target.writeInt(ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE);
+        target.writeLong(nodeId);
+        target.writeLong(epoch);
+        target.writeBoolean(failover);
+        return target;
+    }
+
+    private ByteBuf invalidReservationRecord(long nodeId, long epoch, boolean failover) {
+        ByteBuf target = reservationRecord(nodeId, epoch, failover);
+        target.setInt(0, ObjectReservationService.S3_RESERVATION_OBJECT_MAGIC_CODE + 1);
+        return target;
+    }
+
+    private String reservationPath(long nodeId) {
+        return "reservation/_kafka_cluster/" + nodeId;
     }
 }


### PR DESCRIPTION
## Summary

This patch changes object WAL reservation acquire from blind write to read-then-write validation.

Before writing the reservation object, `ObjectReservationService` now reads the existing reservation and applies the reservation state machine:

- normal acquire can create a missing reservation
- failover acquire cannot create a missing reservation
- repeated acquire with the same normal reservation is idempotent
- failover can acquire the same epoch only from an existing normal reservation
- normal acquire cannot overwrite a same-epoch failover reservation
- higher epoch normal acquire can replace an older reservation

The write path still uses the existing object storage `write` API. This change does not introduce conditional write, ETag metadata, or object storage API changes.

## Motivation

The previous implementation wrote the reservation object directly during acquire. That allowed a restarted node to blindly overwrite a failover reservation with the same epoch, which could break the intended ownership protection during failover/recover races.

By reading and validating the current reservation before writing, acquire preserves the reservation state machine without requiring backend conditional-write support.

## Compatibility and Correctness

This patch intentionally keeps acquire on the plain write path for object-storage compatibility. Some S3-compatible backends either do not support `If-Match` / `If-None-Match` on `PutObject`, or their behavior is not documented consistently enough to rely on it in the common object storage layer.

A concurrent change after the read may still overwrite this write, because this patch does not provide storage-level CAS. This does not make the caller observe a valid reservation unless the final object content still matches the requested node/epoch/failover state. The acquire state machine prevents known invalid transitions, and the existing verification path remains responsible for checking the final reservation content.

## Changes

- Add read-before-write validation in `ObjectReservationService.acquire`
- Parse and validate existing reservation object content before deciding whether to write
- Reject invalid acquire transitions instead of blindly overwriting
- Keep object storage writes on the existing `write` path
- Add unit coverage for acquire state transitions

## Tests

```bash
./gradlew :s3stream:test --tests com.automq.stream.s3.wal.impl.object.ObjectReservationServiceTest
```