### PR TITLE
feat(s3stream): support cross-bucket multipart copy

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/AbstractObjectStorage.java
@@ -1150,30 +1150,6 @@ public abstract class AbstractObjectStorage implements ObjectStorage {
         }
     }
 
-    public static class ObjectStorageCompletedPart {
-        private final int partNumber;
-        private final String partId;
-        private final String checkSum;
-
-        public ObjectStorageCompletedPart(int partNumber, String partId, String checkSum) {
-            this.partNumber = partNumber;
-            this.partId = partId;
-            this.checkSum = checkSum;
-        }
-
-        public int getPartNumber() {
-            return partNumber;
-        }
-
-        public String getPartId() {
-            return partId;
-        }
-
-        public String getCheckSum() {
-            return checkSum;
-        }
-    }
-
     /**
      * An object storage operation task.
      */

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
@@ -41,11 +41,12 @@ import io.netty.buffer.CompositeByteBuf;
 
 public class MultiPartWriter implements Writer {
     private static final long MAX_MERGE_WRITE_SIZE = 32L * 1024 * 1024;
+    private static final long CROSS_BUCKET_COPY_CHUNK_SIZE = 32L * 1024 * 1024;
     final CompletableFuture<String> uploadIdCf = new CompletableFuture<>();
-    private final AbstractObjectStorage operator;
+    private final ObjectStorage operator;
     private final String path;
     private final ObjectStorage.WriteOptions writeOptions;
-    private final List<CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart>> parts = new LinkedList<>();
+    private final List<CompletableFuture<ObjectStorage.ObjectStorageCompletedPart>> parts = new LinkedList<>();
     private final AtomicInteger nextPartNumber = new AtomicInteger(1);
     /**
      * The minPartSize represents the minimum size of a part for a multipart object.
@@ -58,12 +59,12 @@ public class MultiPartWriter implements Writer {
     private CompletableFuture<Void> closeCf;
     private ObjectPart objectPart = null;
 
-    public MultiPartWriter(ObjectStorage.WriteOptions writeOptions, AbstractObjectStorage operator, String path,
+    public MultiPartWriter(ObjectStorage.WriteOptions writeOptions, ObjectStorage operator, String path,
         long minPartSize) {
         this(writeOptions, operator, path, minPartSize, MAX_MERGE_WRITE_SIZE);
     }
 
-    public MultiPartWriter(ObjectStorage.WriteOptions writeOptions, AbstractObjectStorage operator, String path,
+    public MultiPartWriter(ObjectStorage.WriteOptions writeOptions, ObjectStorage operator, String path,
         long minPartSize, long maxMergeWriteSize) {
         this.writeOptions = writeOptions;
         this.operator = operator;
@@ -115,6 +116,10 @@ public class MultiPartWriter implements Writer {
 
     @Override
     public void copyWrite(S3ObjectMetadata sourceObjectMateData, long start, long end) {
+        if (sourceObjectMateData.bucket() != writeOptions.bucketId()) {
+            crossBucketCopyWrite(sourceObjectMateData, start, end);
+            return;
+        }
         long nextStart = start;
         for (; ; ) {
             long currentEnd = Math.min(nextStart + Writer.MAX_PART_SIZE, end);
@@ -123,6 +128,22 @@ public class MultiPartWriter implements Writer {
             if (currentEnd == end) {
                 break;
             }
+        }
+    }
+
+    private void crossBucketCopyWrite(S3ObjectMetadata sourceObjectMateData, long start, long end) {
+        long nextStart = start;
+        while (nextStart < end) {
+            long currentEnd = Math.min(nextStart + CROSS_BUCKET_COPY_CHUNK_SIZE, end);
+            if (objectPart == null) {
+                objectPart = new ObjectPart(writeOptions.throttleStrategy());
+            }
+            objectPart.readAndWrite(sourceObjectMateData, nextStart, currentEnd);
+            if (objectPart.size() > minPartSize) {
+                objectPart.upload();
+                objectPart = null;
+            }
+            nextStart = currentEnd;
         }
     }
 
@@ -178,7 +199,7 @@ public class MultiPartWriter implements Writer {
 
     @Override
     public CompletableFuture<Void> release() {
-        List<CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart>> partsToWait = parts;
+        List<CompletableFuture<ObjectStorage.ObjectStorageCompletedPart>> partsToWait = parts;
         if (objectPart != null) {
             // skip waiting for pending part
             partsToWait = partsToWait.subList(0, partsToWait.size() - 1);
@@ -196,7 +217,7 @@ public class MultiPartWriter implements Writer {
         return writeOptions.bucketId();
     }
 
-    private List<AbstractObjectStorage.ObjectStorageCompletedPart> genCompleteParts() {
+    private List<ObjectStorage.ObjectStorageCompletedPart> genCompleteParts() {
         return this.parts.stream().map(cf -> {
             try {
                 return cf.get();
@@ -209,7 +230,7 @@ public class MultiPartWriter implements Writer {
 
     class ObjectPart {
         private final int partNumber = nextPartNumber.getAndIncrement();
-        private final CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
+        private final CompletableFuture<ObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
         private final ThrottleStrategy throttleStrategy;
         private CompositeByteBuf partBuf = ByteBufAlloc.compositeByteBuffer();
         private CompletableFuture<Void> lastRangeReadCf = CompletableFuture.completedFuture(null);
@@ -281,7 +302,7 @@ public class MultiPartWriter implements Writer {
     }
 
     class CopyObjectPart {
-        private final CompletableFuture<AbstractObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
+        private final CompletableFuture<ObjectStorage.ObjectStorageCompletedPart> partCf = new CompletableFuture<>();
 
         public CopyObjectPart(String sourcePath, long start, long end) {
             int partNumber = nextPartNumber.getAndIncrement();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -67,7 +67,48 @@ public interface ObjectStorage {
     default CompletableFuture<WriteResult> write(WriteOptions options, String objectPath, ByteBuf buf) {
         Writer writer = writer(options, objectPath);
         writer.write(buf);
-        return writer.close().thenApply(nil -> new WriteResult(bucketId()));
+        return writer.close().thenApply(nil -> new WriteResult(writer.bucketId()));
+    }
+
+    /**
+     * Start a multipart upload for the target object path.
+     * <p>
+     * Implementations that do not support low-level multipart operations fail with
+     * {@link UnsupportedOperationException}.
+     */
+    default CompletableFuture<String> createMultipartUpload(WriteOptions options, String path) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    /**
+     * Upload one multipart part to the target object path.
+     * <p>
+     * The implementation owns {@code data} after this call and is responsible for releasing it when the returned future
+     * completes. Implementations that do not support low-level multipart operations fail with
+     * {@link UnsupportedOperationException}.
+     */
+    default CompletableFuture<ObjectStorageCompletedPart> uploadPart(WriteOptions options, String path, String uploadId,
+        int partNumber, ByteBuf data) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    /**
+     * Copy one source range into a multipart part for the target object path.
+     * <p>
+     * This low-level operation is same-storage copy. Cross-bucket routing should fall back to range read plus
+     * {@link #uploadPart(WriteOptions, String, String, int, ByteBuf)} before calling this method.
+     */
+    default CompletableFuture<ObjectStorageCompletedPart> uploadPartCopy(WriteOptions options, String sourcePath,
+        String path, long start, long end, String uploadId, int partNumber) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    /**
+     * Complete a multipart upload for the target object path using the completed parts in part-number order.
+     */
+    default CompletableFuture<Void> completeMultipartUpload(WriteOptions options, String path, String uploadId,
+        List<ObjectStorageCompletedPart> parts) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
     }
 
     CompletableFuture<List<ObjectInfo>> list(String prefix);
