### PR TITLE
feat(tabletopic): derive identifiers from Debezium key

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -310,8 +310,8 @@ public class TopicConfig {
         "Note: 'flatten_debezium' requires schema-based conversion.";
 
     public static final String TABLE_TOPIC_ID_COLUMNS_CONFIG = "automq.table.topic.id.columns";
-    public static final String TABLE_TOPIC_ID_COLUMNS_DOC = "The primary key, comma-separated list of columns that identify a row in tables."
-        + "ex. [region, name]";
+    public static final String TABLE_TOPIC_ID_COLUMNS_DOC = "The primary key, comma-separated list of columns that identify a row in tables. "
+        + "ex. [region, name]. Use [_from_debezium_key_] to derive identifier columns from the schema-based Debezium Kafka key.";
     public static final String TABLE_TOPIC_PARTITION_BY_CONFIG = "automq.table.topic.partition.by";
     public static final String TABLE_TOPIC_PARTITION_BY_DOC = "The partition fields of the table. ex. [bucket(name), month(timestamp)]";
     public static final String TABLE_TOPIC_UPSERT_ENABLE_CONFIG = "automq.table.topic.upsert.enable";

--- a/core/src/main/java/kafka/automq/table/binder/RecordBinder.java
+++ b/core/src/main/java/kafka/automq/table/binder/RecordBinder.java
@@ -65,6 +65,14 @@ public class RecordBinder {
         this(AvroSchemaUtil.toIceberg(avroRecord.getSchema()), avroRecord.getSchema());
     }
 
+    /**
+     * Creates a binder whose Iceberg schema carries identifier field IDs resolved from column names.
+     *
+     * @param avroRecord source Avro record used to derive the Iceberg schema
+     * @param identifierColumns identifier column names to resolve, or empty when the schema has no identifiers
+     * @return a binder for the Avro record schema with matching Iceberg identifier fields
+     * @throws IllegalArgumentException if any identifier column does not exist in the derived Iceberg schema
+     */
     public static RecordBinder create(GenericRecord avroRecord, List<String> identifierColumns) {
         org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroRecord.getSchema());
         if (identifierColumns == null || identifierColumns.isEmpty()) {

--- a/core/src/main/java/kafka/automq/table/binder/RecordBinder.java
+++ b/core/src/main/java/kafka/automq/table/binder/RecordBinder.java
@@ -32,10 +32,13 @@ import org.apache.iceberg.types.Types;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.apache.avro.Schema.Type.ARRAY;
 import static org.apache.avro.Schema.Type.NULL;
@@ -60,6 +63,23 @@ public class RecordBinder {
 
     public RecordBinder(GenericRecord avroRecord) {
         this(AvroSchemaUtil.toIceberg(avroRecord.getSchema()), avroRecord.getSchema());
+    }
+
+    public static RecordBinder create(GenericRecord avroRecord, List<String> identifierColumns) {
+        org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroRecord.getSchema());
+        if (identifierColumns == null || identifierColumns.isEmpty()) {
+            return new RecordBinder(icebergSchema, avroRecord.getSchema());
+        }
+        Set<Integer> identifierFieldIds = identifierColumns.stream()
+            .map(column -> {
+                Types.NestedField field = icebergSchema.findField(column);
+                if (field == null) {
+                    throw new IllegalArgumentException(String.format("Cannot find identifier field %s in schema %s", column, icebergSchema));
+                }
+                return field.fieldId();
+            })
+            .collect(Collectors.toCollection(HashSet::new));
+        return new RecordBinder(new org.apache.iceberg.Schema(icebergSchema.columns(), identifierFieldIds), avroRecord.getSchema());
     }
 
     public RecordBinder(org.apache.iceberg.Schema icebergSchema, Schema avroSchema) {

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -83,6 +83,15 @@ public class DefaultRecordProcessor implements RecordProcessor {
         this(topicName, keyConverter, valueConverter, transforms, List.of());
     }
 
+    /**
+     * Creates a processor with explicit transforms and identifier column configuration.
+     *
+     * @param topicName source Kafka topic name
+     * @param keyConverter converter used for Kafka record keys
+     * @param valueConverter converter used for Kafka record values
+     * @param transforms ordered transform chain applied after value conversion
+     * @param idColumns configured identifier columns, or {@code [_from_debezium_key_]} to derive them from the key schema
+     */
     public DefaultRecordProcessor(String topicName, Converter keyConverter, Converter valueConverter,
                                   List<Transform> transforms, List<String> idColumns) {
         this.transformChain = transforms;

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -83,7 +83,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
     public DefaultRecordProcessor(String topicName, Converter keyConverter, Converter valueConverter,
                                   List<Transform> transforms, List<String> idColumns) {
         this.transformChain = transforms;
-        this.idColumns = idColumns;
+        this.idColumns = idColumns == null ? List.of() : List.copyOf(idColumns);
         this.topicName = topicName;
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -66,8 +66,11 @@ public class DefaultRecordProcessor implements RecordProcessor {
     private final Converter valueConverter;
     private final List<Transform> transformChain;
     private final List<String> idColumns;
+    private final boolean fromDebeziumKey;
     private final RecordAssembler recordAssembler; // Reusable assembler
     private final String transformIdentity; // precomputed transform chain identity
+    private String lastKeySchemaId;
+    private List<String> lastKeyIds = List.of();
 
     private static final int VALUE_WRAPPER_SCHEMA_CACHE_MAX = 32;
     private final Cache<String, Schema> valueWrapperSchemaCache = new LRUCache<>(VALUE_WRAPPER_SCHEMA_CACHE_MAX);
@@ -84,6 +87,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
                                   List<Transform> transforms, List<String> idColumns) {
         this.transformChain = transforms;
         this.idColumns = idColumns == null ? List.of() : List.copyOf(idColumns);
+        this.fromDebeziumKey = this.idColumns.size() == 1 && FROM_DEBEZIUM_KEY.equals(this.idColumns.get(0));
         this.topicName = topicName;
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;
@@ -110,7 +114,8 @@ public class DefaultRecordProcessor implements RecordProcessor {
             GenericRecord baseRecord = wrapValue(valueResult);
             GenericRecord transformedRecord = applyTransformChain(baseRecord, partition, kafkaRecord);
 
-            String schemaIdentity = generateCompositeSchemaIdentity(headerResult, keyResult, valueResult);
+            List<String> identifierColumns = resolveIdentifierColumns(keyResult);
+            String schemaIdentity = generateCompositeSchemaIdentity(headerResult, keyResult, valueResult, identifierColumns);
 
             GenericRecord record = recordAssembler
                 .reset(transformedRecord)
@@ -121,8 +126,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
                 .assemble();
             Schema schema = record.getSchema();
 
-            return new ProcessingResult(record, schema, schemaIdentity,
-                resolveIdentifierColumns(keyResult.getSchema()));
+            return new ProcessingResult(record, schema, schemaIdentity, identifierColumns);
         } catch (ConverterException e) {
             return getProcessingResult(kafkaRecord, "Convert operation failed for record: %s", DataError.ErrorType.CONVERT_ERROR, e);
         } catch (TransformException e) {
@@ -142,10 +146,21 @@ public class DefaultRecordProcessor implements RecordProcessor {
         }
     }
 
-    private List<String> resolveIdentifierColumns(Schema keySchema) {
-        if (idColumns.size() != 1 || !FROM_DEBEZIUM_KEY.equals(idColumns.get(0))) {
+    private List<String> resolveIdentifierColumns(ConversionResult keyResult) {
+        if (!fromDebeziumKey) {
             return idColumns;
         }
+        String keySchemaId = keyResult.getSchemaIdentity();
+        if (Objects.equals(lastKeySchemaId, keySchemaId)) {
+            return lastKeyIds;
+        }
+        List<String> ids = resolveIdentifierColumns(keyResult.getSchema());
+        lastKeySchemaId = keySchemaId;
+        lastKeyIds = ids;
+        return ids;
+    }
+
+    private List<String> resolveIdentifierColumns(Schema keySchema) {
         Schema unwrappedKeySchema = unwrapNullable(keySchema);
         if (unwrappedKeySchema == null || unwrappedKeySchema.getType() != Schema.Type.RECORD) {
             return List.of();
@@ -257,12 +272,14 @@ public class DefaultRecordProcessor implements RecordProcessor {
     private String generateCompositeSchemaIdentity(
         ConversionResult headerResult,
         ConversionResult keyResult,
-        ConversionResult valueResult) {
+        ConversionResult valueResult,
+        List<String> identifierColumns) {
         // Extract schema identities
         String headerIdentity = headerResult.getSchemaIdentity();
         String keyIdentity = keyResult.getSchemaIdentity();
         String valueIdentity = valueResult.getSchemaIdentity();
-        return "h:" + headerIdentity + "|v:" + valueIdentity + "|k:" + keyIdentity + "|t:" + transformIdentity;
+        return "h:" + headerIdentity + "|v:" + valueIdentity + "|k:" + keyIdentity + "|t:" + transformIdentity
+            + "|id:" + identifierColumns.hashCode();
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -279,7 +279,15 @@ public class DefaultRecordProcessor implements RecordProcessor {
         String keyIdentity = keyResult.getSchemaIdentity();
         String valueIdentity = valueResult.getSchemaIdentity();
         return "h:" + headerIdentity + "|v:" + valueIdentity + "|k:" + keyIdentity + "|t:" + transformIdentity
-            + "|id:" + identifierColumns.hashCode();
+            + "|id:" + encodeIdentifierColumns(identifierColumns);
+    }
+
+    private String encodeIdentifierColumns(List<String> identifierColumns) {
+        StringBuilder builder = new StringBuilder();
+        for (String column : identifierColumns) {
+            builder.append(column.length()).append('#').append(column);
+        }
+        return builder.toString();
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -36,7 +36,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +47,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static kafka.automq.table.process.RecordAssembler.KAFKA_VALUE_FIELD;
 import static kafka.automq.table.process.RecordAssembler.ensureOptional;
+import static org.apache.kafka.server.common.automq.TableTopicConfigValidator.FROM_DEBEZIUM_KEY;
 
 /**
  * Default implementation of RecordProcessor using a two-stage processing pipeline.
@@ -65,6 +65,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
     private final Converter keyConverter;
     private final Converter valueConverter;
     private final List<Transform> transformChain;
+    private final List<String> idColumns;
     private final RecordAssembler recordAssembler; // Reusable assembler
     private final String transformIdentity; // precomputed transform chain identity
 
@@ -72,16 +73,17 @@ public class DefaultRecordProcessor implements RecordProcessor {
     private final Cache<String, Schema> valueWrapperSchemaCache = new LRUCache<>(VALUE_WRAPPER_SCHEMA_CACHE_MAX);
 
     public DefaultRecordProcessor(String topicName, Converter keyConverter, Converter valueConverter) {
-        this.transformChain = new ArrayList<>();
-        this.topicName = topicName;
-        this.keyConverter = keyConverter;
-        this.valueConverter = valueConverter;
-        this.recordAssembler = new RecordAssembler();
-        this.transformIdentity = ""; // no transforms
+        this(topicName, keyConverter, valueConverter, List.of(), List.of());
     }
 
     public DefaultRecordProcessor(String topicName, Converter keyConverter, Converter valueConverter, List<Transform> transforms) {
+        this(topicName, keyConverter, valueConverter, transforms, List.of());
+    }
+
+    public DefaultRecordProcessor(String topicName, Converter keyConverter, Converter valueConverter,
+                                  List<Transform> transforms, List<String> idColumns) {
         this.transformChain = transforms;
+        this.idColumns = idColumns;
         this.topicName = topicName;
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;
@@ -119,7 +121,8 @@ public class DefaultRecordProcessor implements RecordProcessor {
                 .assemble();
             Schema schema = record.getSchema();
 
-            return new ProcessingResult(record, schema, schemaIdentity);
+            return new ProcessingResult(record, schema, schemaIdentity,
+                resolveIdentifierColumns(keyResult.getSchema()));
         } catch (ConverterException e) {
             return getProcessingResult(kafkaRecord, "Convert operation failed for record: %s", DataError.ErrorType.CONVERT_ERROR, e);
         } catch (TransformException e) {
@@ -137,6 +140,36 @@ public class DefaultRecordProcessor implements RecordProcessor {
             }
             return getProcessingResult(kafkaRecord, "Unexpected error processing record: %s", DataError.ErrorType.UNKNOW_ERROR, e);
         }
+    }
+
+    private List<String> resolveIdentifierColumns(Schema keySchema) {
+        if (idColumns.size() != 1 || !FROM_DEBEZIUM_KEY.equals(idColumns.get(0))) {
+            return idColumns;
+        }
+        Schema unwrappedKeySchema = unwrapNullable(keySchema);
+        if (unwrappedKeySchema == null || unwrappedKeySchema.getType() != Schema.Type.RECORD) {
+            return List.of();
+        }
+        return unwrappedKeySchema.getFields().stream()
+            .map(Schema.Field::name)
+            .toList();
+    }
+
+    private Schema unwrapNullable(Schema schema) {
+        if (schema == null || schema.getType() != Schema.Type.UNION) {
+            return schema;
+        }
+        Schema nonNull = null;
+        for (Schema type : schema.getTypes()) {
+            if (type.getType() == Schema.Type.NULL) {
+                continue;
+            }
+            if (nonNull != null) {
+                return schema;
+            }
+            nonNull = type;
+        }
+        return nonNull;
     }
 
     // io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient#isSchemaOrSubjectNotFoundException

--- a/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
+++ b/core/src/main/java/kafka/automq/table/process/DefaultRecordProcessor.java
@@ -59,6 +59,7 @@ import static org.apache.kafka.server.common.automq.TableTopicConfigValidator.FR
 public class DefaultRecordProcessor implements RecordProcessor {
     private static final Schema HEADER_SCHEMA = Schema.createMap(Schema.create(Schema.Type.BYTES));
     private static final String HEADER_SCHEMA_IDENTITY = String.valueOf(HEADER_SCHEMA.hashCode());
+    private static final String NULL_KEY_SCHEMA_IDENTITY = "null";
     private static final ConversionResult EMPTY_HEADERS_RESULT =
         new ConversionResult(Map.of(), HEADER_SCHEMA, HEADER_SCHEMA_IDENTITY);
     private final String topicName;
@@ -117,7 +118,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
             Objects.requireNonNull(kafkaRecord, "Kafka record cannot be null");
 
             ConversionResult headerResult = processHeaders(kafkaRecord);
-            ConversionResult keyResult = keyConverter.convert(topicName, kafkaRecord.key());
+            ConversionResult keyResult = convertKey(kafkaRecord);
             ConversionResult valueResult = valueConverter.convert(topicName, kafkaRecord.value());
 
             GenericRecord baseRecord = wrapValue(valueResult);
@@ -159,6 +160,9 @@ public class DefaultRecordProcessor implements RecordProcessor {
         if (!fromDebeziumKey) {
             return idColumns;
         }
+        if (keyResult == null) {
+            return List.of();
+        }
         String keySchemaId = keyResult.getSchemaIdentity();
         if (Objects.equals(lastKeySchemaId, keySchemaId)) {
             return lastKeyIds;
@@ -167,6 +171,13 @@ public class DefaultRecordProcessor implements RecordProcessor {
         lastKeySchemaId = keySchemaId;
         lastKeyIds = ids;
         return ids;
+    }
+
+    private ConversionResult convertKey(Record kafkaRecord) throws ConverterException {
+        if (fromDebeziumKey && kafkaRecord.key() == null) {
+            return null;
+        }
+        return keyConverter.convert(topicName, kafkaRecord.key());
     }
 
     private List<String> resolveIdentifierColumns(Schema keySchema) {
@@ -285,7 +296,7 @@ public class DefaultRecordProcessor implements RecordProcessor {
         List<String> identifierColumns) {
         // Extract schema identities
         String headerIdentity = headerResult.getSchemaIdentity();
-        String keyIdentity = keyResult.getSchemaIdentity();
+        String keyIdentity = keyResult == null ? NULL_KEY_SCHEMA_IDENTITY : keyResult.getSchemaIdentity();
         String valueIdentity = valueResult.getSchemaIdentity();
         return "h:" + headerIdentity + "|v:" + valueIdentity + "|k:" + keyIdentity + "|t:" + transformIdentity
             + "|id:" + encodeIdentifierColumns(identifierColumns);

--- a/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
+++ b/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
@@ -62,7 +62,7 @@ public final class ProcessingResult {
         this.finalRecord = Objects.requireNonNull(finalRecord, "finalRecord cannot be null");
         this.finalSchema = Objects.requireNonNull(finalSchema, "finalSchema cannot be null");
         this.finalSchemaIdentity = Objects.requireNonNull(finalSchemaIdentity, "finalSchemaIdentity cannot be null");
-        this.identifierColumns = Objects.requireNonNull(identifierColumns, "identifierColumns cannot be null");
+        this.identifierColumns = identifierColumns == null ? List.of() : List.copyOf(identifierColumns);
         this.error = null;
     }
 
@@ -108,17 +108,18 @@ public final class ProcessingResult {
         return Objects.equals(finalRecord, that.finalRecord) &&
                Objects.equals(finalSchema, that.finalSchema) &&
                Objects.equals(finalSchemaIdentity, that.finalSchemaIdentity) &&
+               Objects.equals(identifierColumns, that.identifierColumns) &&
                Objects.equals(error, that.error);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(finalRecord, finalSchema, finalSchemaIdentity, error);
+        return Objects.hash(finalRecord, finalSchema, finalSchemaIdentity, identifierColumns, error);
     }
 
     @Override
     public String toString() {
-        if (!isSuccess()) {
+        if (isSuccess()) {
             return "ProcessingResult{success=true, schemaIdentity=" + finalSchemaIdentity + "}";
         } else {
             return "ProcessingResult{success=false, error=" + error + "}";

--- a/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
+++ b/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
@@ -22,6 +22,7 @@ package kafka.automq.table.process;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -42,6 +43,7 @@ public final class ProcessingResult {
     private final GenericRecord finalRecord;
     private final Schema finalSchema;
     private final String finalSchemaIdentity;
+    private final List<String> identifierColumns;
     private final DataError error;
 
     /**
@@ -53,9 +55,14 @@ public final class ProcessingResult {
      * @throws IllegalArgumentException if any parameter is null
      */
     public ProcessingResult(GenericRecord finalRecord, Schema finalSchema, String finalSchemaIdentity) {
+        this(finalRecord, finalSchema, finalSchemaIdentity, List.of());
+    }
+
+    public ProcessingResult(GenericRecord finalRecord, Schema finalSchema, String finalSchemaIdentity, List<String> identifierColumns) {
         this.finalRecord = Objects.requireNonNull(finalRecord, "finalRecord cannot be null");
         this.finalSchema = Objects.requireNonNull(finalSchema, "finalSchema cannot be null");
         this.finalSchemaIdentity = Objects.requireNonNull(finalSchemaIdentity, "finalSchemaIdentity cannot be null");
+        this.identifierColumns = Objects.requireNonNull(identifierColumns, "identifierColumns cannot be null");
         this.error = null;
     }
 
@@ -69,6 +76,7 @@ public final class ProcessingResult {
         this.finalRecord = null;
         this.finalSchema = null;
         this.finalSchemaIdentity = null;
+        this.identifierColumns = List.of();
         this.error = Objects.requireNonNull(error, "error cannot be null");
     }
 
@@ -83,6 +91,9 @@ public final class ProcessingResult {
     }
     public DataError getError() {
         return error;
+    }
+    public List<String> getIdentifierColumns() {
+        return identifierColumns;
     }
     public boolean isSuccess() {
         return error == null;

--- a/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
+++ b/core/src/main/java/kafka/automq/table/process/ProcessingResult.java
@@ -58,6 +58,15 @@ public final class ProcessingResult {
         this(finalRecord, finalSchema, finalSchemaIdentity, List.of());
     }
 
+    /**
+     * Creates a successful processing result with the resolved identifier columns.
+     *
+     * @param finalRecord the Avro GenericRecord ready for further processing, must not be null
+     * @param finalSchema the Avro schema matching the finalRecord, must not be null
+     * @param finalSchemaIdentity unique identifier for schema and identifier comparison, must not be null
+     * @param identifierColumns resolved identifier column names, or empty when no identifier columns apply
+     * @throws IllegalArgumentException if finalRecord, finalSchema, or finalSchemaIdentity is null
+     */
     public ProcessingResult(GenericRecord finalRecord, Schema finalSchema, String finalSchemaIdentity, List<String> identifierColumns) {
         this.finalRecord = Objects.requireNonNull(finalRecord, "finalRecord cannot be null");
         this.finalSchema = Objects.requireNonNull(finalSchema, "finalSchema cannot be null");
@@ -92,6 +101,9 @@ public final class ProcessingResult {
     public DataError getError() {
         return error;
     }
+    /**
+     * Returns the resolved identifier column names that should be applied to the Iceberg schema.
+     */
     public List<String> getIdentifierColumns() {
         return identifierColumns;
     }

--- a/core/src/main/java/kafka/automq/table/process/RecordProcessorFactory.java
+++ b/core/src/main/java/kafka/automq/table/process/RecordProcessorFactory.java
@@ -65,7 +65,7 @@ public class RecordProcessorFactory {
 
         var transforms = createTransforms(config.transformType());
 
-        return new DefaultRecordProcessor(topic, keyConverter, valueConverter, transforms);
+        return new DefaultRecordProcessor(topic, keyConverter, valueConverter, transforms, config.idColumns());
     }
 
     private List<Transform> createTransforms(TableTopicTransformType transformType) {

--- a/core/src/main/java/kafka/automq/table/worker/IcebergTableManager.java
+++ b/core/src/main/java/kafka/automq/table/worker/IcebergTableManager.java
@@ -155,11 +155,11 @@ public class IcebergTableManager {
      * @param changes list of schema changes
      */
     @VisibleForTesting
-    protected synchronized void applySchemaChange(Table table, List<SchemaChange> changes) {
+    protected void applySchemaChange(Table table, List<SchemaChange> changes) {
         applySchemaChange(table, changes, Set.of());
     }
 
-    protected synchronized void applySchemaChange(Table table, List<SchemaChange> changes, Set<String> expectedIdentifierFieldNames) {
+    private synchronized void applySchemaChange(Table table, List<SchemaChange> changes, Set<String> expectedIdentifierFieldNames) {
         LOGGER.info("Applying schema changes to table {}, changes {}, identifier fields {}",
             tableId, changes.stream().map(c -> c.getType() + ":" + c.getColumnFullName()).toList(), expectedIdentifierFieldNames);
         Tasks.range(1)
@@ -168,7 +168,8 @@ public class IcebergTableManager {
         table.refresh();
     }
 
-    protected synchronized void ensureIdentifierFields(Table table, Set<String> expectedIdentifierFieldNames) {
+    @VisibleForTesting
+    protected void ensureIdentifierFields(Table table, Set<String> expectedIdentifierFieldNames) {
         if (expectedIdentifierFieldNames.isEmpty()) {
             return;
         }

--- a/core/src/main/java/kafka/automq/table/worker/IcebergTableManager.java
+++ b/core/src/main/java/kafka/automq/table/worker/IcebergTableManager.java
@@ -45,7 +45,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class IcebergTableManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(IcebergTableManager.class);
@@ -115,13 +117,15 @@ public class IcebergTableManager {
     public boolean handleSchemaChangesWithFlush(Schema schema, FlushAction flush) throws IOException {
         Table currentTable = getTableOrCreate(schema);
         List<SchemaChange> changes = checkSchemaChanges(currentTable, schema);
-        if (changes.isEmpty()) {
+        Set<String> expectedIdentifierFieldNames = identifierFieldNames(schema);
+        boolean identifierFieldsChanged = identifierFieldsChanged(currentTable, expectedIdentifierFieldNames);
+        if (changes.isEmpty() && !identifierFieldsChanged) {
             return false;
         }
 
         flush.perform();
 
-        applySchemaChange(currentTable, changes);
+        applySchemaChange(currentTable, changes, expectedIdentifierFieldNames);
         return true;
     }
 
@@ -152,11 +156,41 @@ public class IcebergTableManager {
      */
     @VisibleForTesting
     protected synchronized void applySchemaChange(Table table, List<SchemaChange> changes) {
-        LOGGER.info("Applying schema changes to table {}, changes {}", tableId, changes.stream().map(c -> c.getType() + ":" + c.getColumnFullName()).toList());
+        applySchemaChange(table, changes, Set.of());
+    }
+
+    protected synchronized void applySchemaChange(Table table, List<SchemaChange> changes, Set<String> expectedIdentifierFieldNames) {
+        LOGGER.info("Applying schema changes to table {}, changes {}, identifier fields {}",
+            tableId, changes.stream().map(c -> c.getType() + ":" + c.getColumnFullName()).toList(), expectedIdentifierFieldNames);
         Tasks.range(1)
             .retry(2)
-            .run(notUsed -> applyChanges(table, changes));
+            .run(notUsed -> applyChanges(table, changes, expectedIdentifierFieldNames));
         table.refresh();
+    }
+
+    protected synchronized void ensureIdentifierFields(Table table, Set<String> expectedIdentifierFieldNames) {
+        if (expectedIdentifierFieldNames.isEmpty()) {
+            return;
+        }
+        table.refresh();
+        Set<String> currentIdentifierFieldNames = identifierFieldNames(table.schema());
+        if (currentIdentifierFieldNames.equals(expectedIdentifierFieldNames)) {
+            return;
+        }
+        LOGGER.info("Setting identifier fields for table {}, fields {}, previous fields {}",
+            tableId, expectedIdentifierFieldNames, currentIdentifierFieldNames);
+        applySchemaChange(table, List.of(), expectedIdentifierFieldNames);
+    }
+
+    private boolean identifierFieldsChanged(Table table, Set<String> expectedIdentifierFieldNames) {
+        return !expectedIdentifierFieldNames.isEmpty()
+            && !identifierFieldNames(table.schema()).equals(expectedIdentifierFieldNames);
+    }
+
+    private Set<String> identifierFieldNames(Schema schema) {
+        return schema.identifierFieldIds().stream()
+            .map(id -> schema.findField(id).name())
+            .collect(Collectors.toSet());
     }
 
     private static UpdateSchema applySchemaChange(UpdateSchema updateSchema, SchemaChange change) {
@@ -303,11 +337,24 @@ public class IcebergTableManager {
         return oldType.typeId() == Type.TypeID.FLOAT && newType.typeId() == Type.TypeID.DOUBLE;
     }
 
-    private void applyChanges(Table table, List<SchemaChange> changes) {
+    private void applyChanges(Table table, List<SchemaChange> changes, Set<String> expectedIdentifierFieldNames) {
         table.refresh();
         UpdateSchema updateSchema = table.updateSchema();
-        changes.stream().filter(c -> !shouldSkipChange(table.schema(), c))
-            .forEach(c -> applySchemaChange(updateSchema, c));
+        boolean changed = false;
+        for (SchemaChange change : changes) {
+            if (!shouldSkipChange(table.schema(), change)) {
+                applySchemaChange(updateSchema, change);
+                changed = true;
+            }
+        }
+        if (!expectedIdentifierFieldNames.isEmpty()
+            && !identifierFieldNames(table.schema()).equals(expectedIdentifierFieldNames)) {
+            updateSchema.setIdentifierFields(expectedIdentifierFieldNames);
+            changed = true;
+        }
+        if (!changed) {
+            return;
+        }
         updateSchema.commit();
     }
 

--- a/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
+++ b/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
@@ -73,8 +73,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.toSet;
-
 public class IcebergWriter implements Writer {
     private static final Logger LOGGER = LoggerFactory.getLogger(IcebergWriter.class);
     private static final int TARGET_FILE_SIZE = 64 * 1024 * 1024;
@@ -160,16 +158,17 @@ public class IcebergWriter implements Writer {
         }
 
         GenericRecord finalRecord = result.getFinalRecord();
+        List<String> identifierColumns = result.getIdentifierColumns();
 
         RecordBinder currentBinder = this.binder;
         // first write
         if (currentBinder == null) {
-            currentBinder = new RecordBinder(finalRecord);
+            currentBinder = RecordBinder.create(finalRecord, identifierColumns);
         }
 
         // schema change
         if (!result.getFinalSchemaIdentity().equals(lastSchemaIdentity)) {
-            Schema icebergSchema = new RecordBinder(finalRecord).getIcebergSchema();
+            Schema icebergSchema = RecordBinder.create(finalRecord, identifierColumns).getIcebergSchema();
             //  compare table schema and evolution
             icebergTableManager.handleSchemaChangesWithFlush(
                 icebergSchema,
@@ -350,11 +349,6 @@ public class IcebergWriter implements Writer {
         FileAppenderFactory<Record> appenderFactory;
 
         Set<Integer> identifierFieldIds = table.schema().identifierFieldIds();
-        if (!config.idColumns().isEmpty()) {
-            identifierFieldIds = config.idColumns().stream()
-                .map(colName -> table.schema().findField(colName).fieldId())
-                .collect(toSet());
-        }
         // Use a consistent partition spec instead of retrieve from table in real times.
         PartitionSpec spec = icebergTableManager.spec();
         if (identifierFieldIds.isEmpty()) {

--- a/core/src/test/java/kafka/automq/table/binder/AvroRecordBinderTest.java
+++ b/core/src/test/java/kafka/automq/table/binder/AvroRecordBinderTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -48,6 +49,33 @@ class AvroRecordBinderTest {
 
     static {
         CodecSetup.setup();
+    }
+
+    /**
+     * Given identifier columns, RecordBinder should carry the matching Iceberg
+     * field IDs into the generated schema.
+     */
+    @Test
+    public void testCreateWithIdentifierColumns() {
+        Schema avroSchema = Schema.createRecord("IdentifierRoot", null, TEST_NAMESPACE, false);
+        avroSchema.setFields(Arrays.asList(
+            new Schema.Field("region_id", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("user_id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)
+        ));
+
+        GenericRecord record = new GenericData.Record(avroSchema);
+        record.put("region_id", "us-east-1");
+        record.put("user_id", 42L);
+        record.put("name", "alice");
+
+        org.apache.iceberg.Schema icebergSchema = RecordBinder.create(record, List.of("region_id", "user_id"))
+            .getIcebergSchema();
+
+        assertEquals(Set.of(
+            icebergSchema.findField("region_id").fieldId(),
+            icebergSchema.findField("user_id").fieldId()
+        ), icebergSchema.identifierFieldIds());
     }
 
     /**

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -231,6 +231,23 @@ public class DefaultRecordProcessorTest {
     }
 
     @Test
+    void testSchemaIdentityIncludesIdentifierColumns() {
+        Converter rawConverter = new RawConverter();
+        Record kafkaRecord = createKafkaRecord("key".getBytes(), "value".getBytes(), new Header[0]);
+        DefaultRecordProcessor idProcessor = new DefaultRecordProcessor(TEST_TOPIC, rawConverter, rawConverter,
+            List.of(), List.of("id"));
+        DefaultRecordProcessor appointmentIdProcessor = new DefaultRecordProcessor(TEST_TOPIC, rawConverter, rawConverter,
+            List.of(), List.of("appointment_id"));
+
+        ProcessingResult idResult = idProcessor.process(TEST_PARTITION, kafkaRecord);
+        ProcessingResult appointmentIdResult = appointmentIdProcessor.process(TEST_PARTITION, kafkaRecord);
+
+        assertTrue(idResult.isSuccess());
+        assertTrue(appointmentIdResult.isSuccess());
+        assertNotEquals(idResult.getFinalSchemaIdentity(), appointmentIdResult.getFinalSchemaIdentity());
+    }
+
+    @Test
     void testConverterErrorHandling() {
         // Arrange
         Converter errorConverter = (topic, buffer) -> {
@@ -417,7 +434,7 @@ public class DefaultRecordProcessorTest {
         ProcessingResult orderedResult = ordered.process(TEST_PARTITION, kafkaRecord);
         assertTrue(orderedResult.isSuccess());
         String orderedIdentity = orderedResult.getFinalSchemaIdentity();
-        assertTrue(orderedIdentity.endsWith("|t:A,B"));
+        assertTrue(orderedIdentity.contains("|t:A,B|id:"));
 
         DefaultRecordProcessor reversed = new DefaultRecordProcessor(TEST_TOPIC, keyConverter, valueConverter,
             List.of(new NamedPassthroughTransform("B"), new NamedPassthroughTransform("A")));

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -237,6 +237,22 @@ public class DefaultRecordProcessorTest {
     }
 
     /**
+     * Given a schema-id key converter and a null key, the Debezium key sentinel silently resolves no identifiers.
+     */
+    @Test
+    void testIdentifierColumnsFromDebeziumKeySkipsSchemaIdConverterWhenKeyMissing() {
+        DefaultRecordProcessor processor = new DefaultRecordProcessor(TEST_TOPIC,
+            new AvroRegistryConverter(schemaRegistryClient, "http://mock:8081", true), new StringConverter(),
+            List.of(), List.of("_from_debezium_key_"));
+
+        ProcessingResult result = processor.process(TEST_PARTITION,
+            createKafkaRecord(null, "value".getBytes(), new Header[0]));
+
+        assertTrue(result.isSuccess());
+        assertEquals(List.of(), result.getIdentifierColumns());
+    }
+
+    /**
      * Given unchanged record schemas, changing identifier columns must still change the composite schema identity.
      */
     @Test

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -196,6 +196,41 @@ public class DefaultRecordProcessorTest {
     }
 
     @Test
+    void testIdentifierColumnsFromDebeziumKeySchema() {
+        Schema keySchema = SchemaBuilder.record("Key")
+            .namespace("kafka.automq.table.process")
+            .fields()
+            .name("region_id").type().stringType().noDefault()
+            .name("user_id").type().longType().noDefault()
+            .endRecord();
+        Converter keyConverter = (topic, buffer) -> new ConversionResult(new GenericRecordBuilder(keySchema)
+            .set("region_id", "us-east-1")
+            .set("user_id", 42L)
+            .build(), "key-schema");
+        Converter valueConverter = new StringConverter();
+        DefaultRecordProcessor processor = new DefaultRecordProcessor(TEST_TOPIC, keyConverter, valueConverter,
+            List.of(), List.of("_from_debezium_key_"));
+
+        ProcessingResult result = processor.process(TEST_PARTITION,
+            createKafkaRecord("key".getBytes(), "value".getBytes(), new Header[0]));
+
+        assertTrue(result.isSuccess());
+        assertEquals(List.of("region_id", "user_id"), result.getIdentifierColumns());
+    }
+
+    @Test
+    void testIdentifierColumnsFromDebeziumKeySchemaFallbackWhenKeySchemaMissing() {
+        DefaultRecordProcessor processor = new DefaultRecordProcessor(TEST_TOPIC, new StringConverter(), new StringConverter(),
+            List.of(), List.of("_from_debezium_key_"));
+
+        ProcessingResult result = processor.process(TEST_PARTITION,
+            createKafkaRecord("key".getBytes(), "value".getBytes(), new Header[0]));
+
+        assertTrue(result.isSuccess());
+        assertEquals(List.of(), result.getIdentifierColumns());
+    }
+
+    @Test
     void testConverterErrorHandling() {
         // Arrange
         Converter errorConverter = (topic, buffer) -> {

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -195,6 +195,9 @@ public class DefaultRecordProcessorTest {
         assertEquals(ByteBuffer.wrap(value), ByteBuffer.wrap((byte[]) finalRecord.get(RecordAssembler.KAFKA_VALUE_FIELD)));
     }
 
+    /**
+     * Given the Debezium key sentinel, the processor derives identifier columns from the key record schema.
+     */
     @Test
     void testIdentifierColumnsFromDebeziumKeySchema() {
         Schema keySchema = SchemaBuilder.record("Key")
@@ -218,6 +221,9 @@ public class DefaultRecordProcessorTest {
         assertEquals(List.of("region_id", "user_id"), result.getIdentifierColumns());
     }
 
+    /**
+     * Given the Debezium key sentinel with a converter that has no key schema, the processor keeps processing silently.
+     */
     @Test
     void testIdentifierColumnsFromDebeziumKeySchemaFallbackWhenKeySchemaMissing() {
         DefaultRecordProcessor processor = new DefaultRecordProcessor(TEST_TOPIC, new StringConverter(), new StringConverter(),
@@ -230,6 +236,9 @@ public class DefaultRecordProcessorTest {
         assertEquals(List.of(), result.getIdentifierColumns());
     }
 
+    /**
+     * Given unchanged record schemas, changing identifier columns must still change the composite schema identity.
+     */
     @Test
     void testSchemaIdentityIncludesIdentifierColumns() {
         Converter rawConverter = new RawConverter();
@@ -268,6 +277,9 @@ public class DefaultRecordProcessorTest {
         assertNotEquals(fbResult.getFinalSchemaIdentity(), eaResult.getFinalSchemaIdentity());
     }
 
+    /**
+     * Given otherwise equal processing results, resolved identifier columns participate in equality and hash code.
+     */
     @Test
     void testProcessingResultEqualityIncludesIdentifierColumns() {
         GenericRecord record = new GenericRecordBuilder(USER_SCHEMA_V1)

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -248,6 +248,22 @@ public class DefaultRecordProcessorTest {
     }
 
     @Test
+    void testProcessingResultEqualityIncludesIdentifierColumns() {
+        GenericRecord record = new GenericRecordBuilder(USER_SCHEMA_V1)
+            .set("name", "test-user")
+            .build();
+        ProcessingResult emptyIdentifiers = new ProcessingResult(record, USER_SCHEMA_V1, "schema-id");
+        ProcessingResult explicitEmptyIdentifiers = new ProcessingResult(record, USER_SCHEMA_V1, "schema-id", List.of());
+        ProcessingResult idIdentifiers = new ProcessingResult(record, USER_SCHEMA_V1, "schema-id", List.of("id"));
+        ProcessingResult userIdIdentifiers = new ProcessingResult(record, USER_SCHEMA_V1, "schema-id", List.of("user_id"));
+
+        assertEquals(emptyIdentifiers, explicitEmptyIdentifiers);
+        assertEquals(emptyIdentifiers.hashCode(), explicitEmptyIdentifiers.hashCode());
+        assertNotEquals(idIdentifiers, userIdIdentifiers);
+        assertNotEquals(idIdentifiers.hashCode(), userIdIdentifiers.hashCode());
+    }
+
+    @Test
     void testConverterErrorHandling() {
         // Arrange
         Converter errorConverter = (topic, buffer) -> {

--- a/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
+++ b/core/src/test/java/kafka/automq/table/process/DefaultRecordProcessorTest.java
@@ -247,6 +247,27 @@ public class DefaultRecordProcessorTest {
         assertNotEquals(idResult.getFinalSchemaIdentity(), appointmentIdResult.getFinalSchemaIdentity());
     }
 
+    /**
+     * Given identifier column names with colliding hash codes, schema identity must still distinguish them.
+     */
+    @Test
+    void testSchemaIdentityDistinguishesIdentifierHashCollisions() {
+        Converter rawConverter = new RawConverter();
+        Record kafkaRecord = createKafkaRecord("key".getBytes(), "value".getBytes(), new Header[0]);
+        DefaultRecordProcessor fbProcessor = new DefaultRecordProcessor(TEST_TOPIC, rawConverter, rawConverter,
+            List.of(), List.of("FB"));
+        DefaultRecordProcessor eaProcessor = new DefaultRecordProcessor(TEST_TOPIC, rawConverter, rawConverter,
+            List.of(), List.of("Ea"));
+
+        ProcessingResult fbResult = fbProcessor.process(TEST_PARTITION, kafkaRecord);
+        ProcessingResult eaResult = eaProcessor.process(TEST_PARTITION, kafkaRecord);
+
+        assertEquals(List.of("FB").hashCode(), List.of("Ea").hashCode());
+        assertTrue(fbResult.isSuccess());
+        assertTrue(eaResult.isSuccess());
+        assertNotEquals(fbResult.getFinalSchemaIdentity(), eaResult.getFinalSchemaIdentity());
+    }
+
     @Test
     void testProcessingResultEqualityIncludesIdentifierColumns() {
         GenericRecord record = new GenericRecordBuilder(USER_SCHEMA_V1)

--- a/core/src/test/java/kafka/automq/table/worker/IcebergTableManagerTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/IcebergTableManagerTest.java
@@ -421,6 +421,9 @@ public class IcebergTableManagerTest {
         assertTrue(schemaChanges.isEmpty());
     }
 
+    /**
+     * Given a table without identifiers, ensureIdentifierFields commits the expected identifier field IDs.
+     */
     @Test
     public void setsIdentifierFieldsWhenTableHasNone() {
         TableIdentifier tableId = randomTableId();
@@ -438,6 +441,9 @@ public class IcebergTableManagerTest {
         ), updatedTable.schema().identifierFieldIds());
     }
 
+    /**
+     * Given a table with stale identifiers, ensureIdentifierFields replaces them with the expected set.
+     */
     @Test
     public void updatesExistingIdentifierFields() {
         TableIdentifier tableId = randomTableId();

--- a/core/src/test/java/kafka/automq/table/worker/IcebergTableManagerTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/IcebergTableManagerTest.java
@@ -40,6 +40,7 @@ import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -421,6 +422,40 @@ public class IcebergTableManagerTest {
     }
 
     @Test
+    public void setsIdentifierFieldsWhenTableHasNone() {
+        TableIdentifier tableId = randomTableId();
+        IcebergTableManager manager = newManager(tableId);
+        Table table = manager.getTableOrCreate(new Schema(
+            Types.NestedField.required(1, "region_id", Types.StringType.get()),
+            Types.NestedField.required(2, "user_id", Types.LongType.get())));
+
+        manager.ensureIdentifierFields(table, Set.of("region_id", "user_id"));
+
+        Table updatedTable = catalog.loadTable(tableId);
+        assertEquals(Set.of(
+            updatedTable.schema().findField("region_id").fieldId(),
+            updatedTable.schema().findField("user_id").fieldId()
+        ), updatedTable.schema().identifierFieldIds());
+    }
+
+    @Test
+    public void updatesExistingIdentifierFields() {
+        TableIdentifier tableId = randomTableId();
+        IcebergTableManager manager = newManager(tableId);
+        Table table = manager.getTableOrCreate(new Schema(
+            List.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.required(2, "user_id", Types.LongType.get())),
+            Set.of(1)));
+
+        manager.ensureIdentifierFields(table, Set.of("user_id"));
+
+        Table updatedTable = catalog.loadTable(tableId);
+        assertEquals(Set.of(updatedTable.schema().findField("user_id").fieldId()),
+            updatedTable.schema().identifierFieldIds());
+    }
+
+    @Test
     public void skipsDuplicateNestedAdditions() {
         TableIdentifier tableId = randomTableId();
         IcebergTableManager manager = newManager(tableId);
@@ -471,7 +506,7 @@ public class IcebergTableManagerTest {
 
         verify(mockUpdateSchema, never()).makeColumnOptional("name");
         verify(mockUpdateSchema, never()).updateColumn(eq("id"), any());
-        verify(mockUpdateSchema).commit();
+        verify(mockUpdateSchema, never()).commit();
     }
 
     private Table applyChanges(IcebergTableManager manager, Table table, Schema newSchema) {

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTableTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTableTest.scala
@@ -24,8 +24,9 @@ import kafka.server.{ControllerConfigurationValidator, KafkaConfig}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.TOPIC
-import org.apache.kafka.common.config.TopicConfig.{AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG, AUTOMQ_TABLE_TOPIC_CONVERT_VALUE_TYPE_CONFIG, AUTOMQ_TABLE_TOPIC_TRANSFORM_VALUE_TYPE_CONFIG}
+import org.apache.kafka.common.config.TopicConfig.{AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG, AUTOMQ_TABLE_TOPIC_CONVERT_VALUE_TYPE_CONFIG, AUTOMQ_TABLE_TOPIC_TRANSFORM_VALUE_TYPE_CONFIG, TABLE_TOPIC_ID_COLUMNS_CONFIG}
 import org.apache.kafka.common.errors.InvalidConfigurationException
+import org.apache.kafka.server.common.automq.TableTopicConfigValidator.FROM_DEBEZIUM_KEY
 import org.apache.kafka.server.record.{TableTopicConvertType, TableTopicTransformType}
 import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertThrows}
 import org.junit.jupiter.api.{BeforeEach, Tag, Test, Timeout}
@@ -94,6 +95,29 @@ class ControllerConfigurationValidatorTableTest {
             validator.validate(new ConfigResource(TOPIC, "foo"), config)
         })
         assertEquals("raw convert type cannot be used with 'flatten_debezium' transform type", exception.getMessage)
+    }
+
+    @Test
+    def testDebeziumKeyIdentifierRequiresKeyBySchemaId(): Unit = {
+        val config = new util.TreeMap[String, String]()
+        config.put(AUTOMQ_TABLE_TOPIC_CONVERT_VALUE_TYPE_CONFIG, TableTopicConvertType.BY_SCHEMA_ID.name)
+        config.put(AUTOMQ_TABLE_TOPIC_TRANSFORM_VALUE_TYPE_CONFIG, TableTopicTransformType.FLATTEN_DEBEZIUM.name)
+        config.put(TABLE_TOPIC_ID_COLUMNS_CONFIG, s"[$FROM_DEBEZIUM_KEY]")
+
+        config.put(AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG, TableTopicConvertType.STRING.name)
+        var exception = assertThrows(classOf[InvalidConfigurationException], () => {
+            validatorWithSchemaRegistry.validate(new ConfigResource(TOPIC, "foo"), config)
+        })
+        assertEquals("automq.table.topic.id.columns=[_from_debezium_key_] requires automq.table.topic.convert.key.type to be 'by_schema_id'", exception.getMessage)
+
+        config.put(AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG, TableTopicConvertType.BY_LATEST_SCHEMA.name)
+        exception = assertThrows(classOf[InvalidConfigurationException], () => {
+            validatorWithSchemaRegistry.validate(new ConfigResource(TOPIC, "foo"), config)
+        })
+        assertEquals("automq.table.topic.id.columns=[_from_debezium_key_] requires automq.table.topic.convert.key.type to be 'by_schema_id'", exception.getMessage)
+
+        config.put(AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG, TableTopicConvertType.BY_SCHEMA_ID.name)
+        assertDoesNotThrow(new org.junit.jupiter.api.function.Executable { def execute(): Unit = validatorWithSchemaRegistry.validate(new ConfigResource(TOPIC, "foo"), config) })
     }
 
     @Test

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTableTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTableTest.scala
@@ -97,6 +97,9 @@ class ControllerConfigurationValidatorTableTest {
         assertEquals("raw convert type cannot be used with 'flatten_debezium' transform type", exception.getMessage)
     }
 
+    /**
+     * Given the Debezium key identifier sentinel, controller-side validation only accepts by_schema_id key conversion.
+     */
     @Test
     def testDebeziumKeyIdentifierRequiresKeyBySchemaId(): Unit = {
         val config = new util.TreeMap[String, String]()

--- a/server-common/src/main/java/org/apache/kafka/server/common/automq/TableTopicConfigValidator.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/automq/TableTopicConfigValidator.java
@@ -37,6 +37,7 @@ public class TableTopicConfigValidator {
     static final Pattern LIST_STRING_REGEX = Pattern.compile("\\[(.*)\\]");
     public static final String COMMA_NO_PARENS_REGEX = ",(?![^()]*+\\))";
     private static final Pattern COLUMN_NAME_REGEX = Pattern.compile("[a-zA-Z0-9_\\-\\.]+");
+    public static final String FROM_DEBEZIUM_KEY = "_from_debezium_key_";
 
     public static class PartitionValidator implements ConfigDef.Validator {
         public static final PartitionValidator INSTANCE = new PartitionValidator();
@@ -115,6 +116,10 @@ public class TableTopicConfigValidator {
             try {
                 String str = (String) value;
                 List<String> idColumns = stringToList(str, COMMA_NO_PARENS_REGEX);
+                if (idColumns.contains(FROM_DEBEZIUM_KEY) && idColumns.size() != 1) {
+                    throw new ConfigException(name, value,
+                        String.format("%s must be used alone", FROM_DEBEZIUM_KEY));
+                }
                 idColumns.forEach(idColumn -> {
                     if (!COLUMN_NAME_REGEX.matcher(idColumn).matches()) {
                         throw new ConfigException(name, value, String.format("Invalid column name %s", idColumn));
@@ -137,6 +142,9 @@ public class TableTopicConfigValidator {
         Matcher matcher = LIST_STRING_REGEX.matcher(value);
         if (matcher.matches()) {
             value = matcher.group(1);
+        }
+        if (value.isEmpty()) {
+            return Collections.emptyList();
         }
         return Arrays.stream(value.split(regex)).map(String::trim).collect(toList());
     }

--- a/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
@@ -35,8 +35,6 @@ public class TableTopicConfigValidatorTest {
 
     @Test
     public void testPartitionValidator() {
-        // not an array
-        assertThrowsExactly(ConfigException.class, () -> PartitionValidator.INSTANCE.ensureValid("config_name", "year(column_name)"));
         // invalid transform function
         assertThrowsExactly(ConfigException.class, () -> PartitionValidator.INSTANCE.ensureValid("config_name", "[clock(column_name)]"));
         // invalid column name
@@ -47,23 +45,28 @@ public class TableTopicConfigValidatorTest {
         assertThrowsExactly(ConfigException.class, () -> PartitionValidator.INSTANCE.ensureValid("config_name", "[truncate(column_name, abc)]"));
 
         // valid
+        PartitionValidator.INSTANCE.ensureValid("config_name", "year(column_name)");
         PartitionValidator.INSTANCE.ensureValid("config_name", "[year(l1.l2.c1), month(c2), day(c3), hour(c4), bucket(c5, 1), truncate(c6, 10)]");
     }
 
     @Test
     public void testIdColumnsValidator() {
-        // not an array
-        assertThrowsExactly(ConfigException.class, () -> IdColumnsValidator.INSTANCE.ensureValid("config_name", "c1, c2"));
         // invalid column name
         assertThrowsExactly(ConfigException.class, () -> IdColumnsValidator.INSTANCE.ensureValid("config_name", "[\"c1\", \"c2\"]"));
+        // _from_debezium_key_ must be used alone
+        assertThrowsExactly(ConfigException.class, () -> IdColumnsValidator.INSTANCE.ensureValid("config_name", "[_from_debezium_key_, c2]"));
 
         // valid
+        IdColumnsValidator.INSTANCE.ensureValid("config_name", "c1, c2");
         IdColumnsValidator.INSTANCE.ensureValid("config_name", "[l1.c1, c2]");
+        IdColumnsValidator.INSTANCE.ensureValid("config_name", "[_from_debezium_key_]");
     }
 
     @Test
     public void testStringToList() {
         Assertions.assertEquals(List.of("a", "b", "c"), TableTopicConfigValidator.stringToList("a, b, c", COMMA_NO_PARENS_REGEX));
         Assertions.assertEquals(List.of("a", "b", "c"), TableTopicConfigValidator.stringToList("[a, b, c]", COMMA_NO_PARENS_REGEX));
+        Assertions.assertEquals(List.of(), TableTopicConfigValidator.stringToList("", COMMA_NO_PARENS_REGEX));
+        Assertions.assertEquals(List.of(), TableTopicConfigValidator.stringToList("[]", COMMA_NO_PARENS_REGEX));
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/automq/TableTopicConfigValidatorTest.java
@@ -49,6 +49,9 @@ public class TableTopicConfigValidatorTest {
         PartitionValidator.INSTANCE.ensureValid("config_name", "[year(l1.l2.c1), month(c2), day(c3), hour(c4), bucket(c5, 1), truncate(c6, 10)]");
     }
 
+    /**
+     * Given identifier column configuration, the validator accepts normal columns and a standalone Debezium key sentinel.
+     */
     @Test
     public void testIdColumnsValidator() {
         // invalid column name

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -74,6 +74,7 @@ import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_0_IV1;
+import static org.apache.kafka.server.common.automq.TableTopicConfigValidator.FROM_DEBEZIUM_KEY;
 import static org.apache.kafka.server.record.TableTopicConvertType.BY_LATEST_SCHEMA;
 import static org.apache.kafka.server.record.TableTopicConvertType.BY_SCHEMA_ID;
 import static org.apache.kafka.server.record.TableTopicConvertType.RAW;
@@ -794,6 +795,9 @@ public class LogConfig extends AbstractConfig {
         String valueConvertProperty = props.getProperty(TopicConfig.AUTOMQ_TABLE_TOPIC_CONVERT_VALUE_TYPE_CONFIG);
         String keyConvertProperty = props.getProperty(TopicConfig.AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG);
         String transformProperty = props.getProperty(TopicConfig.AUTOMQ_TABLE_TOPIC_TRANSFORM_VALUE_TYPE_CONFIG);
+        List<String> idColumns = TableTopicConfigValidator.stringToList(
+            props.getProperty(TopicConfig.TABLE_TOPIC_ID_COLUMNS_CONFIG),
+            TableTopicConfigValidator.COMMA_NO_PARENS_REGEX);
 
         // Validation logic using new (or mapped) configs
         if ((BY_SCHEMA_ID.name.equals(valueConvertProperty) || BY_LATEST_SCHEMA.name.equals(valueConvertProperty)) && (tableTopicSchemaRegistryUrl == null || tableTopicSchemaRegistryUrl.isEmpty())) {
@@ -804,6 +808,11 @@ public class LogConfig extends AbstractConfig {
         }
         if (!(BY_SCHEMA_ID.name.equals(valueConvertProperty) || BY_LATEST_SCHEMA.name.equals(valueConvertProperty)) && FLATTEN_DEBEZIUM.name.equals(transformProperty)) {
             throw new InvalidConfigurationException(valueConvertProperty + " convert type cannot be used with '" + FLATTEN_DEBEZIUM.name + "' transform type");
+        }
+        if (idColumns.equals(List.of(FROM_DEBEZIUM_KEY)) && !BY_SCHEMA_ID.name.equals(keyConvertProperty)) {
+            throw new InvalidConfigurationException(
+                TopicConfig.TABLE_TOPIC_ID_COLUMNS_CONFIG + "=[" + FROM_DEBEZIUM_KEY + "] requires "
+                    + TopicConfig.AUTOMQ_TABLE_TOPIC_CONVERT_KEY_TYPE_CONFIG + " to be '" + BY_SCHEMA_ID.name + "'");
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `automq.table.topic.id.columns=[_from_debezium_key_]` to derive Table Topic identifier columns from Debezium key schema.
- Propagate resolved identifier columns through schema identity, `ProcessingResult`, Iceberg schema metadata, and equality-delete writes.
- Require `_from_debezium_key_` to use `automq.table.topic.convert.key.type=by_schema_id` at server-side topic config validation.
- Keep runtime null/missing Debezium keys silent: they resolve to empty identifiers.

Fixes #3448

## Notes

- `_from_debezium_key_` must be used alone in `automq.table.topic.id.columns`.
- Key fields must exist as top-level fields after `flatten_debezium`; otherwise schema binding fails clearly.
- DevKit/KRaft create and alter validation paths are covered. ZK admin path coverage is a remaining boundary if TableTopic still supports ZK mode.

## Verification

- Focused unit tests for processor, binder, Iceberg table manager, and config validation.
- Required local gate:

```bash
./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck
```

- DevKit regression with Debezium + Schema Registry + Iceberg REST:
  - stable PK derives Iceberg `identifier-field-ids` and writes equality deletes
  - null key / no key schema is silent and creates an identifier-less table schema
  - explicit identifier config can be changed to `_from_debezium_key_`, updating Iceberg identifier metadata
  - invalid `_from_debezium_key_` + non-`by_schema_id` key converter is rejected on create and alter
