### PR TITLE
fix(s3stream): track stalled pending requests (#3441)

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -44,19 +44,18 @@ import com.automq.stream.s3.streams.StreamMetadataListener;
 import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.GlobalSwitch;
 import com.automq.stream.utils.LogContext;
+import com.automq.stream.utils.PendingRequestTracker;
 
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -72,6 +71,14 @@ import static com.automq.stream.utils.FutureUtil.exec;
 import static com.automq.stream.utils.FutureUtil.propagate;
 
 public class S3Stream implements Stream, StreamMetadataListener {
+    private static final PendingRequestTracker PENDING_APPEND_TRACKER = new PendingRequestTracker();
+    private static final PendingRequestTracker PENDING_FETCH_TRACKER = new PendingRequestTracker();
+
+    static {
+        S3StreamMetricsManager.registerPendingStreamAppendLatencySupplier(PENDING_APPEND_TRACKER::pendingLatencyNanos);
+        S3StreamMetricsManager.registerPendingStreamFetchLatencySupplier(PENDING_FETCH_TRACKER::pendingLatencyNanos);
+    }
+
     private final Logger logger;
     final AtomicLong confirmOffset;
     private final String logIdent;
@@ -86,10 +93,8 @@ public class S3Stream implements Stream, StreamMetadataListener {
     private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
     private final ReentrantLock appendLock = new ReentrantLock();
     private final Set<CompletableFuture<?>> pendingAppends = ConcurrentHashMap.newKeySet();
-    private final Deque<Long> pendingAppendTimestamps = new ConcurrentLinkedDeque<>();
     private volatile CompletableFuture<AppendResult> lastAppendFuture;
     private final Set<CompletableFuture<?>> pendingFetches = ConcurrentHashMap.newKeySet();
-    private final Deque<Long> pendingFetchTimestamps = new ConcurrentLinkedDeque<>();
     private final OpenStreamOptions options;
     private long startOffset;
     private CompletableFuture<Void> lastPendingTrim = CompletableFuture.completedFuture(null);
@@ -127,17 +132,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
         if (snapshotRead()) {
             listenerHandle = streamManager.addMetadataListener(streamId, this);
         }
-        S3StreamMetricsManager.registerPendingStreamAppendLatencySupplier(streamId, () -> getHeadLatency(this.pendingAppendTimestamps));
-        S3StreamMetricsManager.registerPendingStreamFetchLatencySupplier(streamId, () -> getHeadLatency(this.pendingFetchTimestamps));
         NetworkStats.getInstance().createStreamReadBytesStats(streamId);
-    }
-
-    private long getHeadLatency(Deque<Long> timestamps) {
-        Long timestamp = timestamps.peek();
-        if (timestamp == null) {
-            return 0;
-        }
-        return System.nanoTime() - timestamp;
     }
 
     public boolean isClosed() {
@@ -199,11 +194,11 @@ public class S3Stream implements Stream, StreamMetadataListener {
                 }
             }, logger, "append");
             pendingAppends.add(cf);
-            pendingAppendTimestamps.push(startTimeNanos);
+            PendingRequestTracker.Handle pendingAppend = PENDING_APPEND_TRACKER.begin();
             return cf.whenComplete((nil, ex) -> {
                 StreamOperationStats.getInstance().appendStreamLatency.record(TimerUtil.timeElapsedSince(startTimeNanos, TimeUnit.NANOSECONDS));
                 pendingAppends.remove(cf);
-                pendingAppendTimestamps.pop();
+                pendingAppend.close();
             });
         } finally {
             readLock.unlock();
@@ -265,7 +260,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
                 return rs;
             });
             pendingFetches.add(retCf);
