### PR TITLE
feat: parallelize list offset handling

### DIFF
--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -206,7 +206,6 @@ public class KafkaApisBuilder {
                              tokenManager,
                              apiVersionManager,
                              OptionConverters.toScala(clientMetricsManager),
-                             Executors.newSingleThreadExecutor(ThreadUtils.createThreadFactory("kafka-apis-async-handle-executor-%d", true)),
-                             Executors.newSingleThreadExecutor(ThreadUtils.createThreadFactory("kafka-apis-list-offset-handle-executor-%d", true)));
+                             Executors.newSingleThreadExecutor(ThreadUtils.createThreadFactory("kafka-apis-async-handle-executor-%d", true)));
     }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -27,6 +27,7 @@ import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache}
 import kafka.utils.Implicits._
 import kafka.utils.{CoreUtils, Logging}
+import com.automq.stream.utils.{Systems, ThreadUtils}
 import org.apache.kafka.admin.AdminUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, EndpointType}
@@ -81,7 +82,7 @@ import java.nio.ByteBuffer
 import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
+import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ExecutorService, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.{Collections, Optional, OptionalInt}
 import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
@@ -127,8 +128,20 @@ class KafkaApis(val requestChannel: RequestChannel,
     case _ => None
   }
 
+  // AutoMQ inject start
+  private val listOffsetFastExecutor = KafkaApis.newListOffsetExecutor("kafka-apis-list-offset-fast-%d")
+  private val listOffsetSlowExecutor = KafkaApis.newListOffsetExecutor("kafka-apis-list-offset-slow-%d")
+  private val listOffsetRequestExecutor = KafkaApis.newListOffsetExecutor("kafka-apis-list-offset-request-%d")
+  private val listOffsetInflightPartitions = new AtomicInteger(0)
+  // AutoMQ inject end
+
 
   def close(): Unit = {
+    // AutoMQ inject start
+    ThreadUtils.shutdownExecutor(listOffsetFastExecutor, 5, TimeUnit.SECONDS, logger.underlying)
+    ThreadUtils.shutdownExecutor(listOffsetSlowExecutor, 5, TimeUnit.SECONDS, logger.underlying)
+    ThreadUtils.shutdownExecutor(listOffsetRequestExecutor, 5, TimeUnit.SECONDS, logger.underlying)
+    // AutoMQ inject end
     aclApis.close()
     info("Shutdown complete.")
   }
@@ -1111,15 +1124,38 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleListOffsetRequest(request: RequestChannel.Request): Unit = {
     val version = request.header.apiVersion
+    val offsetRequest = request.body[ListOffsetsRequest]
+    val partitionCount = offsetRequest.topics.asScala.map(_.partitions.size).sum
 
-    val topics = if (version == 0) {
-      handleListOffsetRequestV0(request)
-    } else
+    // AutoMQ inject start
+    if (listOffsetInflightPartitions.get() > KafkaApis.listOffsetInflightPartitionLimit) {
+      val topics = buildListOffsetErrorTopics(offsetRequest, KafkaApis.listOffsetOverloadError)
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => new ListOffsetsResponse(new ListOffsetsResponseData()
+        .setThrottleTimeMs(requestThrottleMs)
+        .setTopics(topics.asJava)))
+      return
+    }
+    listOffsetInflightPartitions.addAndGet(partitionCount)
+    // AutoMQ inject end
+
+    // AutoMQ inject start
+    val topicsFuture = if (version == 0) {
+      CompletableFuture.supplyAsync(() => handleListOffsetRequestV0(request), listOffsetRequestExecutor)
+    } else {
       handleListOffsetRequestV1AndAbove(request)
+    }
 
-    requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => new ListOffsetsResponse(new ListOffsetsResponseData()
-      .setThrottleTimeMs(requestThrottleMs)
-      .setTopics(topics.asJava)))
+    topicsFuture.whenComplete { (topics, throwable) =>
+      listOffsetInflightPartitions.addAndGet(-partitionCount)
+      if (throwable != null) {
+        handleError(request, throwable)
+      } else {
+        requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => new ListOffsetsResponse(new ListOffsetsResponseData()
+          .setThrottleTimeMs(requestThrottleMs)
+          .setTopics(topics.asJava)))
+      }
+    }
+    // AutoMQ inject end
   }
 
   private def handleListOffsetRequestV0(request : RequestChannel.Request) : List[ListOffsetsTopicResponse] = {
@@ -1185,7 +1221,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     (responseTopics ++ unauthorizedResponseStatus).toList
   }
 
