### PR TITLE
fix(tabletopic): use stable fps metric name

### DIFF
--- a/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
+++ b/automq-metrics/src/test/java/com/automq/opentelemetry/exporter/s3/PrometheusUtilsTest.java
@@ -34,6 +34,8 @@ public class PrometheusUtilsTest {
         assertMetricName("foo_count_sum_count", "foo_count_sum", "count", false, true);
         assertMetricName("foo_ratio", "foo", "1", false, true);
         assertMetricName("foo_ratio_total", "foo", "1", true, false);
+        assertMetricName("kafka_tabletopic_fields_per_second",
+            "kafka_tabletopic_fields", "1/s", false, true);
     }
 
     private static void assertMetricName(String expected, String name, String unit, boolean isCounter, boolean isGauge) {

--- a/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
+++ b/core/src/main/java/kafka/automq/table/metric/TableTopicMetricsManager.java
@@ -37,7 +37,7 @@ public final class TableTopicMetricsManager {
     private static final Metrics.LongGaugeBundle DELAY_GAUGES = Metrics.instance()
         .longGauge("kafka_tabletopic_delay", "Table topic commit delay", "ms");
     private static final Metrics.DoubleGaugeBundle FIELDS_PER_SECOND_GAUGES = Metrics.instance()
-        .doubleGauge("kafka_tabletopic_fps", "Table topic fields per second", "fields/s");
+        .doubleGauge("kafka_tabletopic_fields", "Table topic fields per second", "1/s");
     private static final Metrics.DoubleGaugeBundle EVENT_LOOP_BUSY_GAUGES = Metrics.instance()
         .doubleGauge("kafka_tableworker_eventloop_busy_ratio", "Table worker event loop busy ratio", "%");
 


### PR DESCRIPTION
## Summary
- backport the TableTopic fields-per-second metric rename to 1.7
- replace custom `fields/s` with standard rate unit `1/s`
- emit final Prometheus metric name `kafka_tabletopic_fields_per_second` from `name=kafka_tabletopic_fields`
- add regression coverage for the Prometheus name conversion

## Context
This cherry-picks the main-branch fix from PR #3439. Runtime 1.7 still defines the metric as `kafka_tabletopic_fps` with custom unit `fields/s`, which exports as `kafka_tabletopic_fps_fields/s`. Using standard `1/s` avoids one-off custom unit mapping and aligns with the compatible dashboard updates in opsbox and automq-labs.

## Verification
- `./gradlew automq-metrics:test --tests com.automq.opentelemetry.exporter.s3.PrometheusUtilsTest`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`