-            pendingFetchTimestamps.push(timerUtil.lastAs(TimeUnit.NANOSECONDS));
+            PendingRequestTracker.Handle pendingFetch = PENDING_FETCH_TRACKER.begin();
             retCf.whenComplete((rs, ex) -> {
                 if (ex != null) {
                     Throwable cause = FutureUtil.cause(ex);
@@ -283,7 +278,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
                         startOffset, endOffset, totalSize, timerUtil.elapsedAs(TimeUnit.MILLISECONDS));
                 }
                 pendingFetches.remove(retCf);
-                pendingFetchTimestamps.pop();
+                pendingFetch.close();
             });
             return retCf;
         } finally {
@@ -374,8 +369,6 @@ public class S3Stream implements Stream, StreamMetadataListener {
         if (snapshotRead()) {
             listenerHandle.close();
             NetworkStats.getInstance().removeStreamReadBytesStats(streamId);
-            S3StreamMetricsManager.removePendingStreamAppendLatencySupplier(streamId);
-            S3StreamMetricsManager.removePendingStreamFetchLatencySupplier(streamId);
             return CompletableFuture.completedFuture(null);
         }
         TimerUtil timerUtil = new TimerUtil();
@@ -416,8 +409,6 @@ public class S3Stream implements Stream, StreamMetadataListener {
                     StreamOperationStats.getInstance().closeStreamStats(true).record(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
                 }
                 NetworkStats.getInstance().removeStreamReadBytesStats(streamId);
-                S3StreamMetricsManager.removePendingStreamAppendLatencySupplier(streamId);
-                S3StreamMetricsManager.removePendingStreamFetchLatencySupplier(streamId);
             });
 
             this.closeCf = closeCf;

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/S3StreamMetricsManager.java
@@ -140,8 +140,8 @@ public class S3StreamMetricsManager {
     private static Map<String, LongSupplier> asyncCacheMaxSizeSupplier = new ConcurrentHashMap<>();
 
     private static Supplier<Integer> inflightWALUploadTasksCountSupplier = () -> 0;
-    private static Map<Long, Supplier<Long>> pendingStreamAppendLatencySupplier = new ConcurrentHashMap<>();
-    private static Map<Long, Supplier<Long>> pendingStreamFetchLatencySupplier = new ConcurrentHashMap<>();
+    private static Supplier<Long> pendingStreamAppendLatencySupplier = () -> 0L;
+    private static Supplier<Long> pendingStreamFetchLatencySupplier = () -> 0L;
     private static MetricsConfig metricsConfig = new MetricsConfig(MetricsLevel.INFO, Attributes.empty());
     private static final MultiAttributes<String> ALLOC_TYPE_ATTRIBUTES = new MultiAttributes<>(Attributes.empty(),
         S3StreamMetricsConstant.LABEL_TYPE);
@@ -364,8 +364,8 @@ public class S3StreamMetricsManager {
                 }
             });
         pendingStreamAppendLatencyMetrics = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.PENDING_STREAM_APPEND_LATENCY_METRIC_NAME)
-                .setDescription("The maximum latency of pending stream append requests. NOTE: the minimum measurable " +
-                        "latency depends on the reporting interval of this metrics.")
+                .setDescription("The maximum latency of pending stream append requests that exceed the pending latency threshold. " +
+                        "NOTE: the minimum measurable latency depends on the reporting interval of this metrics.")
                 .ofLongs()
                 .setUnit("nanoseconds")
                 .buildWithCallback(result -> {
@@ -374,8 +374,8 @@ public class S3StreamMetricsManager {
                     }
                 });
         pendingStreamFetchLatencyMetrics = meter.gaugeBuilder(prefix + S3StreamMetricsConstant.PENDING_STREAM_FETCH_LATENCY_METRIC_NAME)
