### PR TITLE
fix: align metrics exporter naming (#3424)

### DIFF
--- a/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/s3/PrometheusUtils.java
+++ b/automq-metrics/src/main/java/com/automq/opentelemetry/exporter/s3/PrometheusUtils.java
@@ -19,15 +19,14 @@
 
 package com.automq.opentelemetry.exporter.s3;
 
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.Locale;
-
 /**
  * Utility class for Prometheus metric and label naming.
  */
 public class PrometheusUtils {
     private static final String TOTAL_SUFFIX = "_total";
+    private static final String[] RESERVED_METRIC_NAME_SUFFIXES = {
+        "_total", "_created", "_bucket", "_info"
+    };
 
     /**
      * Get the Prometheus unit from the OpenTelemetry unit.
@@ -93,7 +92,7 @@ public class PrometheusUtils {
             case "Hz":
                 return "hertz";
             case "1":
-                return "";
+                return "ratio";
             case "%":
                 return "percent";
             // Rate units (per second)
@@ -143,11 +142,10 @@ public class PrometheusUtils {
      * @return The Prometheus-compatible metric name.
      */
     public static String mapMetricsName(String name, String unit, boolean isCounter, boolean isGauge) {
-        // Replace "." into "_"
-        name = name.replaceAll("\\.", "_");
+        name = sanitizeMetricName(name);
 
         String prometheusUnit = getPrometheusUnit(unit);
-        boolean shouldAppendUnit = StringUtils.isNotBlank(prometheusUnit) && !name.contains(prometheusUnit);
+        boolean shouldAppendUnit = !prometheusUnit.isBlank() && !name.endsWith(prometheusUnit);
 
         // append prometheus unit if not null or empty.
         // unit should be appended before type suffix
@@ -155,27 +153,8 @@ public class PrometheusUtils {
             name = name + "_" + prometheusUnit;
         }
 
-        // trim counter's _total suffix so the unit is placed before it.
-        if (isCounter && name.endsWith(TOTAL_SUFFIX)) {
-            name = name.substring(0, name.length() - TOTAL_SUFFIX.length());
-        }
-
-        // replace _total suffix, or add if it wasn't already present.
         if (isCounter) {
             name = name + TOTAL_SUFFIX;
-        }
-        
-        // special case - gauge with intelligent Connect metric handling
-        if ("1".equals(unit) && isGauge && !name.contains("ratio")) {
-            if (isConnectMetric(name)) {
-                // For Connect metrics, use improved logic to avoid misleading _ratio suffix
-                if (shouldAddRatioSuffixForConnect(name)) {
-                    name = name + "_ratio";
-                }
-            } else {
-                // For other metrics, maintain original behavior
-                name = name + "_ratio";
-            }
         }
         return name;
     }
@@ -187,90 +166,34 @@ public class PrometheusUtils {
      * @return The Prometheus-compatible label name.
      */
     public static String mapLabelName(String name) {
-        if (StringUtils.isBlank(name)) {
+        if (name == null || name.isBlank()) {
             return "";
         }
         return name.replaceAll("\\.", "_");
     }
 
-    /**
-     * Check if a metric name is related to Kafka Connect.
-     *
-     * @param name The metric name to check.
-     * @return true if it's a Connect metric, false otherwise.
-     */
-    private static boolean isConnectMetric(String name) {
-        String lowerName = name.toLowerCase(Locale.ROOT);
-        return lowerName.contains("kafka_connector_") || 
-               lowerName.contains("kafka_task_") || 
-               lowerName.contains("kafka_worker_") ||
-               lowerName.contains("kafka_connect_") ||
-               lowerName.contains("kafka_source_task_") ||
-               lowerName.contains("kafka_sink_task_") ||
-               lowerName.contains("connector_metrics") ||
-               lowerName.contains("task_metrics") ||
-               lowerName.contains("worker_metrics") ||
-               lowerName.contains("source_task_metrics") ||
-               lowerName.contains("sink_task_metrics");
-    }
-
-    /**
-     * Intelligently determine if a Connect metric should have a _ratio suffix.
-     * This method avoids adding misleading _ratio suffixes to count-based metrics.
-     *
-     * @param name The metric name to check.
-     * @return true if _ratio suffix should be added, false otherwise.
-     */
-    private static boolean shouldAddRatioSuffixForConnect(String name) {
-        String lowerName = name.toLowerCase(Locale.ROOT);
-        
-        if (hasRatioRelatedWords(lowerName)) {
-            return false;
+    private static String sanitizeMetricName(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Cannot convert an empty string to a valid metric name.");
         }
-        
-        if (isCountMetric(lowerName)) {
-            return false;
+        String sanitizedName = name.replaceAll("[^a-zA-Z0-9_.:]", "_");
+        if (!sanitizedName.substring(0, 1).matches("[a-zA-Z_.:]")) {
+            sanitizedName = "_" + sanitizedName;
         }
-        
-        return isRatioMetric(lowerName);
-    }
-    
-    private static boolean hasRatioRelatedWords(String lowerName) {
-        return lowerName.contains("ratio") || lowerName.contains("percent") || 
-               lowerName.contains("rate") || lowerName.contains("fraction");
-    }
-    
-    private static boolean isCountMetric(String lowerName) {
-        return hasBasicCountKeywords(lowerName) || hasConnectCountKeywords(lowerName) ||
-               hasStatusCountKeywords(lowerName);
-    }
-    
-    private static boolean hasBasicCountKeywords(String lowerName) {
-        return lowerName.contains("count") || lowerName.contains("num") || 
-               lowerName.contains("size") || lowerName.contains("total") ||
-               lowerName.contains("active") || lowerName.contains("current");
-    }
-    
-    private static boolean hasConnectCountKeywords(String lowerName) {
-        return lowerName.contains("partition") || lowerName.contains("task") ||
-               lowerName.contains("connector") || lowerName.contains("seq_no") ||
-               lowerName.contains("seq_num") || lowerName.contains("attempts");
-    }
-    
-    private static boolean hasStatusCountKeywords(String lowerName) {
-        return lowerName.contains("success") || lowerName.contains("failure") ||
-               lowerName.contains("errors") || lowerName.contains("retries") ||
-               lowerName.contains("skipped") || lowerName.contains("running") ||
-               lowerName.contains("paused") || lowerName.contains("failed") ||
-               lowerName.contains("destroyed");
-    }
-    
-    private static boolean isRatioMetric(String lowerName) {
-        return lowerName.contains("utilization") || 
-               lowerName.contains("usage") ||
-               lowerName.contains("load") ||
-               lowerName.contains("efficiency") ||
-               lowerName.contains("hit_rate") ||
-               lowerName.contains("miss_rate");
+        sanitizedName = sanitizedName.replaceAll("\\.", "_");
+        boolean modified = true;
+        while (modified) {
+            modified = false;
+            for (String reservedSuffix : RESERVED_METRIC_NAME_SUFFIXES) {
+                if (sanitizedName.equals(reservedSuffix)) {
+                    return reservedSuffix.substring(1);
+                }
+                if (sanitizedName.endsWith(reservedSuffix)) {
+                    sanitizedName = sanitizedName.substring(0, sanitizedName.length() - reservedSuffix.length());
+                    modified = true;
+                }
+            }
+        }
+        return sanitizedName;
     }
 }

--- a/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
+++ b/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.opentelemetry.exporter.s3;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PrometheusUtilsTest {
+
+    @Test
+    public void testPrometheusPullCompatibleReservedSuffixAndUnitRules() {
+        assertMetricName("foo", "foo_total", "", false, true);
+        assertMetricName("foo", "foo_info", "", false, true);
+        assertMetricName("foo_bytes", "foo_bytes_total", "bytes", false, true);
+        assertMetricName("foo_bytes_current_bytes", "foo_bytes_current", "bytes", false, true);
+        assertMetricName("foo_bytes_total", "foo_total", "bytes", true, false);
+        assertMetricName("foo_count_sum_count", "foo_count_sum", "count", false, true);
+        assertMetricName("foo_ratio", "foo", "1", false, true);
+        assertMetricName("foo_ratio_total", "foo", "1", true, false);
+    }
+
+    private static void assertMetricName(String expected, String name, String unit, boolean isCounter, boolean isGauge) {
+        Assertions.assertEquals(expected, PrometheusUtils.mapMetricsName(name, unit, isCounter, isGauge));
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/automq/metrics/OpenTelemetryMetricsReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/automq/metrics/OpenTelemetryMetricsReporter.java
@@ -276,7 +276,12 @@ public class OpenTelemetryMetricsReporter implements MetricsReporter {
     private MetricHandle createMetricHandle(String metricKey, MetricName metricName, Number initialValue, boolean isCounter) {
         MetricHandle handle = new MetricHandle();
         String description = buildDescription(metricName);
-        String unit = determineUnit(metricName);
+        // Kafka Connect metrics have already encoded their semantic unit in the Kafka metric
+        // name, for example "record-age-ms-avg", "byte-rate", and
+        // "offset-commit-avg-time-ms". Keep the OpenTelemetry unit empty here so the
+        // Prometheus-compatible exporter does not append another inferred suffix such as
+        // "_ratio", "_milliseconds", or "_bytes_per_second".
+        String unit = "";
 
         if (isCounter) {
             boolean useLongCounter = initialValue instanceof Long || initialValue instanceof Integer;
@@ -457,37 +462,6 @@ public class OpenTelemetryMetricsReporter implements MetricsReporter {
         return description.toString();
     }
     
-    private String determineUnit(MetricName metricName) {
-        String name = metricName.name().toLowerCase(Locale.ROOT);
-        String group = metricName.group() != null ? metricName.group().toLowerCase(Locale.ROOT) : "";
-
-        if (isKafkaConnectMetric(group)) {
-            return determineConnectMetricUnit(name);
-        }
-
-        if (isTimeMetric(name)) {
-            return determineTimeUnit(name);
-        }
-
-        if (isBytesMetric(name)) {
-            return determineBytesUnit(name);
-        }
-
-        if (isRateMetric(name)) {
-            return "1/s";
-        }
-
-        if (isRatioOrPercentageMetric(name)) {
-            return "1";
-        }
-
-        if (isCountMetric(name)) {
-            return "1";
-        }
-        
-        return "1";
-    }
-    
     private boolean isCounterMetric(MetricName metricName) {
         String name = metricName.name().toLowerCase(Locale.ROOT);
         String group = metricName.group() != null ? metricName.group().toLowerCase(Locale.ROOT) : "";
@@ -640,220 +614,7 @@ public class OpenTelemetryMetricsReporter implements MetricsReporter {
         return group.contains("connector") || group.contains("task") || 
                group.contains("connect") || group.contains("worker");
     }
-    
-    private String determineConnectMetricUnit(String name) {
-        String timeUnit = getTimeUnit(name);
-        if (timeUnit != null) {
-            return timeUnit;
-        }
-        
-        String countUnit = getCountUnit(name);
-        if (countUnit != null) {
-            return countUnit;
-        }
-        
-        String specialUnit = getSpecialUnit(name);
-        if (specialUnit != null) {
-            return specialUnit;
-        }
-        
-        return "1";
-    }
-    
-    private String getTimeUnit(String name) {
-        if (isTimeBasedMetric(name)) {
-            return "ms";
-        }
-        if (isTimestampMetric(name)) {
-            return "ms";
-        }
-        if (isTimeSinceMetric(name)) {
-            return "ms";
-        }
-        return null;
-    }
-    
-    private String getCountUnit(String name) {
-        if (isSequenceOrCountMetric(name)) {
-            return "1";
-        }
-        if (isLagMetric(name)) {
-            return "1";
-        }
-        if (isTotalOrCounterMetric(name)) {
-            return "1";
-        }
-        return null;
-    }
-    
-    private String getSpecialUnit(String name) {
-        if (isStatusOrMetadataMetric(name)) {
-            return "1";
-        }
-        if (isConnectRateMetric(name)) {
-            return "1/s";
-        }
-        if (isRatioMetric(name)) {
-            return "1";
-        }
-        return null;
-    }
-    
-    private boolean isTimeBasedMetric(String name) {
-        return hasTimeMs(name) || hasCommitBatchTime(name);
-    }
-    
-    private boolean hasTimeMs(String name) {
-        return name.endsWith("-time-ms") || name.endsWith("-avg-time-ms") || 
-               name.endsWith("-max-time-ms");
-    }
-    
-    private boolean hasCommitBatchTime(String name) {
-        return name.contains("commit-time") || name.contains("batch-time") || 
-               name.contains("rebalance-time");
-    }
-    
-    private boolean isSequenceOrCountMetric(String name) {
-        return hasSequenceNumbers(name) || hasCountSuffix(name);
-    }
-    
-    private boolean hasSequenceNumbers(String name) {
-        return name.contains("seq-no") || name.contains("seq-num");
-    }
-    
-    private boolean hasCountSuffix(String name) {
-        return name.endsWith("-count") || name.contains("task-count") ||
-               name.contains("partition-count");
-    }
-    
-    private boolean isLagMetric(String name) {
-        return name.contains("lag");
-    }
-    
-    private boolean isStatusOrMetadataMetric(String name) {
-        return isStatusMetric(name) || hasProtocolLeaderMetrics(name) || 
-               hasConnectorMetrics(name);
-    }
-    
-    private boolean isStatusMetric(String name) {
-        return "status".equals(name) || name.contains("protocol");
-    }
-    
-    private boolean hasProtocolLeaderMetrics(String name) {
-        return name.contains("leader-name");
-    }
-    
-    private boolean hasConnectorMetrics(String name) {
-        return name.contains("connector-type") || name.contains("connector-class") ||
-               name.contains("connector-version");
-    }
-    
-    private boolean isRatioMetric(String name) {
-        return name.contains("ratio") || name.contains("percentage");
-    }
-    
-    private boolean isTotalOrCounterMetric(String name) {
-        return hasTotalSum(name) || hasAttempts(name) || hasSuccessFailure(name) ||
-               hasErrorsRetries(name);
-    }
-    
-    private boolean hasTotalSum(String name) {
-        return name.contains("total") || name.contains("sum");
-    }
-    
-    private boolean hasAttempts(String name) {
-        return name.contains("attempts");
-    }
-    
-    private boolean hasSuccessFailure(String name) {
-        return name.contains("success") || name.contains("failure");
-    }
-    
-    private boolean hasErrorsRetries(String name) {
-        return name.contains("errors") || name.contains("retries") || name.contains("skipped");
-    }
-    
-    private boolean isTimestampMetric(String name) {
-        return name.contains("timestamp") || name.contains("epoch");
-    }
-    
-    private boolean isConnectRateMetric(String name) {
-        return name.contains("rate") && !name.contains("ratio");
-    }
-    
-    private boolean isTimeSinceMetric(String name) {
-        return name.contains("time-since-last") || name.contains("since-last");
-    }
-    
-    private boolean isTimeMetric(String name) {
-        return hasTimeKeywords(name) && !hasTimeExclusions(name);
-    }
-    
-    private boolean hasTimeKeywords(String name) {
-        return name.contains("time") || name.contains("latency") || 
-               name.contains("duration");
-    }
-    
-    private boolean hasTimeExclusions(String name) {
-        return name.contains("ratio") || name.contains("rate") ||
-               name.contains("count") || name.contains("since-last");
-    }
-    
-    private String determineTimeUnit(String name) {
-        if (name.contains("ms") || name.contains("millisecond")) {
-            return "ms";
-        } else if (name.contains("us") || name.contains("microsecond")) {
-            return "us";
-        } else if (name.contains("ns") || name.contains("nanosecond")) {
-            return "ns";
-        } else if (name.contains("s") && !name.contains("ms")) {
-            return "s";
-        } else {
-            return "ms";
-        }
-    }
-    
-    private boolean isBytesMetric(String name) {
-        return name.contains("byte") || name.contains("bytes") || 
-               name.contains("size") && !name.contains("batch-size");
-    }
-    
-    private String determineBytesUnit(String name) {
-        boolean isRate = name.contains("rate") || name.contains("per-sec") || 
-                        name.contains("persec") || name.contains("/s");
-        return isRate ? "By/s" : "By";
-    }
-    
-    private boolean isRateMetric(String name) {
-        return hasRateKeywords(name) && !hasExcludedKeywords(name);
-    }
-    
-    private boolean hasRateKeywords(String name) {
-        return name.contains("rate") || name.contains("per-sec") || 
-               name.contains("persec") || name.contains("/s");
-    }
-    
-    private boolean hasExcludedKeywords(String name) {
-        return name.contains("byte") || name.contains("ratio");
-    }
-    
-    private boolean isRatioOrPercentageMetric(String name) {
-        return hasPercentKeywords(name) || hasRatioKeywords(name);
-    }
-    
-    private boolean hasPercentKeywords(String name) {
-        return name.contains("percent") || name.contains("pct");
-    }
-    
-    private boolean hasRatioKeywords(String name) {
-        return name.contains("ratio");
-    }
-    
-    private boolean isCountMetric(String name) {
-        return name.contains("count") || name.contains("total") || 
-               name.contains("sum") || name.endsWith("-num");
-    }
-    
+
     private boolean shouldIncludeMetric(String metricKey) {
         if (excludePattern != null && metricKey.matches(excludePattern)) {
             return false;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -253,7 +253,7 @@ public class S3StreamMetricsManager {
         getObjectsTime = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.GET_OBJECTS_TIME_METRIC_NAME,
                 "Get objects time", "nanoseconds", () -> GET_OBJECTS_TIME_METRICS);
         objectsToSearchCount = new HistogramInstrument(meter, prefix + S3StreamMetricsConstant.OBJECTS_SEARCH_COUNT_METRIC_NAME,
-                "Number of SSO object to search when get objects", "count", () -> OBJECTS_TO_SEARCH_COUNT_METRICS);
+                "Number of SSO object to search when get objects", "", () -> OBJECTS_TO_SEARCH_COUNT_METRICS);
         deltaWalStartOffset = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.WAL_START_OFFSET)
             .setDescription("Delta WAL start offset")
             .ofLongs()


### PR DESCRIPTION
## Summary
- Align shared Prometheus name normalization with Prometheus pull rules.
- Keep `objects_search_count` pseudo-histogram names stable by removing the inappropriate `count` unit.
- Keep the focused rule regression test in `automq-metrics`.