### PR TITLE
ci: reduce E2E artifact storage usage

### DIFF
--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -116,8 +116,10 @@ jobs:
         if: ${{ always() }}
         with:
           name: ${{ inputs.suite-id }}
-          retention-days: 3
-          compression-level: 1
+          # E2E result directories can be several GiB per suite; keep only the
+          # short debugging window needed after scheduled runs.
+          retention-days: 1
+          compression-level: 6
           path: |
             results/
       - name: show results


### PR DESCRIPTION
## Summary

Reduce storage pressure from E2E workflow artifacts.

Changes:
- Shorten E2E artifact retention from 3 days to 1 day.
- Increase artifact compression level from 1 to 6.
- Add a short comment explaining why E2E artifacts use a short retention window.

## Background

The scheduled Nightly E2E workflow can upload several GiB of result artifacts per suite, with the `benchmarks` artifact alone observed at around 8 GiB. Keeping these artifacts for multiple days can quickly exhaust the shared GitHub Actions/Packages storage quota.

## Validation

- Ran `git diff --check -- .github/workflows/e2e-run.yml`