-                .setDescription("The maximum latency of pending stream append requests. NOTE: the minimum measurable " +
-                        "latency depends on the reporting interval of this metrics.")
+                .setDescription("The maximum latency of pending stream fetch requests that exceed the pending latency threshold. " +
+                        "NOTE: the minimum measurable latency depends on the reporting interval of this metrics.")
                 .ofLongs()
                 .setUnit("nanoseconds")
                 .buildWithCallback(result -> {
@@ -907,28 +907,20 @@ public class S3StreamMetricsManager {
         }
     }
 
-    public static void registerPendingStreamAppendLatencySupplier(long streamId, Supplier<Long> pendingStreamAppendLatencySupplier) {
-        S3StreamMetricsManager.pendingStreamAppendLatencySupplier.put(streamId, pendingStreamAppendLatencySupplier);
+    public static void registerPendingStreamAppendLatencySupplier(Supplier<Long> pendingStreamAppendLatencySupplier) {
+        S3StreamMetricsManager.pendingStreamAppendLatencySupplier = pendingStreamAppendLatencySupplier;
     }
 
-    public static void registerPendingStreamFetchLatencySupplier(long streamId, Supplier<Long> pendingStreamFetchLatencySupplier) {
-        S3StreamMetricsManager.pendingStreamFetchLatencySupplier.put(streamId, pendingStreamFetchLatencySupplier);
-    }
-
-    public static void removePendingStreamAppendLatencySupplier(long streamId) {
-        S3StreamMetricsManager.pendingStreamAppendLatencySupplier.remove(streamId);
-    }
-
-    public static void removePendingStreamFetchLatencySupplier(long streamId) {
-        S3StreamMetricsManager.pendingStreamFetchLatencySupplier.remove(streamId);
+    public static void registerPendingStreamFetchLatencySupplier(Supplier<Long> pendingStreamFetchLatencySupplier) {
+        S3StreamMetricsManager.pendingStreamFetchLatencySupplier = pendingStreamFetchLatencySupplier;
     }
 
     public static long maxPendingStreamAppendLatency() {
-        return pendingStreamAppendLatencySupplier.values().stream().map(Supplier::get).max(Long::compareTo).orElse(0L);
+        return pendingStreamAppendLatencySupplier.get();
     }
 
     public static long maxPendingStreamFetchLatency() {
-        return pendingStreamFetchLatencySupplier.values().stream().map(Supplier::get).max(Long::compareTo).orElse(0L);
+        return pendingStreamFetchLatencySupplier.get();
     }
 
     public static void registerCompactionDelayTimeSuppler(Supplier<Long> compactionDelayTimeSupplier) {

--- a/s3stream/src/main/java/com/automq/stream/utils/PendingRequestTracker.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/PendingRequestTracker.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.utils;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+
+/**
+ * Tracks in-flight requests and reports the oldest request that remains pending beyond a latency threshold.
+ */
+public final class PendingRequestTracker implements AutoCloseable {
+    public static final long DEFAULT_LATENCY_THRESHOLD_NANOS = TimeUnit.SECONDS.toNanos(30);
+    private static final long MIN_ROTATE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(1);
+
+    private final long latencyThresholdNanos;
+    private final long rotateIntervalNanos;
+    private final LongSupplier nanoTimeSupplier;
+    private final ScheduledFuture<?> rotateTask;
+    private volatile Set<Handle> active = ConcurrentHashMap.newKeySet();
+    private volatile Set<Handle> cooling = ConcurrentHashMap.newKeySet();
+    private volatile Set<Handle> overdue = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean rotating = new AtomicBoolean(false);
+
+    public PendingRequestTracker() {
+        this(DEFAULT_LATENCY_THRESHOLD_NANOS);
+    }
+
+    public PendingRequestTracker(long latencyThresholdNanos) {
+        this(latencyThresholdNanos, System::nanoTime);
+    }
+
+    PendingRequestTracker(long latencyThresholdNanos, LongSupplier nanoTimeSupplier) {
+        if (latencyThresholdNanos <= 0) {
+            throw new IllegalArgumentException("latencyThresholdNanos must be positive");
+        }
+        this.latencyThresholdNanos = latencyThresholdNanos;
+        this.rotateIntervalNanos = Math.max(latencyThresholdNanos / 2, MIN_ROTATE_INTERVAL_NANOS);
+        this.nanoTimeSupplier = nanoTimeSupplier;
+        this.rotateTask = Threads.COMMON_SCHEDULER.scheduleWithFixedDelay(this::rotate, rotateIntervalNanos,
+            rotateIntervalNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public Handle begin() {
+        Handle handle = new Handle(nanoTimeSupplier.getAsLong());
+        active.add(handle);
+        return handle;
+    }
+
+    public long pendingLatencyNanos() {
+        long now = nanoTimeSupplier.getAsLong();
+        long oldestStartNanos = Long.MAX_VALUE;
+        for (Handle handle : overdue) {
+            if (handle.done.get()) {
+                overdue.remove(handle);
+                continue;
+            }
+            long latencyNanos = now - handle.startNanos;
+            if (latencyNanos >= latencyThresholdNanos) {
+                oldestStartNanos = Math.min(oldestStartNanos, handle.startNanos);
+            }
+        }
+        if (oldestStartNanos == Long.MAX_VALUE) {
+            return 0;
+        }
+        return now - oldestStartNanos;
+    }
+
+    @Override
+    public void close() {
+        rotateTask.cancel(false);
+        active.clear();
+        cooling.clear();
+        overdue.clear();
+    }
+
+    void rotate() {
+        if (!rotating.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            overdue.removeIf(handle -> handle.done.get());
+            // begin() may add to a stale bucket if it is paused across multiple rotations. This tracker accepts
+            // that rare race because pending latency is only a stuck-request signal: the handle may enter overdue
+            // one or more rotations later, while completed handles are still removed by close(), removeIf(), and
+            // the post-add done check.
+            Iterator<Handle> iterator = cooling.iterator();
+            while (iterator.hasNext()) {
+                Handle handle = iterator.next();
+                overdue.add(handle);
+                iterator.remove();
+                if (handle.done.get()) {
+                    overdue.remove(handle);
+                }
+            }
+            Set<Handle> tmp = cooling;
+            cooling = active;
+            active = tmp;
+        } finally {
+            rotating.set(false);
+        }
+    }
+
+    public class Handle implements AutoCloseable {
+        private final long startNanos;
+        private final AtomicBoolean done = new AtomicBoolean(false);
+
+        private Handle(long startNanos) {
+            this.startNanos = startNanos;
+        }
+
+        @Override
+        public void close() {
+            if (!done.compareAndSet(false, true)) {
+                return;
+            }
+            active.remove(this);
+            cooling.remove(this);
+            overdue.remove(this);
+        }
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/utils/PendingRequestTrackerTest.java
+++ b/s3stream/src/test/java/com/automq/stream/utils/PendingRequestTrackerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.utils;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("S3Unit")
+public class PendingRequestTrackerTest {
+    private static final long THRESHOLD_NANOS = TimeUnit.SECONDS.toNanos(30);
+
+    /**
+     * Given a pending request younger than the threshold, the tracker should not report it as stalled.
+     */
+    @Test
+    public void testPendingLatencyBeforeThreshold() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(29));
+
+        assertEquals(0, tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given multiple overdue requests, the tracker should report the oldest unfinished request age.
+     */
+    @Test
+    public void testPendingLatencyReportsOldestOverdueRequest() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(10));
+        tracker.rotate();
+        tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(45));
+        tracker.rotate();
+
+        assertEquals(TimeUnit.SECONDS.toNanos(45), tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given a request starts late in a rotation window, the tracker should keep it until it crosses the threshold.
+     */
+    @Test
+    public void testRequestLateInWindowIsNotDroppedBeforeThreshold() {
+        AtomicLong now = new AtomicLong(TimeUnit.SECONDS.toNanos(14));
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(30));
+        tracker.rotate();
+        assertEquals(0, tracker.pendingLatencyNanos());
+
+        now.set(TimeUnit.SECONDS.toNanos(45));
+        tracker.rotate();
+        assertEquals(TimeUnit.SECONDS.toNanos(31), tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given time passes without rotation, pending latency reads should not rotate buckets by themselves.
+     */
+    @Test
+    public void testPendingLatencyReadDoesNotRotateBuckets() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(45));
+
+        assertEquals(0, tracker.pendingLatencyNanos());
+
+        rotateTwice(tracker);
+
+        assertEquals(TimeUnit.SECONDS.toNanos(45), tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given an overdue request completes, the tracker should remove it from future pending latency reads.
+     */
+    @Test
+    public void testCompletedOverdueRequestIsRemoved() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        PendingRequestTracker.Handle handle = tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(45));
+        rotateTwice(tracker);
+        assertEquals(TimeUnit.SECONDS.toNanos(45), tracker.pendingLatencyNanos());
+
+        handle.close();
+
+        assertEquals(0, tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given requests complete out of order, the tracker should keep only unfinished overdue requests visible.
+     */
+    @Test
+    public void testOutOfOrderCompletionDoesNotCreateGhostPendingLatency() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        PendingRequestTracker.Handle first = tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(10));
+        tracker.rotate();
+        PendingRequestTracker.Handle second = tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(45));
+        tracker.rotate();
+
+        second.close();
+
+        assertEquals(TimeUnit.SECONDS.toNanos(45), tracker.pendingLatencyNanos());
+
+        first.close();
+
+        assertEquals(0, tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    /**
+     * Given a handle is closed repeatedly, the tracker should keep removal idempotent.
+     */
+    @Test
+    public void testHandleCloseIsIdempotent() {
+        AtomicLong now = new AtomicLong();
+        PendingRequestTracker tracker = new PendingRequestTracker(THRESHOLD_NANOS, now::get);
+
+        PendingRequestTracker.Handle handle = tracker.begin();
+        now.set(TimeUnit.SECONDS.toNanos(45));
+        rotateTwice(tracker);
+        assertEquals(TimeUnit.SECONDS.toNanos(45), tracker.pendingLatencyNanos());
+
+        handle.close();
+        handle.close();
+
+        assertEquals(0, tracker.pendingLatencyNanos());
+        tracker.close();
+    }
+
+    private static void rotateTwice(PendingRequestTracker tracker) {
+        tracker.rotate();
+        tracker.rotate();
+    }
+}


### PR DESCRIPTION
- replace per-stream pending append/fetch timestamp deque tracking with broker-level stalled request trackers
- add a utils PendingRequestTracker that reports only requests pending beyond the latency threshold
- preserve existing pending latency metric names while changing the supplier to broker-level tracking