-  private def handleListOffsetRequestV1AndAbove(request : RequestChannel.Request): List[ListOffsetsTopicResponse] = {
+  private def handleListOffsetRequestV1AndAbove(request : RequestChannel.Request): CompletableFuture[List[ListOffsetsTopicResponse]] = {
     val correlationId = request.header.correlationId
     val clientId = request.header.clientId
     val offsetRequest = request.body[ListOffsetsRequest]
@@ -1216,76 +1252,100 @@ class KafkaApis(val requestChannel: RequestChannel,
           buildErrorResponse(Errors.TOPIC_AUTHORIZATION_FAILED, partition)).asJava)
     )
 
-    val responseTopics = authorizedRequestInfo.map { topic =>
-      val responsePartitions = topic.partitions.asScala.map { partition =>
+    def fetchOffsetForPartition(topicName: String, partition: ListOffsetsPartition): ListOffsetsPartitionResponse = {
+      val topicPartition = new TopicPartition(topicName, partition.partitionIndex)
+      try {
+        val fetchOnlyFromLeader = offsetRequest.replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID
+        val isClientRequest = offsetRequest.replicaId == ListOffsetsRequest.CONSUMER_REPLICA_ID
+        val isolationLevelOpt = if (isClientRequest)
+          Some(offsetRequest.isolationLevel)
+        else
+          None
+
+        val foundOpt = replicaManager.fetchOffsetForTimestamp(topicPartition,
+          partition.timestamp,
+          isolationLevelOpt,
+          if (partition.currentLeaderEpoch == ListOffsetsResponse.UNKNOWN_EPOCH) Optional.empty() else Optional.of(partition.currentLeaderEpoch),
+          fetchOnlyFromLeader)
+
+        val response = foundOpt match {
+          case Some(found) =>
+            val partitionResponse = new ListOffsetsPartitionResponse()
+              .setPartitionIndex(partition.partitionIndex)
+              .setErrorCode(Errors.NONE.code)
+              .setTimestamp(found.timestamp)
+              .setOffset(found.offset)
+            if (found.leaderEpoch.isPresent && version >= 4)
+              partitionResponse.setLeaderEpoch(found.leaderEpoch.get)
+            partitionResponse
+          case None =>
+            buildErrorResponse(Errors.NONE, partition)
+        }
+        response
+      } catch {
+        // NOTE: These exceptions are special cases since these error messages are typically transient or the client
+        // would have received a clear exception and there is no value in logging the entire stack trace for the same
+        case e @ (_ : UnknownTopicOrPartitionException |
+                  _ : NotLeaderOrFollowerException |
+                  _ : UnknownLeaderEpochException |
+                  _ : FencedLeaderEpochException |
+                  _ : KafkaStorageException |
+                  _ : UnsupportedForMessageFormatException) =>
+          debug(s"Offset request with correlation id $correlationId from client $clientId on " +
+              s"partition $topicPartition failed due to ${e.getMessage}")
+          buildErrorResponse(Errors.forException(e), partition)
+
+        // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
+        case e: OffsetNotAvailableException =>
+          if (request.header.apiVersion >= 5) {
+            buildErrorResponse(Errors.forException(e), partition)
+          } else {
+            buildErrorResponse(Errors.LEADER_NOT_AVAILABLE, partition)
+          }
+
+        case e: Throwable =>
+          error("Error while responding to offset request", e)
+          buildErrorResponse(Errors.forException(e), partition)
+      }
+    }
+
+    val responseTopicFutures = authorizedRequestInfo.map { topic =>
+      val responsePartitionFutures = topic.partitions.asScala.map { partition =>
         val topicPartition = new TopicPartition(topic.name, partition.partitionIndex)
         if (offsetRequest.duplicatePartitions.contains(topicPartition)) {
           debug(s"OffsetRequest with correlation id $correlationId from client $clientId on partition $topicPartition " +
               s"failed because the partition is duplicated in the request.")
-          buildErrorResponse(Errors.INVALID_REQUEST, partition)
+          CompletableFuture.completedFuture(buildErrorResponse(Errors.INVALID_REQUEST, partition))
         } else if (partition.timestamp() < 0 &&
           (!timestampMinSupportedVersion.contains(partition.timestamp()) || version < timestampMinSupportedVersion(partition.timestamp()))) {
-          buildErrorResponse(Errors.UNSUPPORTED_VERSION, partition)
+          CompletableFuture.completedFuture(buildErrorResponse(Errors.UNSUPPORTED_VERSION, partition))
         } else {
-          try {
-            val fetchOnlyFromLeader = offsetRequest.replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID
-            val isClientRequest = offsetRequest.replicaId == ListOffsetsRequest.CONSUMER_REPLICA_ID
-            val isolationLevelOpt = if (isClientRequest)
-              Some(offsetRequest.isolationLevel)
-            else
-              None
-
-            val foundOpt = replicaManager.fetchOffsetForTimestamp(topicPartition,
-              partition.timestamp,
-              isolationLevelOpt,
-              if (partition.currentLeaderEpoch == ListOffsetsResponse.UNKNOWN_EPOCH) Optional.empty() else Optional.of(partition.currentLeaderEpoch),
-              fetchOnlyFromLeader)
-
-            val response = foundOpt match {
-              case Some(found) =>
-                val partitionResponse = new ListOffsetsPartitionResponse()
-                  .setPartitionIndex(partition.partitionIndex)
-                  .setErrorCode(Errors.NONE.code)
-                  .setTimestamp(found.timestamp)
-                  .setOffset(found.offset)
-                if (found.leaderEpoch.isPresent && version >= 4)
-                  partitionResponse.setLeaderEpoch(found.leaderEpoch.get)
-                partitionResponse
-              case None =>
-                buildErrorResponse(Errors.NONE, partition)
-            }
-            response
-          } catch {
-            // NOTE: These exceptions are special cases since these error messages are typically transient or the client
-            // would have received a clear exception and there is no value in logging the entire stack trace for the same
-            case e @ (_ : UnknownTopicOrPartitionException |
-                      _ : NotLeaderOrFollowerException |
-                      _ : UnknownLeaderEpochException |
-                      _ : FencedLeaderEpochException |
-                      _ : KafkaStorageException |
-                      _ : UnsupportedForMessageFormatException) =>
-              debug(s"Offset request with correlation id $correlationId from client $clientId on " +
-                  s"partition $topicPartition failed due to ${e.getMessage}")
-              buildErrorResponse(Errors.forException(e), partition)
-
-            // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
-            case e: OffsetNotAvailableException =>
-              if (request.header.apiVersion >= 5) {
-                buildErrorResponse(Errors.forException(e), partition)
-              } else {
-                buildErrorResponse(Errors.LEADER_NOT_AVAILABLE, partition)
-              }
-
-            case e: Throwable =>
-              error("Error while responding to offset request", e)
-              buildErrorResponse(Errors.forException(e), partition)
-          }
+          val executor = KafkaApis.listOffsetExecutor(partition.timestamp, listOffsetFastExecutor, listOffsetSlowExecutor)
+          CompletableFuture.supplyAsync(() => fetchOffsetForPartition(topic.name, partition), executor)
         }
-      }
-      new ListOffsetsTopicResponse().setName(topic.name).setPartitions(responsePartitions.asJava)
+      }.toSeq
+      CompletableFuture.allOf(responsePartitionFutures.map(_.asInstanceOf[CompletableFuture[_]]).toArray: _*)
+        .thenApply(_ => new ListOffsetsTopicResponse()
+          .setName(topic.name)
+          .setPartitions(responsePartitionFutures.map(_.join()).asJava))
     }
-    (responseTopics ++ unauthorizedResponseStatus).toList
+    CompletableFuture.allOf(responseTopicFutures.map(_.asInstanceOf[CompletableFuture[_]]).toArray: _*)
+      .thenApply(_ => (responseTopicFutures.map(_.join()) ++ unauthorizedResponseStatus).toList)
   }
