### PR TITLE
fix(s3stream): limit cleanup v1 compaction scope

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3StreamClient.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3StreamClient.java
@@ -74,10 +74,11 @@ public class S3StreamClient implements StreamClient {
     private static final long MAJOR_V1_COMPACTION_INTERVAL = Systems.getEnvLong("AUTOMQ_STREAM_COMPACTION_MAJOR_V1_INTERVAL", TimeUnit.MINUTES.toMillis(60));
     private static final long MINOR_V1_COMPACTION_SIZE = Systems.getEnvLong("AUTOMQ_STREAM_COMPACTION_MINOR_V1_COMPACTION_SIZE_THRESHOLD", MINOR_V1_COMPACTION_SIZE_THRESHOLD);
     /**
-     * When the cluster objects count exceed MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD, the MAJOR_V1 compaction will be triggered.
+     * When the cluster objects count approaches MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD, the MAJOR_V1 compaction will be triggered.
      * Default value is 400000: 10w partitions ~= 30w streams ~= 40w object
      */
     private static final int MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD = Systems.getEnvInt("AUTOMQ_STREAM_COMPACTION_MAJOR_V1_MAX_OBJECT_THRESHOLD", 400000);
+    static final double MAJOR_V1_COMPACTION_OBJECT_COUNT_SOFT_THRESHOLD_RATIO = 0.9;
     private static final int STREAM_OBJECT_COMPACTION_JITTER_MAX_DELAY = Systems.getEnvInt("AUTOMQ_STREAM_OBJECT_COMPACTION_JITTER_MAX_DELAY", 20);
     private final ScheduledExecutorService streamObjectCompactionScheduler = Threads.newSingleThreadScheduledExecutor(
         ThreadUtils.createThreadFactory("stream-object-compaction-scheduler", true), LOGGER, true);
@@ -428,7 +429,8 @@ public class S3StreamClient implements StreamClient {
         }
 
         private void compactV1(CompactionHint hint, long now) {
-            if (now - lastMajorV1CompactionTimestamp > MAJOR_V1_COMPACTION_INTERVAL || hint.objectsCount >= MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD) {
+            if (now - lastMajorV1CompactionTimestamp > MAJOR_V1_COMPACTION_INTERVAL ||
+                shouldRunMajorV1CompactionByObjectCount(hint.objectsCount, MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD)) {
                 compact(MAJOR_V1, hint);
                 lastMajorV1CompactionTimestamp = System.currentTimeMillis();
             } else if (now - lastMinorV1CompactionTimestamp > MINOR_V1_COMPACTION_INTERVAL) {
@@ -453,6 +455,10 @@ public class S3StreamClient implements StreamClient {
 
             taskBuilder.build().compact(compactionType);
         }
+    }
+
+    static boolean shouldRunMajorV1CompactionByObjectCount(int objectsCount, int maxObjectThreshold) {
+        return objectsCount >= (int) Math.ceil(maxObjectThreshold * MAJOR_V1_COMPACTION_OBJECT_COUNT_SOFT_THRESHOLD_RATIO);
     }
 
     static class CompactionHint {

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -142,7 +142,7 @@ public class StreamObjectCompactor {
     }
 
     protected static Predicate<S3ObjectMetadata> getObjectFilter(CompactionType compactionType, long minMajorV1CompactionSize) {
-        boolean includeCompositeObject = CLEANUP_V1.equals(compactionType) || MAJOR_V1.equals(compactionType);
+        boolean includeCompositeObject = MAJOR_V1.equals(compactionType);
 
         return object -> {
             ObjectAttributes.Type objectType = ObjectAttributes.from(object.attributes()).type();
@@ -188,9 +188,14 @@ public class StreamObjectCompactor {
         }
 
         // compact the living objects
-        List<List<S3ObjectMetadata>> objectGroups = group0(livingObjects,
-            getMaxGroupSize(compactionType),
-            getObjectFilter(compactionType, majorV1CompactionSkipSmallObject ? minorV1CompactionThreshold : 0));
+        List<List<S3ObjectMetadata>> objectGroups;
+        if (CLEANUP_V1.equals(compactionType)) {
+            objectGroups = cleanupV1Groups(livingObjects, startOffset);
+        } else {
+            objectGroups = group0(livingObjects,
+                getMaxGroupSize(compactionType),
+                getObjectFilter(compactionType, majorV1CompactionSkipSmallObject ? minorV1CompactionThreshold : 0));
+        }
 
         for (List<S3ObjectMetadata> objectGroup : objectGroups) {
             if (!checkObjectGroupCouldBeCompact(objectGroup, startOffset, compactionType)) {
@@ -221,8 +226,6 @@ public class StreamObjectCompactor {
                 return MINOR_COMPACTION_SIZE_THRESHOLD;
             case MAJOR:
                 return this.maxStreamObjectSize;
-            case CLEANUP_V1:
-                return this.maxStreamObjectSize;
             case MINOR_V1:
                 return this.minorV1CompactionThreshold;
             case MAJOR_V1:
@@ -240,15 +243,21 @@ public class StreamObjectCompactor {
         if (objectGroup.stream().anyMatch(o -> o.bucket() == LocalFileObjectStorage.BUCKET_ID)) {
             return false;
         }
-        if (CLEANUP_V1.equals(compactionType)) {
-            S3ObjectMetadata metadata = objectGroup.get(0);
-            if (ObjectAttributes.from(metadata.attributes()).type() != Composite) {
-                return false;
-            }
-            double dirtySize = ((double) startOffset - metadata.startOffset()) / (metadata.endOffset() - metadata.startOffset()) * metadata.objectSize();
-            return dirtySize > MAX_DIRTY_BYTES;
-        }
         return true;
+    }
+
+    static List<List<S3ObjectMetadata>> cleanupV1Groups(List<S3ObjectMetadata> livingObjects, long startOffset) {
+        List<S3ObjectMetadata> objects = deduplicateObjectsById(livingObjects, "stream object compaction");
+        if (objects.isEmpty()) {
+            return List.of();
+        }
+        S3ObjectMetadata firstObject = objects.get(0);
+        if (ObjectAttributes.from(firstObject.attributes()).type() != Composite) {
+            return List.of();
+        }
+        double dirtySize = ((double) startOffset - firstObject.startOffset())
+            / (firstObject.endOffset() - firstObject.startOffset()) * firstObject.objectSize();
+        return dirtySize > MAX_DIRTY_BYTES ? List.of(List.of(firstObject)) : List.of();
     }
 
     private void cleanupExpiredObject(

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StreamClientTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StreamClientTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -88,6 +90,18 @@ public class S3StreamClientTest {
         assertEquals(0, client.openingStreams.size());
         assertEquals(0, client.openedStreams.size());
         assertEquals(0, client.closingStreams.size());
+    }
+
+    /**
+     * Given the cluster object count approaches the hard major-v1 threshold,
+     * when deciding whether to run major-v1 compaction, then the soft threshold triggers early.
+     */
+    @Test
+    public void testMajorV1CompactionTriggeredAtSoftObjectThreshold() {
+        int hardThreshold = 100;
+        assertFalse(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(89, hardThreshold));
+        assertTrue(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(90, hardThreshold));
+        assertTrue(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(100, hardThreshold));
     }
 
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -66,6 +66,7 @@ import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.
 import static com.automq.stream.s3.compact.StreamObjectCompactor.EXPIRED_OBJECTS_CLEAN_UP_STEP;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.SKIP_COMPACTION_TYPE_WHEN_ONE_OBJECT_IN_GROUP;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.builder;
+import static com.automq.stream.s3.compact.StreamObjectCompactor.cleanupV1Groups;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.getObjectFilter;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.group0;
 import static com.automq.stream.s3.objects.ObjectAttributes.Type.Composite;
@@ -511,6 +512,24 @@ class StreamObjectCompactorTest {
             .findAny().isEmpty());
     }
 
+    /**
+     * Given CLEANUP_V1 candidates with normal objects after a dirty composite,
+     * when cleanup groups are selected, then only the first dirty composite is compacted.
+     */
+    @Test
+    public void testCleanupV1OnlyCompactsFirstDirtyCompositeObject() {
+        long objectSize = 1024L * 1024 * 1024;
+        S3ObjectMetadata dirtyComposite = s3ObjectMetadata(1, 100, 200, objectSize, Composite);
+        S3ObjectMetadata followingNormal = s3ObjectMetadata(2, 200, 300, objectSize, Normal);
+        S3ObjectMetadata followingComposite = s3ObjectMetadata(3, 300, 400, objectSize, Composite);
+
+        List<List<S3ObjectMetadata>> groups = cleanupV1Groups(List.of(
+            dirtyComposite, followingNormal, followingComposite), 170);
+
+        assertEquals(1, groups.size());
+        assertEquals(List.of(dirtyComposite), groups.get(0));
+    }
+
     @Test
     public void testCleanup_byStep() throws ExecutionException, InterruptedException {
         // prepare object
@@ -617,5 +636,14 @@ class StreamObjectCompactorTest {
 
     StreamRecordBatch newRecord(long offset, int count, int payloadSize) {
         return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize));
+    }
+
+    private S3ObjectMetadata s3ObjectMetadata(long objectId, long startOffset, long endOffset, long objectSize,
+        ObjectAttributes.Type objectType) {
+        S3ObjectMetadata metadata = new S3ObjectMetadata(objectId, S3ObjectType.STREAM,
+            List.of(new StreamOffsetRange(streamId, startOffset, endOffset)),
+            System.currentTimeMillis(), System.currentTimeMillis(), objectSize, objectId);
+        metadata.setAttributes(ObjectAttributes.builder().bucket((short) 0).type(objectType).build().attributes());
+        return metadata;
     }
 }


### PR DESCRIPTION
- make CLEANUP_V1 bypass general grouping and only compact the first dirty composite object after expired cleanup
- remove obsolete CLEANUP_V1 branches from shared compaction filter/group validation paths
- trigger MAJOR_V1 at 90% of the object-count threshold while preserving small-normal-object skipping before the hard threshold