### PR TITLE
fix(tabletopic): use stable fps metric name

### DIFF
--- a/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
+++ b/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
@@ -34,6 +34,8 @@ public class PrometheusUtilsTest {
         assertMetricName("foo_count_sum_count", "foo_count_sum", "count", false, true);
         assertMetricName("foo_ratio", "foo", "1", false, true);
         assertMetricName("foo_ratio_total", "foo", "1", true, false);
+        assertMetricName("kafka_tabletopic_fields_per_second",
+            "kafka_tabletopic_fields", "1/s", false, true);
     }
 
     private static void assertMetricName(String expected, String name, String unit, boolean isCounter, boolean isGauge) {

--- a/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
+++ b/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
@@ -37,7 +37,7 @@ public final class TableTopicMetricsManager {
     private static final Metrics.LongGaugeBundle DELAY_GAUGES = Metrics.instance()
         .longGauge("kafka_tabletopic_delay", "Table topic commit delay", "ms");
     private static final Metrics.DoubleGaugeBundle FIELDS_PER_SECOND_GAUGES = Metrics.instance()
-        .doubleGauge("kafka_tabletopic_fps", "Table topic fields per second", "fields/s");
+        .doubleGauge("kafka_tabletopic_fields", "Table topic fields per second", "1/s");
     private static final Metrics.DoubleGaugeBundle EVENT_LOOP_BUSY_GAUGES = Metrics.instance()
         .doubleGauge("kafka_tableworker_eventloop_busy_ratio", "Table worker event loop busy ratio", "%");
 


### PR DESCRIPTION
## Summary
- replace the custom `fields/s` TableTopic FPS unit with standard rate unit `1/s`
- define the instrument as `kafka_tabletopic_fields`, producing final Prometheus metric `kafka_tabletopic_fields_per_second`
- add a regression check for Prometheus metric-name conversion

## Context
Runtime 5.5.0 exports `kafka_tabletopic_fps_fields/s` because the previous OTel metric used custom unit `fields/s`. The exporter should not grow one-off mappings for custom business units. Using `name=kafka_tabletopic_fields` with `unit=1/s` follows the existing Prometheus-compatible unit rules and avoids the redundant `fps_fields_per_second` name.

Dashboard compatibility is handled in opsbox and automq-labs by matching legacy `kafka_tabletopic_fps_fields/s`, interim `kafka_tabletopic_fps_fields_per_second`, and final `kafka_tabletopic_fields_per_second`.

## Verification
- `./gradlew automq-metrics:test --tests com.automq.opentelemetry.exporter.s3.PrometheusUtilsTest`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`