### PR TITLE
fix: precompute s3 write checksums (#3416)

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -30,10 +30,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,6 +59,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.SdkChecksum;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -72,6 +78,7 @@ import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CopyPartResult;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.Delete;
@@ -88,6 +95,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 import static com.automq.stream.s3.metadata.ObjectUtils.tagging;
 import static com.automq.stream.s3.metrics.operations.S3Operation.COMPLETE_MULTI_PART_UPLOAD;
@@ -145,12 +153,17 @@ public class AwsObjectStorage extends AbstractObjectStorage {
 
     // used for test only
     public AwsObjectStorage(S3AsyncClient s3Client, String bucket) {
+        this(s3Client, bucket, ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION);
+    }
+
+    // used for test only
+    AwsObjectStorage(S3AsyncClient s3Client, String bucket, ChecksumAlgorithm checksumAlgorithm) {
         super(BucketURI.parse("0@s3://b"), NetworkBandwidthLimiter.NOOP, NetworkBandwidthLimiter.NOOP, 50, 0, true, false, false, "test");
         this.bucket = bucket;
         this.writeS3Client = s3Client;
         this.readS3Client = s3Client;
         this.tagging = null;
-        this.checksumAlgorithm = ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION;
+        this.checksumAlgorithm = checksumAlgorithm;
     }
 
     public static Builder builder() {
@@ -242,13 +255,18 @@ public class AwsObjectStorage extends AbstractObjectStorage {
 
     @Override
     CompletableFuture<Void> doWrite(WriteOptions options, String path, ByteBuf data) {
+        // Compute checksum before handing unsafe ByteBuffers to the SDK. A timed-out attempt may still be writing
+        // after a later retry completes and the caller releases/reuses the ByteBuf; the stale attempt would then read
+        // dirty bytes. A fixed request checksum makes the service reject that corrupted body instead of persisting it.
         PutObjectRequest.Builder builder = PutObjectRequest.builder().bucket(bucket).key(path);
         if (null != tagging) {
             builder.tagging(tagging);
         }
 
-        if (checksumAlgorithm != ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION) {
-            builder.checksumAlgorithm(checksumAlgorithm);
+        if (hasFlexibleChecksumAlgorithm()) {
+            putChecksum(builder, data);
+        } else {
+            builder.contentMD5(contentMd5(data));
         }
 
         PutObjectRequest request = builder.build();
@@ -263,7 +281,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
             builder.tagging(tagging);
         }
 
-        if (checksumAlgorithm != ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION) {
+        if (hasFlexibleChecksumAlgorithm()) {
             builder.checksumAlgorithm(checksumAlgorithm);
         }
 
@@ -274,38 +292,22 @@ public class AwsObjectStorage extends AbstractObjectStorage {
     @Override
     CompletableFuture<ObjectStorageCompletedPart> doUploadPart(WriteOptions options, String path, String uploadId,
         int partNumber, ByteBuf part) {
-        AsyncRequestBody body = AsyncRequestBody.fromByteBuffersUnsafe(part.nioBuffers());
+        // Same dirty-retry protection as doWrite.
         UploadPartRequest.Builder builder = UploadPartRequest.builder()
             .bucket(bucket)
             .key(path)
             .uploadId(uploadId)
             .partNumber(partNumber);
 
-        if (checksumAlgorithm != ChecksumAlgorithm.UNKNOWN_TO_SDK_VERSION) {
-            builder.checksumAlgorithm(checksumAlgorithm);
+        if (hasFlexibleChecksumAlgorithm()) {
+            putChecksum(builder, part);
+        } else {
+            builder.contentMD5(contentMd5(part));
         }
 
+        AsyncRequestBody body = AsyncRequestBody.fromByteBuffersUnsafe(part.nioBuffers());
         return writeS3Client.uploadPart(builder.build(), body)
-            .thenApply(resp -> {
-                String checksum;
-                switch (checksumAlgorithm) {
-                    case CRC32_C:
-                        checksum = resp.checksumCRC32C();
-                        break;
-                    case CRC32:
-                        checksum = resp.checksumCRC32();
-                        break;
-                    case SHA1:
-                        checksum = resp.checksumSHA1();
-                        break;
-                    case SHA256:
-                        checksum = resp.checksumSHA256();
-                        break;
-                    default:
-                        checksum = null;
-                }
-                return new ObjectStorageCompletedPart(partNumber, resp.eTag(), checksum);
-            });
+            .thenApply(resp -> new ObjectStorageCompletedPart(partNumber, resp.eTag(), checksumValue(resp)));
     }
 
     @Override
@@ -319,14 +321,15 @@ public class AwsObjectStorage extends AbstractObjectStorage {
                     .apiCallTimeout(Duration.ofMillis(options.apiCallAttemptTimeout())).build()
             )
             .build();
-        return writeS3Client.uploadPartCopy(request).thenApply(resp -> new ObjectStorageCompletedPart(partNumber, resp.copyPartResult().eTag(), resp.copyPartResult().checksumCRC32C()));
+        return writeS3Client.uploadPartCopy(request)
+            .thenApply(resp -> new ObjectStorageCompletedPart(partNumber, resp.copyPartResult().eTag(), checksumValue(resp.copyPartResult())));
     }
 
     @Override
     public CompletableFuture<Void> doCompleteMultipartUpload(WriteOptions options, String path, String uploadId,
         List<ObjectStorageCompletedPart> parts) {
         List<CompletedPart> completedParts = parts.stream()
-            .map(part -> CompletedPart.builder().partNumber(part.getPartNumber()).eTag(part.getPartId()).checksumCRC32C(part.getCheckSum()).build())
+            .map(this::completedPart)
             .collect(Collectors.toList());
         CompletedMultipartUpload multipartUpload = CompletedMultipartUpload.builder().parts(completedParts).build();
         CompleteMultipartUploadRequest request = CompleteMultipartUploadRequest.builder().bucket(bucket).key(path).uploadId(uploadId).multipartUpload(multipartUpload).build();
@@ -501,7 +504,7 @@ public class AwsObjectStorage extends AbstractObjectStorage {
             .maxConcurrency(maxConcurrency)
             .build();
         builder.httpClient(httpClient);
-        builder.serviceConfiguration(c -> c.pathStyleAccessEnabled(forcePathStyle));
+        builder.serviceConfiguration(c -> c.pathStyleAccessEnabled(forcePathStyle).checksumValidationEnabled(false));
         builder.credentialsProvider(newCredentialsProviderChain(credentialsProviders));
         builder.overrideConfiguration(clientOverrideConfiguration(apiCallTimeoutMs, apiCallAttemptTimeoutMs));
         return builder.build();
@@ -523,6 +526,144 @@ public class AwsObjectStorage extends AbstractObjectStorage {
             .reuseLastProviderEnabled(true)
             .credentialsProviders(providers)
             .build();
+    }
+
+    private CompletedPart completedPart(ObjectStorageCompletedPart part) {
+        CompletedPart.Builder builder = CompletedPart.builder()
+            .partNumber(part.getPartNumber())
+            .eTag(part.getPartId());
+        if (part.getCheckSum() == null) {
+            return builder.build();
+        }
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                return builder.checksumCRC32C(part.getCheckSum()).build();
+            case CRC32:
+                return builder.checksumCRC32(part.getCheckSum()).build();
+            case SHA1:
+                return builder.checksumSHA1(part.getCheckSum()).build();
+            case SHA256:
+                return builder.checksumSHA256(part.getCheckSum()).build();
+            default:
+                return builder.build();
+        }
+    }
+
+    private boolean hasFlexibleChecksumAlgorithm() {
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+            case CRC32:
+            case SHA1:
+            case SHA256:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void putChecksum(PutObjectRequest.Builder builder, ByteBuf buf) {
+        String checksum = checksum(buf);
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                builder.checksumCRC32C(checksum);
+                break;
+            case CRC32:
+                builder.checksumCRC32(checksum);
+                break;
+            case SHA1:
+                builder.checksumSHA1(checksum);
+                break;
+            case SHA256:
+                builder.checksumSHA256(checksum);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported checksum algorithm: " + checksumAlgorithm);
+        }
+    }
+
+    private void putChecksum(UploadPartRequest.Builder builder, ByteBuf buf) {
+        String checksum = checksum(buf);
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                builder.checksumCRC32C(checksum);
+                break;
+            case CRC32:
+                builder.checksumCRC32(checksum);
+                break;
+            case SHA1:
+                builder.checksumSHA1(checksum);
+                break;
+            case SHA256:
+                builder.checksumSHA256(checksum);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported checksum algorithm: " + checksumAlgorithm);
+        }
+    }
+
+    private String checksum(ByteBuf buf) {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(defaultChecksumAlgorithm());
+        for (ByteBuffer buffer : buf.nioBuffers()) {
+            checksum.update(buffer.duplicate());
+        }
+        return Base64.getEncoder().encodeToString(checksum.getChecksumBytes());
+    }
+
+    private software.amazon.awssdk.checksums.spi.ChecksumAlgorithm defaultChecksumAlgorithm() {
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                return DefaultChecksumAlgorithm.CRC32C;
+            case CRC32:
+                return DefaultChecksumAlgorithm.CRC32;
+            case SHA1:
+                return DefaultChecksumAlgorithm.SHA1;
+            case SHA256:
+                return DefaultChecksumAlgorithm.SHA256;
+            default:
+                throw new IllegalArgumentException("Unsupported checksum algorithm: " + checksumAlgorithm);
+        }
+    }
+
+    private String checksumValue(UploadPartResponse response) {
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                return response.checksumCRC32C();
+            case CRC32:
+                return response.checksumCRC32();
+            case SHA1:
+                return response.checksumSHA1();
+            case SHA256:
+                return response.checksumSHA256();
+            default:
+                return null;
+        }
+    }
+
+    private String checksumValue(CopyPartResult response) {
+        switch (checksumAlgorithm) {
+            case CRC32_C:
+                return response.checksumCRC32C();
+            case CRC32:
+                return response.checksumCRC32();
+            case SHA1:
+                return response.checksumSHA1();
+            case SHA256:
+                return response.checksumSHA256();
+            default:
+                return null;
+        }
+    }
+
+    static String contentMd5(ByteBuf buf) {
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            for (ByteBuffer buffer : buf.nioBuffers()) {
+                md5.update(buffer.duplicate());
+            }
+            return Base64.getEncoder().encodeToString(md5.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 algorithm is not available", e);
+        }
     }
 
     public boolean readinessCheck() {

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
@@ -1,23 +1,84 @@
 package com.automq.stream.s3.operator;
 
+import com.automq.stream.s3.TestUtils;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.CRC32C;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Error;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AwsObjectStorageTest {
+
+    @Test
+    void testDoWriteSetsContentMd5() throws Exception {
+        S3AsyncClient s3 = mock(S3AsyncClient.class);
+        AwsObjectStorage storage = new AwsObjectStorage(s3, "bucket");
+        ByteBuf data = TestUtils.random(128);
+        List<PutObjectRequest> requests = new java.util.ArrayList<>();
+
+        when(s3.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenAnswer(invocation -> {
+            requests.add(invocation.getArgument(0));
+            return CompletableFuture.completedFuture(null);
+        });
+
+        try {
+            storage.doWrite(ObjectStorage.WriteOptions.DEFAULT, "test-key", data).get();
+
+            Assertions.assertEquals(1, requests.size());
+            Assertions.assertEquals(md5Base64(data), requests.get(0).contentMD5());
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
+    void testDoWriteSetsPrecomputedChecksumWhenChecksumAlgorithmIsConfigured() throws Exception {
+        S3AsyncClient s3 = mock(S3AsyncClient.class);
+        AwsObjectStorage storage = new AwsObjectStorage(s3, "bucket", ChecksumAlgorithm.CRC32_C);
+        ByteBuf data = Unpooled.wrappedBuffer("hello checksum".getBytes(StandardCharsets.UTF_8));
+        List<PutObjectRequest> requests = new java.util.ArrayList<>();
+
+        when(s3.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenAnswer(invocation -> {
+            requests.add(invocation.getArgument(0));
+            return CompletableFuture.completedFuture(null);
+        });
+
+        try {
+            storage.doWrite(ObjectStorage.WriteOptions.DEFAULT, "test-key", data).get();
+
+            Assertions.assertEquals(1, requests.size());
+            Assertions.assertNull(requests.get(0).contentMD5());
+            Assertions.assertNull(requests.get(0).checksumAlgorithm());
+            Assertions.assertEquals(crc32cBase64(data), requests.get(0).checksumCRC32C());
+        } finally {
+            data.release();
+        }
+    }
 
     @Test
     void testCredentialsProviderChain() {
@@ -64,4 +125,23 @@ public class AwsObjectStorageTest {
         Assertions.assertTrue(ex.getRetriableKeys().containsKey("retry"));
         Assertions.assertTrue(ex.getFailedKeyErrors().containsKey("fail"));
     }
+
+    private static String md5Base64(ByteBuf data) throws Exception {
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        for (ByteBuffer buffer : data.nioBuffers()) {
+            md5.update(buffer.duplicate());
+        }
+        return Base64.getEncoder().encodeToString(md5.digest());
+    }
+
+    private static String crc32cBase64(ByteBuf data) {
+        CRC32C crc32c = new CRC32C();
+        for (ByteBuffer buffer : data.nioBuffers()) {
+            crc32c.update(buffer.duplicate());
+        }
+        ByteBuffer value = ByteBuffer.allocate(Integer.BYTES);
+        value.putInt((int) crc32c.getValue());
+        return Base64.getEncoder().encodeToString(value.array());
+    }
+
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
@@ -29,7 +29,11 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -42,6 +46,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.ResponsePublisher;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CopyPartResult;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
@@ -54,6 +59,7 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -122,6 +128,41 @@ class MultiPartWriterTest {
             .map(UploadPartRequest::partNumber)
             .collect(Collectors.toList()));
         assertEquals(List.of(120L, 120L, 280L, 10L), contentLengths);
+        assertEquals(md5Base64(payloads.get(0)), requests.get(0).contentMD5());
+    }
+
+    @Test
+    void testWriteWithChecksumAlgorithm() throws Exception {
+        operator = new AwsObjectStorage(s3, "unit-test-bucket", ChecksumAlgorithm.SHA256);
+        writer = new MultiPartWriter(ObjectStorage.WriteOptions.DEFAULT, operator, "test-path-checksum", 100, 100);
+
+        List<UploadPartRequest> requests = new ArrayList<>();
+        List<CompleteMultipartUploadRequest> completeRequests = new ArrayList<>();
+
+        UploadPartResponse response = UploadPartResponse.builder()
+            .eTag("unit-test-etag")
+            .checksumSHA256("part-checksum")
+            .build();
+        when(s3.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class))).thenAnswer(invocation -> {
+            requests.add(invocation.getArgument(0));
+            return CompletableFuture.completedFuture(response);
+        });
+        when(s3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class))).thenAnswer(invocation -> {
+            completeRequests.add(invocation.getArgument(0));
+            return CompletableFuture.completedFuture(null);
+        });
+        writer.uploadIdCf.get();
+
+        ByteBuf payload = TestUtils.random(120);
+        writer.write(payload);
+        writer.close().get();
+
+        assertEquals(1, requests.size());
+        assertNull(requests.get(0).contentMD5());
+        assertNull(requests.get(0).checksumAlgorithm());
+        assertEquals(sha256Base64(payload), requests.get(0).checksumSHA256());
+        assertEquals(1, completeRequests.size());
+        assertEquals("part-checksum", completeRequests.get(0).multipartUpload().parts().get(0).checksumSHA256());
     }
 
     @Test
@@ -235,6 +276,26 @@ class MultiPartWriterTest {
         assertEquals(List.of("bytes=0-119"), uploadPartCopyRequests.stream()
             .map(UploadPartCopyRequest::copySourceRange)
             .collect(Collectors.toList()));
+    }
+
+    private static String md5Base64(ByteBuf data) {
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            for (ByteBuffer buffer : data.nioBuffers()) {
+                md5.update(buffer.duplicate());
+            }
+            return Base64.getEncoder().encodeToString(md5.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String sha256Base64(ByteBuf data) throws Exception {
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+        for (ByteBuffer buffer : data.nioBuffers()) {
+            sha256.update(buffer.duplicate());
+        }
+        return Base64.getEncoder().encodeToString(sha256.digest());
     }
 
 }


### PR DESCRIPTION
## Summary

This PR hardens S3 object writes against dirty buffer reads during SDK-level retries.

## Bug Flow

AutoMQ writes S3 request bodies with
`AsyncRequestBody.fromByteBuffersUnsafe(...)` to avoid copying Netty `ByteBuf` data.

A rare corruption flow can happen when an SDK attempt times out but the underlying HTTP write is still alive:

1. AutoMQ submits a PutObject or UploadPart request backed by unsafe `ByteBuffer` views of a Netty `ByteBuf`.
2. The SDK attempt times out and starts a retry, while the first low-level request may still continue writing from the original buffers.
3. A later retry succeeds and completes the future.
4. The caller releases the `ByteBuf`; Netty may recycle the memory for another buffer.
5. The stale first request can still read from the recycled memory and send dirty bytes.
6. Without a stable precomputed checksum attached to the request, object storage may accept and persist the corrupted body.

## How This PR Fixes It

The fix is to bind each write request to the bytes that were present before the unsafe buffers are passed to the SDK.

For PutObject and UploadPart, AutoMQ now computes the request checksum synchronously while it still owns a valid `ByteBuf`. That checksum becomes the immutable expected value for the request body:

- If the SDK later retries normally using the same original bytes, the object storage service receives bytes matching the precomputed checksum and accepts the write.
- If an earlier timed-out HTTP attempt keeps running after the successful retry and reads from recycled Netty memory, it sends bytes that no longer match the precomputed checksum. The service should reject that stale request instead of persisting corrupted data.

This is why the checksum must be computed before
`AsyncRequestBody.fromByteBuffersUnsafe(...)` is handed to the SDK. Letting the SDK calculate a checksum from the unsafe body during the actual HTTP attempt would not fully protect this flow, because the checksum calculation could observe the same dirty/recycled memory as the stale request.

The implementation uses the strongest available request-side checksum for the configured mode:

- When a supported S3 flexible checksum algorithm is configured, AutoMQ precomputes and sets the concrete checksum header (`checksumCRC32`, `checksumCRC32C`, `checksumSHA1`, or `checksumSHA256`) on PutObject and UploadPart.
- When no flexible checksum algorithm is configured, AutoMQ precomputes and sets `Content-MD5`.
- For multipart uploads, CreateMultipartUpload still carries `checksumAlgorithm` to define the upload's checksum algorithm, and CompleteMultipartUpload sends the returned per-part checksum in the matching part checksum field instead of assuming CRC32C.
- The SDK's legacy S3 ETag MD5 validation path is disabled to avoid a second client-side MD5 pass after AutoMQ already attaches its own request checksum.