### PR TITLE
fix(s3stream): abort upload part on NoSuchUploadException to prevent broker crash

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AwsObjectStorage.java
@@ -415,9 +415,13 @@ public class AwsObjectStorage extends AbstractObjectStorage {
                 default:
                     strategy = RetryStrategy.RETRY;
             }
-            if (COMPLETE_MULTI_PART_UPLOAD == operation) {
-                if (cause instanceof NoSuchUploadException) {
+            if (cause instanceof NoSuchUploadException) {
+                if (COMPLETE_MULTI_PART_UPLOAD == operation) {
                     strategy = RetryStrategy.VISIBILITY_CHECK;
+                } else if (S3Operation.UPLOAD_PART == operation || S3Operation.UPLOAD_PART_COPY == operation) {
+                    // The multipart upload no longer exists (expired, aborted, or cleaned by the backend).
+                    // Retrying with a dead upload ID is futile and would loop until the broker crashes.
+                    strategy = RetryStrategy.ABORT;
                 }
             }
             if (GET_OBJECT == operation) {

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java
@@ -1,7 +1,9 @@
 package com.automq.stream.s3.operator;
 
 import com.automq.stream.s3.TestUtils;
+import com.automq.stream.s3.metrics.operations.S3Operation;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Error;
 
@@ -142,6 +145,62 @@ public class AwsObjectStorageTest {
         ByteBuffer value = ByteBuffer.allocate(Integer.BYTES);
         value.putInt((int) crc32c.getValue());
         return Base64.getEncoder().encodeToString(value.array());
+    }
+
+
+    /**
+     * Given a NoSuchUploadException during UPLOAD_PART,
+     * When toRetryStrategyAndCause is called,
+     * Then the strategy should be ABORT because retrying with a dead upload ID is futile.
+     */
+    @Test
+    void testNoSuchUploadExceptionAbortsUploadPart() {
+        AwsObjectStorage storage = new AwsObjectStorage(null, "bucket");
+        NoSuchUploadException cause = NoSuchUploadException.builder()
+            .message("The specified upload does not exist")
+            .statusCode(404)
+            .build();
+
+        Pair<RetryStrategy, Throwable> result = storage.toRetryStrategyAndCause(cause, S3Operation.UPLOAD_PART);
+        Assertions.assertEquals(RetryStrategy.ABORT, result.getLeft(),
+            "UPLOAD_PART with NoSuchUploadException should ABORT, not retry indefinitely");
+    }
+
+    /**
+     * Given a NoSuchUploadException during UPLOAD_PART_COPY,
+     * When toRetryStrategyAndCause is called,
+     * Then the strategy should be ABORT for the same reason as UPLOAD_PART.
+     */
+    @Test
+    void testNoSuchUploadExceptionAbortsUploadPartCopy() {
+        AwsObjectStorage storage = new AwsObjectStorage(null, "bucket");
+        NoSuchUploadException cause = NoSuchUploadException.builder()
+            .message("The specified upload does not exist")
+            .statusCode(404)
+            .build();
+
+        Pair<RetryStrategy, Throwable> result = storage.toRetryStrategyAndCause(cause, S3Operation.UPLOAD_PART_COPY);
+        Assertions.assertEquals(RetryStrategy.ABORT, result.getLeft(),
+            "UPLOAD_PART_COPY with NoSuchUploadException should ABORT, not retry indefinitely");
+    }
+
+    /**
+     * Given a NoSuchUploadException during COMPLETE_MULTI_PART_UPLOAD,
+     * When toRetryStrategyAndCause is called,
+     * Then the strategy should be VISIBILITY_CHECK because the upload may have already completed
+     * and the object may just not be visible yet.
+     */
+    @Test
+    void testNoSuchUploadExceptionVisibilityCheckForComplete() {
+        AwsObjectStorage storage = new AwsObjectStorage(null, "bucket");
+        NoSuchUploadException cause = NoSuchUploadException.builder()
+            .message("The specified upload does not exist")
+            .statusCode(404)
+            .build();
+
+        Pair<RetryStrategy, Throwable> result = storage.toRetryStrategyAndCause(cause, S3Operation.COMPLETE_MULTI_PART_UPLOAD);
+        Assertions.assertEquals(RetryStrategy.VISIBILITY_CHECK, result.getLeft(),
+            "COMPLETE_MULTI_PART_UPLOAD with NoSuchUploadException should VISIBILITY_CHECK");
     }
 
 }


### PR DESCRIPTION
### Description
When using AutoMQ with S3-compatible storage backends, a `NoSuchUploadException` can occur during an `UploadPart` or `UploadPartCopy` operation (e.g., if the multipart upload has expired, been aborted, or cleaned up by the backend).

Previously, `AwsObjectStorage.toRetryStrategyAndCause` only handled `NoSuchUploadException` for `COMPLETE_MULTI_PART_UPLOAD` (mapping it to `RetryStrategy.VISIBILITY_CHECK`). For `UPLOAD_PART` and `UPLOAD_PART_COPY` operations, the exception fell through to the default `RetryStrategy.RETRY`. This caused an infinite retry loop, ultimately leading to a broker crash.

This PR addresses the issue by mapping `NoSuchUploadException` to `RetryStrategy.ABORT` for both `UPLOAD_PART` and `UPLOAD_PART_COPY` operations. Since the multipart upload ID is no longer valid, aborting early prevents the crash loop.

Fixes #3206

### Testing Strategy
- Added new unit tests in [AwsObjectStorageTest](file:///Users/divyanshuyadav/Downloads/automq/s3stream/src/test/java/com/automq/stream/s3/operator/AwsObjectStorageTest.java) to verify retry strategy mapping:
- `testNoSuchUploadExceptionAbortsUploadPart` verifies `UPLOAD_PART` maps to `RetryStrategy.ABORT`.
- `testNoSuchUploadExceptionAbortsUploadPartCopy` verifies `UPLOAD_PART_COPY` maps to `RetryStrategy.ABORT`.
- `testNoSuchUploadExceptionVisibilityCheckForComplete` verifies `COMPLETE_MULTI_PART_UPLOAD` still maps to
`RetryStrategy.VISIBILITY_CHECK`.
- Ran the unit tests locally: ```bash ./gradlew :s3stream:test --tests
"com.automq.stream.s3.operator.AwsObjectStorageTest"