@@ -125,6 +166,30 @@ public interface ObjectStorage {
 
         public long size() {
             return size;
+        }
+    }
+
+    class ObjectStorageCompletedPart {
+        private final int partNumber;
+        private final String partId;
+        private final String checkSum;
+
+        public ObjectStorageCompletedPart(int partNumber, String partId, String checkSum) {
+            this.partNumber = partNumber;
+            this.partId = partId;
+            this.checkSum = checkSum;
+        }
+
+        public int getPartNumber() {
+            return partNumber;
+        }
+
+        public String getPartId() {
+            return partId;
+        }
+
+        public String getCheckSum() {
+            return checkSum;
         }
     }
 
@@ -191,7 +256,7 @@ public interface ObjectStorage {
         }
 
         // Writer will set the value
-        WriteOptions bucketId(short bucketId) {
+        public WriteOptions bucketId(short bucketId) {
             this.bucketId = bucketId;
             return this;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
@@ -37,22 +37,22 @@ import io.netty.buffer.CompositeByteBuf;
  * If object data size is less than ObjectWriter.MAX_UPLOAD_SIZE, we should use single upload to upload it.
  * Else, we should use multi-part upload to upload it.
  */
-class ProxyWriter implements Writer {
+public class ProxyWriter implements Writer {
     final ObjectWriter objectWriter = new ObjectWriter();
     private final WriteOptions writeOptions;
-    private final AbstractObjectStorage objectStorage;
+    private final ObjectStorage objectStorage;
     private final String path;
     private final long minPartSize;
     Writer largeObjectWriter = null;
 
-    public ProxyWriter(WriteOptions writeOptions, AbstractObjectStorage objectStorage, String path, long minPartSize) {
+    public ProxyWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path, long minPartSize) {
         this.writeOptions = writeOptions;
         this.objectStorage = objectStorage;
         this.path = path;
         this.minPartSize = minPartSize;
     }
 
-    public ProxyWriter(WriteOptions writeOptions, AbstractObjectStorage objectStorage, String path) {
+    public ProxyWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path) {
         this(writeOptions, objectStorage, path, Writer.MIN_PART_SIZE);
     }
 
@@ -118,7 +118,7 @@ class ProxyWriter implements Writer {
         return writeOptions.bucketId();
     }
 
-    protected void newLargeObjectWriter(WriteOptions writeOptions, AbstractObjectStorage objectStorage, String path) {
+    protected void newLargeObjectWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path) {
         this.largeObjectWriter = new MultiPartWriter(writeOptions, objectStorage, path, minPartSize);
         if (objectWriter.data.readableBytes() > 0) {
             FutureUtil.propagate(largeObjectWriter.write(objectWriter.data), objectWriter.cf);

--- a/s3stream/src/test/java/com/automq/stream/s3/DefaultUploadWriteAheadLogTaskTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/DefaultUploadWriteAheadLogTaskTest.java
@@ -20,10 +20,10 @@
 package com.automq.stream.s3;
 
 import com.automq.stream.s3.metadata.S3ObjectMetadata;
-import com.automq.stream.s3.metadata.S3ObjectType;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.objects.CommitStreamSetObjectRequest;
 import com.automq.stream.s3.objects.CommitStreamSetObjectResponse;
+import com.automq.stream.s3.objects.ObjectAttributes;
 import com.automq.stream.s3.objects.ObjectManager;
 import com.automq.stream.s3.objects.StreamObject;
 import com.automq.stream.s3.operator.MemoryObjectStorage;
@@ -58,6 +58,8 @@ import static org.mockito.Mockito.when;
 
 @Tag("S3Unit")
 public class DefaultUploadWriteAheadLogTaskTest {
+    private static final short DATA_BUCKET_ID = 3;
+
     ObjectManager objectManager;
     ObjectStorage objectStorage;
     DefaultUploadWriteAheadLogTask deltaWALUploadTask;
@@ -65,7 +67,7 @@ public class DefaultUploadWriteAheadLogTaskTest {
     @BeforeEach
     public void setup() {
         objectManager = mock(ObjectManager.class);
-        objectStorage = new MemoryObjectStorage();
+        objectStorage = new MemoryObjectStorage(DATA_BUCKET_ID);
     }
 
     @Test
@@ -110,6 +112,7 @@ public class DefaultUploadWriteAheadLogTaskTest {
         // - stream234 write to one stream range
         CommitStreamSetObjectRequest request = reqArg.getValue();
         assertEquals(10, request.getObjectId());
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(request.getAttributes()).bucket());
         assertEquals(1, request.getStreamRanges().size());
         assertEquals(234, request.getStreamRanges().get(0).getStreamId());
         assertEquals(20, request.getStreamRanges().get(0).getStartOffset());
@@ -117,13 +120,15 @@ public class DefaultUploadWriteAheadLogTaskTest {
 
         assertEquals(1, request.getStreamObjects().size());
         StreamObject streamObject = request.getStreamObjects().get(0);
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(streamObject.getAttributes()).bucket());
         assertEquals(233, streamObject.getStreamId());
         assertEquals(11, streamObject.getObjectId());
         assertEquals(10, streamObject.getStartOffset());
         assertEquals(16, streamObject.getEndOffset());
 
         {
-            S3ObjectMetadata s3ObjectMetadata = new S3ObjectMetadata(request.getObjectId(), request.getObjectSize(), S3ObjectType.STREAM_SET);
+            S3ObjectMetadata s3ObjectMetadata = new S3ObjectMetadata(request.getObjectId(), request.getAttributes());
+            s3ObjectMetadata.setObjectSize(request.getObjectSize());
             ObjectReader objectReader = ObjectReader.reader(s3ObjectMetadata, objectStorage);
             DataBlockIndex blockIndex = objectReader.find(234, 20, 24).get()
                 .streamDataBlocks().get(0).dataBlockIndex();
@@ -138,7 +143,8 @@ public class DefaultUploadWriteAheadLogTaskTest {
         }
 
         {
-            S3ObjectMetadata streamObjectMetadata = new S3ObjectMetadata(11, request.getStreamObjects().get(0).getObjectSize(), S3ObjectType.STREAM);
+            S3ObjectMetadata streamObjectMetadata = new S3ObjectMetadata(11, request.getStreamObjects().get(0).getAttributes());
+            streamObjectMetadata.setObjectSize(request.getStreamObjects().get(0).getObjectSize());
             ObjectReader objectReader = ObjectReader.reader(streamObjectMetadata, objectStorage);
             DataBlockIndex blockIndex = objectReader.find(233, 10, 16).get()
                 .streamDataBlocks().get(0).dataBlockIndex();

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -86,6 +86,7 @@ import static org.mockito.Mockito.when;
 @Timeout(60)
 @Tag("S3Unit")
 class StreamObjectCompactorTest {
+    private static final short DATA_BUCKET_ID = 3;
 
     private ObjectManager objectManager;
     private MemoryObjectStorage objectStorage;
@@ -95,7 +96,7 @@ class StreamObjectCompactorTest {
     @BeforeEach
     void setUp() {
         objectManager = Mockito.mock(ObjectManager.class);
-        objectStorage = new MemoryObjectStorage();
+        objectStorage = new MemoryObjectStorage(DATA_BUCKET_ID);
         stream = Mockito.mock(S3Stream.class);
     }
 
@@ -257,6 +258,7 @@ class StreamObjectCompactorTest {
         // verify compact request
         List<CompactStreamObjectRequest> requests = ac.getAllValues();
         CompactStreamObjectRequest req1 = requests.get(0);
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(req1.getAttributes()).bucket());
         assertEquals(5, req1.getObjectId());
         assertEquals(233L, req1.getStreamId());
         assertEquals(13L, req1.getStartOffset());
@@ -264,6 +266,7 @@ class StreamObjectCompactorTest {
         assertEquals(List.of(1L, 2L), req1.getSourceObjectIds());
 
         CompactStreamObjectRequest req2 = requests.get(1);
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(req2.getAttributes()).bucket());
         assertEquals(6, req2.getObjectId());
         assertEquals(233L, req2.getStreamId());
         assertEquals(30L, req2.getStartOffset());
@@ -272,7 +275,9 @@ class StreamObjectCompactorTest {
 
         // verify compacted object record
         {
-            ObjectReader objectReader = ObjectReader.reader(new S3ObjectMetadata(5, req1.getObjectSize(), S3ObjectType.STREAM), objectStorage);
+            S3ObjectMetadata metadata = new S3ObjectMetadata(5, req1.getAttributes());
+            metadata.setObjectSize(req1.getObjectSize());
+            ObjectReader objectReader = ObjectReader.reader(metadata, objectStorage);
             assertEquals(3, objectReader.basicObjectInfo().get().indexBlock().count());
             ObjectReader.FindIndexResult rst = objectReader.find(streamId, 13L, 18L).get();
             assertEquals(3, rst.streamDataBlocks().size());
@@ -300,7 +305,9 @@ class StreamObjectCompactorTest {
             objectReader.close();
         }
         {
-            ObjectReader objectReader = ObjectReader.reader(new S3ObjectMetadata(6, req2.getObjectSize(), S3ObjectType.STREAM), objectStorage);
+            S3ObjectMetadata metadata = new S3ObjectMetadata(6, req2.getAttributes());
+            metadata.setObjectSize(req2.getObjectSize());
+            ObjectReader objectReader = ObjectReader.reader(metadata, objectStorage);
             assertEquals(3, objectReader.basicObjectInfo().get().indexBlock().count());
             ObjectReader.FindIndexResult rst = objectReader.find(streamId, 30L, 33L).get();
             assertEquals(3, rst.streamDataBlocks().size());
@@ -360,6 +367,7 @@ class StreamObjectCompactorTest {
         CompactStreamObjectRequest req = new CompactByPhysicalMerge(streamId, 0L, 14L,
             objects.subList(0, 2), 5, 5000, objectStorage).compact().get();
         // verify compact request
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(req.getAttributes()).bucket());
         assertEquals(5, req.getObjectId());
         assertEquals(233L, req.getStreamId());
         assertEquals(13L, req.getStartOffset());
@@ -368,7 +376,9 @@ class StreamObjectCompactorTest {
 
         // verify compacted object record, expect [13,16) + [16, 17) compact to one data block group.
         {
-            ObjectReader objectReader = ObjectReader.reader(new S3ObjectMetadata(5, req.getObjectSize(), S3ObjectType.STREAM), objectStorage);
+            S3ObjectMetadata metadata = new S3ObjectMetadata(5, req.getAttributes());
+            metadata.setObjectSize(req.getObjectSize());
+            ObjectReader objectReader = ObjectReader.reader(metadata, objectStorage);
             assertEquals(2, objectReader.basicObjectInfo().get().indexBlock().count());
             ObjectReader.FindIndexResult rst = objectReader.find(streamId, 13L, 18L).get();
             assertEquals(2, rst.streamDataBlocks().size());
@@ -576,6 +586,7 @@ class StreamObjectCompactorTest {
         CompactByCompositeObject compact = new CompactByCompositeObject(streamId, 0L, 0L, metadataList.subList(0, 2), 5, objectStorage);
         CompactStreamObjectRequest req = compact.compact().get();
         assertEquals(ObjectAttributes.Type.Composite, ObjectAttributes.from(req.getAttributes()).type());
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(req.getAttributes()).bucket());
         assertEquals(5, req.getObjectId());
         assertEquals(streamId, req.getStreamId());
         assertEquals(10L, req.getStartOffset());
@@ -608,11 +619,13 @@ class StreamObjectCompactorTest {
         writer.close().get();
         S3ObjectMetadata object6Metadata = new S3ObjectMetadata(6, S3ObjectType.STREAM, List.of(new StreamOffsetRange(streamId, 18, 19)),
             System.currentTimeMillis(), System.currentTimeMillis(), writer.size(), 6);
+        object6Metadata.setAttributes(ObjectAttributes.builder().bucket(DATA_BUCKET_ID).build().attributes());
 
         // compact object5 and object6, expect the composite object contains 16 ~ 18 and delete object1
         compact = new CompactByCompositeObject(streamId, 0L, 17L, List.of(object5Metadata, object6Metadata), 7, objectStorage);
         req = compact.compact().get();
         assertEquals(ObjectAttributes.Type.Composite, ObjectAttributes.from(req.getAttributes()).type());
+        assertEquals(DATA_BUCKET_ID, ObjectAttributes.from(req.getAttributes()).bucket());
         assertEquals(7, req.getObjectId());
         assertEquals(16L, req.getStartOffset());
         assertEquals(19L, req.getEndOffset());

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
@@ -22,10 +22,12 @@ package com.automq.stream.s3.operator;
 import com.automq.stream.s3.TestUtils;
 import com.automq.stream.s3.metadata.S3ObjectMetadata;
 import com.automq.stream.s3.metadata.S3ObjectType;
+import com.automq.stream.s3.objects.ObjectAttributes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -42,6 +44,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.ResponsePublisher;
@@ -61,7 +64,14 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Tag("S3Unit")
@@ -276,6 +286,52 @@ class MultiPartWriterTest {
         assertEquals(List.of("bytes=0-119"), uploadPartCopyRequests.stream()
             .map(UploadPartCopyRequest::copySourceRange)
             .collect(Collectors.toList()));
+    }
+
+    /**
+     * Given the source bucket differs from the target bucket, copyWrite reads source ranges through ObjectStorage
+     * instead of issuing same-bucket server-side copy requests.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCrossBucketCopyWriteUsesRangeReadChunks() throws Exception {
+        ObjectStorage.WriteOptions options = ObjectStorage.WriteOptions.DEFAULT.copy().bucketId((short) 1);
+        ObjectStorage readStorage = mock(ObjectStorage.class);
+        when(readStorage.createMultipartUpload(options, "cross-bucket-target"))
+            .thenReturn(CompletableFuture.completedFuture("upload-id"));
+        when(readStorage.rangeRead(any(), anyString(), anyLong(), anyLong())).thenAnswer(invocation -> {
+            long start = invocation.getArgument(2);
+            long end = invocation.getArgument(3);
+            return CompletableFuture.completedFuture(Unpooled.wrappedBuffer(new byte[(int) (end - start)]));
+        });
+        when(readStorage.uploadPart(eq(options), eq("cross-bucket-target"), eq("upload-id"), anyInt(), any()))
+            .thenAnswer(invocation -> CompletableFuture.completedFuture(
+                new ObjectStorage.ObjectStorageCompletedPart(invocation.getArgument(3), "etag", null)));
+        when(readStorage.completeMultipartUpload(eq(options), eq("cross-bucket-target"), eq("upload-id"), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        writer = new MultiPartWriter(options, readStorage, "cross-bucket-target", 100);
+        long chunkSize = 32L * 1024 * 1024;
+
+        S3ObjectMetadata source = new S3ObjectMetadata(1, ObjectAttributes.builder().bucket((short) 2).build().attributes());
+        writer.copyWrite(source, 0, 2 * chunkSize + 1);
+        writer.close().get();
+
+        ArgumentCaptor<ObjectStorage.ReadOptions> readOptionsCaptor = ArgumentCaptor.forClass(ObjectStorage.ReadOptions.class);
+        ArgumentCaptor<Long> startCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> endCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(readStorage, times(3)).rangeRead(readOptionsCaptor.capture(), eq(source.key()), startCaptor.capture(), endCaptor.capture());
+        assertEquals(List.of((short) 2, (short) 2, (short) 2), readOptionsCaptor.getAllValues().stream()
+            .map(ObjectStorage.ReadOptions::bucket)
+            .collect(Collectors.toList()));
+        assertEquals(List.of(0L, chunkSize, 2 * chunkSize), startCaptor.getAllValues());
+        assertEquals(List.of(chunkSize, 2 * chunkSize, 2 * chunkSize + 1), endCaptor.getAllValues());
+
+        ArgumentCaptor<ByteBuf> partCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(readStorage, times(3)).uploadPart(eq(options), eq("cross-bucket-target"), eq("upload-id"), anyInt(), partCaptor.capture());
+        assertEquals(List.of(chunkSize, chunkSize, 1L), partCaptor.getAllValues().stream()
+            .map(part -> (long) part.readableBytes())
+            .collect(Collectors.toList()));
+        verify(readStorage, never()).uploadPartCopy(any(), any(), any(), anyLong(), anyLong(), any(), anyInt());
     }
 
     private static String md5Base64(ByteBuf data) {


### PR DESCRIPTION
- Move low-level multipart APIs to the `ObjectStorage` interface so wrappers can participate in multipart routing.
- Let `MultiPartWriter` fall back to 32 MiB range-read/upload chunks when source and target bucket ids differ.
- Return the concrete writer bucket id from `ObjectStorage.write()` and cover cross-bucket copy chunking with a unit test.
