### PR TITLE
fix(shell): preserve '=' in S3Url credentials when parsing

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/model/S3Url.java
+++ b/automq-shell/src/main/java/com/automq/shell/model/S3Url.java
@@ -86,7 +86,9 @@ public class S3Url {
         boolean s3PathStyle = false;
 
         for (String param : params) {
-            String[] keyValue = param.split("=");
+            // Only split on the first '=' so that values containing '=' (e.g. base64-encoded
+            // access/secret keys, which may include '=' padding) are preserved.
+            String[] keyValue = param.split("=", 2);
             if (keyValue.length != 2) {
                 throw new IllegalArgumentException("Invalid parameter format: " + param);
             }

--- a/tools/src/test/java/org/apache/kafka/tools/automq/model/S3UrlTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/automq/model/S3UrlTest.java
@@ -43,6 +43,19 @@ class S3UrlTest {
     }
 
     @Test
+    void parseWithEqualsSignInCredentials() {
+        // base64-encoded secret keys frequently contain '=' (padding) and '/' characters.
+        // The value must be preserved verbatim instead of being split on every '='.
+        String secretKey = "abc/def+ghi==";
+        String s3Url = "s3://s3.us-east-1.amazonaws.com?s3-access-key=AKIA=EXAMPLE&s3-secret-key=" + secretKey
+            + "&s3-region=us-east-1&s3-endpoint-protocol=https&s3-data-bucket=data&s3-ops-bucket=ops&cluster-id=abc";
+        S3Url s3UrlObj = S3Url.parse(s3Url);
+        assertEquals("AKIA=EXAMPLE", s3UrlObj.getS3AccessKey());
+        assertEquals(secretKey, s3UrlObj.getS3SecretKey());
+        assertEquals("us-east-1", s3UrlObj.getS3Region());
+    }
+
+    @Test
     void parseS3UrlValFromArgs() {
         String s3Url = "s3://s3.cn-northwest-1.amazonaws.com.cn?s3-access-key=xxx&s3-secret-key=yyy&s3-region=cn-northwest-1&s3-endpoint-protocol=https&s3-data-bucket=wanshao-test&s3-ops-bucket=automq-ops-bucket&cluster-id=fZGPJht6Rf-o7WgrUakLxQ";
         String[] args = Arrays.asList("--s3-url=" + s3Url, "--controller-list=\"192.168.123.234:9093\"").toArray(new String[0]);


### PR DESCRIPTION
S3Url.parse split each query parameter on every '=' via split("="), so access/secret keys that contain '=' (common in base64-encoded credentials, including '=' padding) were either rejected with "Invalid parameter format" or silently truncated. Split on the first '=' only via split("=", 2) to preserve the full value.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