+
+  // AutoMQ inject start
+  private def buildListOffsetErrorTopics(offsetRequest: ListOffsetsRequest, error: Errors): List[ListOffsetsTopicResponse] = {
+    offsetRequest.topics.asScala.map { topic =>
+      new ListOffsetsTopicResponse()
+        .setName(topic.name)
+        .setPartitions(topic.partitions.asScala.map(partition => new ListOffsetsPartitionResponse()
+          .setPartitionIndex(partition.partitionIndex)
+          .setErrorCode(error.code)
+          .setTimestamp(ListOffsetsResponse.UNKNOWN_TIMESTAMP)
+          .setOffset(ListOffsetsResponse.UNKNOWN_OFFSET)).asJava)
+    }.toList
+  }
+  // AutoMQ inject end
 
   private def metadataResponseTopic(error: Errors,
                                     topic: String,
@@ -4179,6 +4239,37 @@ class KafkaApis(val requestChannel: RequestChannel,
 }
 
 object KafkaApis {
+  // AutoMQ inject start
+  private[server] val listOffsetThreadPoolSize: Int = Systems.CPU_CORES * 16
+  private[server] val listOffsetInflightPartitionLimit: Int = listOffsetThreadPoolSize * 4
+  private[server] val listOffsetOverloadError: Errors = Errors.REQUEST_TIMED_OUT
+
+  private[server] def isFastListOffsetTimestamp(timestamp: Long): Boolean = {
+    timestamp == ListOffsetsRequest.LATEST_TIMESTAMP ||
+      timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
+      timestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP
+  }
+
+  private[server] def listOffsetExecutor(timestamp: Long,
+                                         fastExecutor: ExecutorService,
+                                         slowExecutor: ExecutorService): ExecutorService = {
+    if (isFastListOffsetTimestamp(timestamp)) fastExecutor else slowExecutor
+  }
+
+  private[server] def newListOffsetExecutor(name: String): ThreadPoolExecutor = {
+    val executor = new ThreadPoolExecutor(
+      listOffsetThreadPoolSize,
+      listOffsetThreadPoolSize,
+      60L,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable](),
+      ThreadUtils.createFastThreadLocalThreadFactory(name, true)
+    )
+    executor.allowCoreThreadTimeOut(true)
+    executor
+  }
+  // AutoMQ inject end
+
   // Traffic from both in-sync and out of sync replicas are accounted for in replication quota to ensure total replication
   // traffic doesn't exceed quota.
   // TODO: remove resolvedResponseData method when sizeOf can take a data object.

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -82,8 +82,7 @@ class ElasticKafkaApis(
   tokenManager: DelegationTokenManager,
   apiVersionManager: ApiVersionManager,
   clientMetricsManager: Option[ClientMetricsManager],
-  val deleteTopicHandleExecutor: ExecutorService = S3StreamThreadPoolMonitor.createAndMonitor(1, 1, 0L, TimeUnit.MILLISECONDS, "kafka-apis-delete-topic-handle-executor", true, 1000),
-  val listOffsetHandleExecutor: ExecutorService = S3StreamThreadPoolMonitor.createAndMonitor(1, 1, 0L, TimeUnit.MILLISECONDS, "kafka-apis-list-offset-handle-executor", true, 1000)
+  val deleteTopicHandleExecutor: ExecutorService = S3StreamThreadPoolMonitor.createAndMonitor(1, 1, 0L, TimeUnit.MILLISECONDS, "kafka-apis-delete-topic-handle-executor", true, 1000)
 ) extends KafkaApis(requestChannel, metadataSupport, replicaManager, groupCoordinator, txnCoordinator,
   autoTopicCreationManager, brokerId, config, configRepository, metadataCache, metrics, authorizer, quotas,
   fetchManager, brokerTopicStats, clusterId, time, tokenManager, apiVersionManager, clientMetricsManager) {
@@ -886,11 +885,6 @@ class ElasticKafkaApis(
         responseCallback = processResponseCallback,
       )
     }
-  }
-
-  override def handleListOffsetRequest(request: RequestChannel.Request): Unit = {
-    // isolate to a separate thread pool to avoid blocking io thread (PRODUCE use io thread).
-    listOffsetHandleExecutor.execute(() => super.handleListOffsetRequest(request))
   }
 
   override def handleOffsetForLeaderEpochRequest(request: RequestChannel.Request): Unit = {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -6563,7 +6563,7 @@ class KafkaApisTest extends Logging {
     request: RequestChannel.Request
   ): T = {
     val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
-    verify(requestChannel).sendResponse(
+    verify(requestChannel, timeout(1000)).sendResponse(
       ArgumentMatchers.eq(request),
       capturedResponse.capture(),
       any()

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -17,6 +17,7 @@
 package kafka.server
 
 import kafka.utils.TestUtils
+import org.apache.kafka.common.errors.RetriableException
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -24,6 +25,7 @@ import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.server.config.ServerConfigs
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -41,6 +43,19 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     props.foreach { p =>
       p.put(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
     }
+  }
+
+  @Test
+  def testAutoMQListOffsetFastTimestampClassificationAndOverloadError(): Unit = {
+    assertTrue(KafkaApis.isFastListOffsetTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP))
+    assertTrue(KafkaApis.isFastListOffsetTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP))
+    assertTrue(KafkaApis.isFastListOffsetTimestamp(ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP))
+    assertFalse(KafkaApis.isFastListOffsetTimestamp(ListOffsetsRequest.MAX_TIMESTAMP))
+    assertFalse(KafkaApis.isFastListOffsetTimestamp(ListOffsetsRequest.LATEST_TIERED_TIMESTAMP))
+    assertFalse(KafkaApis.isFastListOffsetTimestamp(0L))
+
+    assertEquals(Errors.REQUEST_TIMED_OUT, KafkaApis.listOffsetOverloadError)
+    assertTrue(KafkaApis.listOffsetOverloadError.exception().isInstanceOf[RetriableException])
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticKafkaApisTest.scala
@@ -287,7 +287,6 @@ class ElasticKafkaApisTest extends KafkaApisTest {
       tokenManager = null,
       apiVersionManager = apiVersionManager,
       clientMetricsManager = clientMetricsManagerOpt,
-      MoreExecutors.newDirectExecutorService(),
       MoreExecutors.newDirectExecutorService()) {
       override protected def isExtensionApi(apiKey: ApiKeys): Boolean =
         extensionApiMatcherOverride.map(_(apiKey)).getOrElse(super.isExtensionApi(apiKey))


### PR DESCRIPTION
## Problem

AutoMQ ListOffset requests can be slow when timestamp lookups need to read sparse data from object storage. A single request may include many partitions, but the existing handling performs the per-partition `fetchOffsetForTimestamp` work sequentially, so the request latency grows with the number of partitions and slow S3-backed lookups can block the request path for a long time.

Under overload, the existing path also has no ListOffset-specific concurrency protection, so many expensive partition timestamp lookups can accumulate and amplify latency for later requests.

## Solution

This PR parallelizes ListOffset handling in `KafkaApis` while keeping the change scoped with AutoMQ inject markers:

- Runs ListOffset v1+ per-partition `replicaManager.fetchOffsetForTimestamp` calls asynchronously and combines the partition responses with `CompletableFuture`.
- Uses dedicated ListOffset executors so expensive timestamp lookups are isolated from the request thread.
- Separates fast timestamp requests (`LATEST_TIMESTAMP`, `EARLIEST_TIMESTAMP`, `EARLIEST_LOCAL_TIMESTAMP`) from other timestamp lookups with different executors.
- Keeps `MAX_TIMESTAMP` behavior unchanged.
- Adds an inflight partition counter and a limit based on the ListOffset thread pool size. When the limit is exceeded, new ListOffset requests fail fast with a retriable overload response (`REQUEST_TIMED_OUT`) instead of queueing unbounded expensive work.
- Moves the previous `ElasticKafkaApis` ListOffset delegation back into `KafkaApis`, reducing the AutoMQ-specific override surface.
