### PR TITLE
fix(s3stream): distinguish unset write bucket

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ObjectStorage.java
@@ -195,6 +195,7 @@ public interface ObjectStorage {
 
     class WriteOptions {
         public static final WriteOptions DEFAULT = new WriteOptions();
+        public static final short UNSET_BUCKET = (short) -2;
 
         private ThrottleStrategy throttleStrategy = ThrottleStrategy.BYPASS;
         private int allocType = ByteBufAlloc.DEFAULT;
@@ -202,7 +203,7 @@ public interface ObjectStorage {
         private long apiCallAttemptTimeout = -1L;
         // timeout for the whole write operation
         private long timeout = Long.MAX_VALUE;
-        private short bucketId;
+        private short bucketId = UNSET_BUCKET;
         private boolean enableFastRetry;
         // write context start
         private boolean retry;
@@ -255,8 +256,8 @@ public interface ObjectStorage {
             return apiCallAttemptTimeout;
         }
 
-        // Writer will set the value
-        public WriteOptions bucketId(short bucketId) {
+        // Writer will set the value.
+        WriteOptions bucketId(short bucketId) {
             this.bucketId = bucketId;
             return this;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/WriteOptionsBucket.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/WriteOptionsBucket.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024, AutoMQ HK Limited.
+ *
+ * The use of this file is governed by the Business Source License,
+ * as detailed in the file "/LICENSE.S3Stream" included in this repository.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed by
+ * the Apache License, Version 2.0
+ */
+
+package com.automq.stream.s3.operator;
+
+/**
+ * Internal extension point for ObjectStorage/Writer implementations outside this package.
+ * Application code should not bind write options to a bucket. Writers set it after selecting the concrete target bucket.
+ */
+public final class WriteOptionsBucket {
+    private WriteOptionsBucket() {
+    }
+
+    public static ObjectStorage.WriteOptions bucketId(ObjectStorage.WriteOptions options, short bucketId) {
+        return options.bucketId(bucketId);
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/MultiPartWriterTest.java
@@ -178,7 +178,7 @@ class MultiPartWriterTest {
     @Test
     @SuppressWarnings("unchecked")
     void testCopyWrite() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ExecutionException, InterruptedException {
-        writer = new MultiPartWriter(ObjectStorage.WriteOptions.DEFAULT, operator, "test-path-2", 100);
+        writer = new MultiPartWriter(ObjectStorage.WriteOptions.DEFAULT.copy().bucketId((short) 0), operator, "test-path-2", 100);
         List<UploadPartRequest> uploadPartRequests = new ArrayList<>();
         List<UploadPartCopyRequest> uploadPartCopyRequests = new ArrayList<>();
         List<Long> writeContentLengths = new ArrayList<>();

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
@@ -53,7 +53,7 @@ public class ProxyWriterTest {
     @BeforeEach
     public void setup() {
         operator = mock(AbstractObjectStorage.class);
-        writer = new ProxyWriter(ObjectStorage.WriteOptions.DEFAULT, operator, "testpath");
+        writer = new ProxyWriter(ObjectStorage.WriteOptions.DEFAULT.copy().bucketId((short) 0), operator, "testpath");
     }
 
     @Test


### PR DESCRIPTION
- make WriteOptions default bucket id use an explicit UNSET_BUCKET sentinel
- update writer tests to set target bucket explicitly when same-bucket copy semantics are expected