### PR TITLE
feat: support shared network bandwidth limiter

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
 
 import com.automq.stream.s3.ByteBufAllocPolicy;
+import com.automq.stream.s3.network.NetworkBandwidthMode;
 import com.automq.stream.s3.operator.BucketURI;
 
 import org.apache.commons.lang3.StringUtils;
@@ -155,6 +156,10 @@ public class AutoMQConfig {
     public static final String S3_NETWORK_BASELINE_BANDWIDTH_DOC = "The total available bandwidth for object storage requests. This is used to prevent stream set object compaction and catch-up read from monopolizing normal read and write traffic. Produce and Consume will also separately consume traffic in and traffic out. " +
         "For example, suppose this value is set to 100MB/s, and the normal read and write traffic is 80MB/s, then the available traffic for stream set object compaction is 20MB/s.";
     public static final long S3_NETWORK_BASELINE_BANDWIDTH = 1024 * 1024 * 1024; // 1GBps
+
+    public static final String S3_NETWORK_BANDWIDTH_MODE_CONFIG = "s3.network.bandwidth.mode";
+    public static final String S3_NETWORK_BANDWIDTH_MODE_DOC = "The network bandwidth limiting mode. Valid values are separate and shared. " +
+        "In separate mode, inbound and outbound traffic use independent bandwidth buckets. In shared mode, inbound and outbound traffic share one bandwidth bucket.";
 
     public static final String S3_NETWORK_REFILL_PERIOD_MS_CONFIG = "s3.network.refill.period.ms";
     public static final String S3_NETWORK_REFILL_PERIOD_MS_DOC = "The network bandwidth token refill period in milliseconds.";
@@ -296,6 +301,9 @@ public class AutoMQConfig {
             .define(AutoMQConfig.S3_MOCK_ENABLE_CONFIG, BOOLEAN, false, LOW, AutoMQConfig.S3_MOCK_ENABLE_DOC)
             .define(AutoMQConfig.S3_OBJECT_DELETION_MINUTES_CONFIG, LONG, S3_OBJECT_DELETE_RETENTION_MINUTES, MEDIUM, AutoMQConfig.S3_OBJECT_DELETION_MINUTES_DOC)
             .define(AutoMQConfig.S3_NETWORK_BASELINE_BANDWIDTH_CONFIG, LONG, S3_NETWORK_BASELINE_BANDWIDTH, MEDIUM, AutoMQConfig.S3_NETWORK_BASELINE_BANDWIDTH_DOC)
+            .define(AutoMQConfig.S3_NETWORK_BANDWIDTH_MODE_CONFIG, STRING, NetworkBandwidthMode.SEPARATE.getName(),
+                ConfigDef.CaseInsensitiveValidString.in(NetworkBandwidthMode.SEPARATE.getName(), NetworkBandwidthMode.SHARED.getName()),
+                MEDIUM, AutoMQConfig.S3_NETWORK_BANDWIDTH_MODE_DOC)
             .define(AutoMQConfig.S3_NETWORK_REFILL_PERIOD_MS_CONFIG, INT, S3_REFILL_PERIOD_MS, MEDIUM, AutoMQConfig.S3_NETWORK_REFILL_PERIOD_MS_DOC)
             .define(AutoMQConfig.S3_TELEMETRY_METRICS_LEVEL_CONFIG, STRING, "INFO", MEDIUM, AutoMQConfig.S3_TELEMETRY_METRICS_LEVEL_DOC)
             .define(AutoMQConfig.S3_TELEMETRY_EXPORTER_REPORT_INTERVAL_MS_CONFIG, INT, S3_METRICS_EXPORTER_REPORT_INTERVAL_MS, MEDIUM, AutoMQConfig.S3_TELEMETRY_EXPORTER_REPORT_INTERVAL_MS_DOC)

--- a/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
+++ b/core/src/main/java/kafka/automq/table/worker/IcebergWriter.java
@@ -30,7 +30,6 @@ import kafka.automq.table.process.exception.RecordProcessorException;
 import org.apache.kafka.server.record.ErrorsTolerance;
 
 import com.automq.stream.s3.metrics.TimerUtil;
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.s3.network.ThrottleStrategy;
@@ -104,7 +103,7 @@ public class IcebergWriter implements Writer {
         this.processor = processor;
         this.config = config;
         this.deltaWrite = StringUtils.isNoneBlank(config.cdcField()) || config.upsertEnable();
-        this.outboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND);
+        this.outboundLimiter = GlobalNetworkBandwidthLimiters.instance().outbound();
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/zerozone/DefaultConfirmWALProvider.java
+++ b/core/src/main/java/kafka/automq/zerozone/DefaultConfirmWALProvider.java
@@ -19,7 +19,6 @@
 
 package kafka.automq.zerozone;
 
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
@@ -51,8 +50,8 @@ public class DefaultConfirmWALProvider implements ConfirmWALProvider {
         ObjectStorage objectStorage = objectStorages.computeIfAbsent(bucketURI.bucketId(), id -> {
                 try {
                     return ObjectStorageFactory.instance().builder(bucketURI).readWriteIsolate(false)
-                        .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND))
-                        .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND))
+                        .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().inbound())
+                        .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().outbound())
                         .build();
                 } catch (IllegalArgumentException e) {
                     return null;

--- a/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
+++ b/core/src/main/java/kafka/automq/zerozone/DefaultRouterChannelProvider.java
@@ -24,7 +24,6 @@ import org.apache.kafka.controller.stream.RouterChannelEpoch;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
@@ -156,8 +155,8 @@ public class DefaultRouterChannelProvider implements RouterChannelProvider {
         if (objectStorage == null) {
             this.objectStorage = ObjectStorageFactory.instance().builder(bucketURI)
                 .readWriteIsolate(true)
-                .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND))
-                .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND))
+                .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().inbound())
+                .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().outbound())
                 .build();
         }
         return objectStorage;

--- a/core/src/main/java/kafka/automq/zerozone/RouterOut.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterOut.java
@@ -36,7 +36,6 @@ import org.apache.kafka.common.requests.s3.AutomqZoneRouterRequest;
 import org.apache.kafka.common.requests.s3.AutomqZoneRouterResponse;
 import org.apache.kafka.common.utils.Time;
 
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.s3.operator.BucketURI;
@@ -94,7 +93,7 @@ public class RouterOut {
     private final GetRouterOutNode mapping;
     private final ElasticKafkaApis kafkaApis;
     private final Time time;
-    private final NetworkBandwidthLimiter inboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND);
+    private final NetworkBandwidthLimiter inboundLimiter = GlobalNetworkBandwidthLimiters.instance().inbound();
 
     private final PerfMode perfMode = new PerfMode();
 

--- a/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
+++ b/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
@@ -47,7 +47,6 @@ import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.server.common.automq.AutoMQVersion;
 
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
@@ -122,8 +121,8 @@ public class ZeroZoneTrafficInterceptor implements TrafficInterceptor, MetadataP
         this.clientRackProvider = clientRackProvider;
         ObjectStorage objectStorage = ObjectStorageFactory.instance().builder(bucketURI)
             .readWriteIsolate(true)
-            .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND))
-            .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND))
+            .inboundLimiter(GlobalNetworkBandwidthLimiters.instance().inbound())
+            .outboundLimiter(GlobalNetworkBandwidthLimiters.instance().outbound())
             .build();
         this.routerOut = new RouterOut(currentNode, bucketURI, objectStorage, mapping::getRouteOutNode, kafkaApis, asyncSender, time);
         this.routerIn = new RouterIn(objectStorage, kafkaApis, kafkaConfig.rack().get());

--- a/core/src/main/scala/kafka/log/stream/s3/ConfigUtils.java
+++ b/core/src/main/scala/kafka/log/stream/s3/ConfigUtils.java
@@ -23,6 +23,7 @@ import kafka.automq.AutoMQConfig;
 import kafka.server.KafkaConfig;
 
 import com.automq.stream.s3.Config;
+import com.automq.stream.s3.network.NetworkBandwidthMode;
 
 public class ConfigUtils {
 
@@ -53,6 +54,7 @@ public class ConfigUtils {
             .streamSetObjectCompactionMaxObjectNum(s.s3StreamSetObjectCompactionMaxObjectNum())
             .mockEnable(s.s3MockEnable())
             .networkBaselineBandwidth(s.s3NetworkBaselineBandwidthProp())
+            .networkBandwidthMode(NetworkBandwidthMode.parse(s.s3NetworkBandwidthModeProp()))
             .refillPeriodMs(s.s3RefillPeriodMsProp())
             .objectRetentionTimeInSecond(s.s3ObjectDeleteRetentionTimeInSecond());
     }

--- a/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
+++ b/core/src/main/scala/kafka/log/stream/s3/DefaultS3Client.java
@@ -53,10 +53,6 @@ import com.automq.stream.s3.failover.ForceCloseStorageFailureHandler;
 import com.automq.stream.s3.failover.HaltStorageFailureHandler;
 import com.automq.stream.s3.failover.StorageFailureHandlerChain;
 import com.automq.stream.s3.index.LocalStreamRangeIndexCache;
-import com.automq.stream.s3.metrics.Metrics;
-import com.automq.stream.s3.metrics.MetricsLevel;
-import com.automq.stream.s3.metrics.stats.NetworkStats;
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
 import com.automq.stream.s3.network.GlobalNetworkBandwidthLimiters;
 import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.s3.objects.ObjectManager;
@@ -78,20 +74,12 @@ import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.opentelemetry.api.common.Attributes;
-
 import static com.automq.stream.s3.operator.ObjectStorageFactory.EXTENSION_TYPE_BACKGROUND;
 import static com.automq.stream.s3.operator.ObjectStorageFactory.EXTENSION_TYPE_KEY;
 import static com.automq.stream.s3.operator.ObjectStorageFactory.EXTENSION_TYPE_MAIN;
 
 public class DefaultS3Client implements Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultS3Client.class);
-    private static final Metrics.LongGaugeBundle.LongGauge NETWORK_INBOUND_AVAILABLE_BANDWIDTH = Metrics.instance()
-        .longGauge("kafka_stream_network_inbound_available_bandwidth", "Network inbound available bandwidth", "bytes")
-        .register(MetricsLevel.INFO, Attributes.empty());
-    private static final Metrics.LongGaugeBundle.LongGauge NETWORK_OUTBOUND_AVAILABLE_BANDWIDTH = Metrics.instance()
-        .longGauge("kafka_stream_network_outbound_available_bandwidth", "Network outbound available bandwidth", "bytes")
-        .register(MetricsLevel.INFO, Attributes.empty());
     protected final Config config;
     private StreamMetadataManager metadataManager;
 
@@ -134,22 +122,7 @@ public class DefaultS3Client implements Client {
 
     @Override
     public void start() {
-        long refillToken = (long) (config.networkBaselineBandwidth() * ((double) config.refillPeriodMs() / 1000));
-        if (refillToken <= 0) {
-            throw new IllegalArgumentException(String.format("refillToken must be greater than 0, bandwidth: %d, refill period: %dms",
-                config.networkBaselineBandwidth(), config.refillPeriodMs()));
-        }
-        GlobalNetworkBandwidthLimiters.instance().setup(AsyncNetworkBandwidthLimiter.Type.INBOUND,
-            refillToken, config.refillPeriodMs(), config.networkBaselineBandwidth());
-        networkInboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.INBOUND);
-        NETWORK_INBOUND_AVAILABLE_BANDWIDTH.record(() ->
-            config.networkBaselineBandwidth() - (long) NetworkStats.getInstance().networkInboundRate());
-        // Use a larger token pool for outbound traffic to avoid spikes caused by Upload WAL affecting tail-reading performance.
-        GlobalNetworkBandwidthLimiters.instance().setup(AsyncNetworkBandwidthLimiter.Type.OUTBOUND,
-            refillToken, config.refillPeriodMs(), config.networkBaselineBandwidth() * 5);
-        networkOutboundLimiter = GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND);
-        NETWORK_OUTBOUND_AVAILABLE_BANDWIDTH.record(() ->
-            config.networkBaselineBandwidth() - (long) NetworkStats.getInstance().networkOutboundRate());
+        setupNetworkLimiters();
 
         this.localIndexCache = new LocalStreamRangeIndexCache();
         this.objectReaderFactory = new DefaultObjectReaderFactory(() -> this.mainObjectStorage);
@@ -194,10 +167,16 @@ public class DefaultS3Client implements Client {
         this.compactionManager.shutdown();
         this.streamClient.shutdown();
         this.storage.shutdown();
-        this.networkInboundLimiter.shutdown();
-        this.networkOutboundLimiter.shutdown();
+        // Network limiters are process-level singletons managed by GlobalNetworkBandwidthLimiters.
         this.requestSender.shutdown();
         LOGGER.info("S3Client shutdown successfully");
+    }
+
+    protected void setupNetworkLimiters() {
+        GlobalNetworkBandwidthLimiters.instance().setup(
+            config.networkBandwidthMode(), config.networkBaselineBandwidth(), config.refillPeriodMs());
+        networkInboundLimiter = GlobalNetworkBandwidthLimiters.instance().inbound();
+        networkOutboundLimiter = GlobalNetworkBandwidthLimiters.instance().outbound();
     }
 
     @Override

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -793,6 +793,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val s3MockEnable = getBoolean(AutoMQConfig.S3_MOCK_ENABLE_CONFIG)
   val s3ObjectDeleteRetentionTimeInSecond = getLong(AutoMQConfig.S3_OBJECT_DELETION_MINUTES_CONFIG) * 60
   val s3NetworkBaselineBandwidthProp = getLong(AutoMQConfig.S3_NETWORK_BASELINE_BANDWIDTH_CONFIG)
+  val s3NetworkBandwidthModeProp = getString(AutoMQConfig.S3_NETWORK_BANDWIDTH_MODE_CONFIG)
   val s3RefillPeriodMsProp = getInt(AutoMQConfig.S3_NETWORK_REFILL_PERIOD_MS_CONFIG)
   val s3MetricsLevel = getString(AutoMQConfig.S3_TELEMETRY_METRICS_LEVEL_CONFIG)
   val s3ExporterReportIntervalMs = getInt(AutoMQConfig.S3_TELEMETRY_EXPORTER_REPORT_INTERVAL_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
@@ -2,7 +2,7 @@ package kafka.server.streamaspect
 
 import com.automq.stream.api.exceptions.FastReadFailFastException
 import com.automq.stream.s3.metrics.{Metrics => S3Metrics, MetricsLevel, TimerUtil}
-import com.automq.stream.s3.network.{AsyncNetworkBandwidthLimiter, GlobalNetworkBandwidthLimiters, ThrottleStrategy}
+import com.automq.stream.s3.network.{GlobalNetworkBandwidthLimiters, ThrottleStrategy}
 import com.automq.stream.utils.{FutureUtil, Systems}
 import com.automq.stream.utils.threads.S3StreamThreadPoolMonitor
 import io.opentelemetry.api.common.{AttributeKey, Attributes}
@@ -1015,7 +1015,7 @@ class ElasticReplicaManager(
   }
 
   private def acquireNetworkOutPermit(size: Int, throttleStrategy: ThrottleStrategy): Unit = {
-    GlobalNetworkBandwidthLimiters.instance().get(AsyncNetworkBandwidthLimiter.Type.OUTBOUND)
+    GlobalNetworkBandwidthLimiters.instance().outbound()
       .consume(throttleStrategy, size).join()
   }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -20,6 +20,7 @@
 package com.automq.stream.s3;
 
 import com.automq.stream.Version;
+import com.automq.stream.s3.network.NetworkBandwidthMode;
 import com.automq.stream.s3.operator.BucketURI;
 
 import java.util.List;
@@ -56,6 +57,7 @@ public class Config {
     private boolean mockEnable = false;
     // 1GBps/s
     private long networkBaselineBandwidth = 1024 * 1024 * 1024;
+    private NetworkBandwidthMode networkBandwidthMode = NetworkBandwidthMode.SEPARATE;
     private int refillPeriodMs = 10;
     private long objectRetentionTimeInSecond = 10 * 60; // 10min
     private boolean failoverEnable = false;
@@ -166,6 +168,13 @@ public class Config {
 
     public long networkBaselineBandwidth() {
         return networkBaselineBandwidth;
+    }
+
+    /**
+     * Returns whether network bandwidth is limited by independent directional buckets or one shared bucket.
+     */
+    public NetworkBandwidthMode networkBandwidthMode() {
+        return networkBandwidthMode;
     }
 
     public int refillPeriodMs() {
@@ -299,6 +308,14 @@ public class Config {
 
     public Config networkBaselineBandwidth(long networkBaselineBandwidth) {
         this.networkBaselineBandwidth = networkBaselineBandwidth;
+        return this;
+    }
+
+    /**
+     * Sets the network bandwidth limiting mode.
+     */
+    public Config networkBandwidthMode(NetworkBandwidthMode networkBandwidthMode) {
+        this.networkBandwidthMode = networkBandwidthMode;
         return this;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/NetworkStats.java
@@ -23,7 +23,8 @@ import com.automq.stream.s3.metrics.Metrics;
 import com.automq.stream.s3.metrics.MetricsLevel;
 import com.automq.stream.s3.metrics.wrapper.Counter;
 import com.automq.stream.s3.metrics.wrapper.DeltaHistogram;
-import com.automq.stream.s3.network.AsyncNetworkBandwidthLimiter;
+import com.automq.stream.s3.network.MeteredNetworkBandwidthLimiter;
+import com.automq.stream.s3.network.NetworkBandwidthMode;
 import com.automq.stream.s3.network.ThrottleStrategy;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -44,10 +45,6 @@ public class NetworkStats {
         .longCounter("kafka_stream_network_inbound_usage", "Network inbound usage", "bytes");
     private static final Metrics.LongCounterBundle NETWORK_OUTBOUND_USAGE = Metrics.instance()
         .longCounter("kafka_stream_network_outbound_usage", "Network outbound usage", "bytes");
-    private static final Metrics.HistogramBundle NETWORK_INBOUND_LIMITER_QUEUE_TIME = Metrics.instance()
-        .histogram("kafka_stream_network_inbound_limiter_queue_time", "Network inbound limiter queue time", "nanoseconds");
-    private static final Metrics.HistogramBundle NETWORK_OUTBOUND_LIMITER_QUEUE_TIME = Metrics.instance()
-        .histogram("kafka_stream_network_outbound_limiter_queue_time", "Network outbound limiter queue time", "nanoseconds");
     private static final NetworkStats INSTANCE = new NetworkStats();
     // <StreamId, <FastReadBytes, SlowReadBytes>>
     private final Map<Long, Pair<Counter, Counter>> streamReadBytesStats = new ConcurrentHashMap<>();
@@ -59,6 +56,8 @@ public class NetworkStats {
     private final Map<ThrottleStrategy, Metrics.LongCounterBundle.LongCounter> networkOutboundUsageTotalStats = new ConcurrentHashMap<>();
     private final Map<ThrottleStrategy, DeltaHistogram> networkInboundLimiterQueueTimeStatsMap = new ConcurrentHashMap<>();
     private final Map<ThrottleStrategy, DeltaHistogram> networkOutboundLimiterQueueTimeStatsMap = new ConcurrentHashMap<>();
+    private volatile long networkBaselineBandwidth = -1;
+    private volatile NetworkBandwidthMode networkBandwidthMode = NetworkBandwidthMode.SEPARATE;
 
     private NetworkStats() {
         for (ThrottleStrategy strategy : ThrottleStrategy.values()) {
@@ -71,14 +70,6 @@ public class NetworkStats {
                 .register(MetricsLevel.INFO, attributes(strategy));
             outboundUsage.add(0);
             networkOutboundUsageTotalStats.put(strategy, outboundUsage);
-
-            DeltaHistogram inboundQueueTime = NETWORK_INBOUND_LIMITER_QUEUE_TIME
-                .histogram(MetricsLevel.INFO, attributes(strategy));
-            networkInboundLimiterQueueTimeStatsMap.put(strategy, inboundQueueTime);
-
-            DeltaHistogram outboundQueueTime = NETWORK_OUTBOUND_LIMITER_QUEUE_TIME
-                .histogram(MetricsLevel.INFO, attributes(strategy));
-            networkOutboundLimiterQueueTimeStatsMap.put(strategy, outboundQueueTime);
         }
     }
 
@@ -86,13 +77,21 @@ public class NetworkStats {
         return INSTANCE;
     }
 
-    public void recordNetworkUsageTotal(AsyncNetworkBandwidthLimiter.Type type, ThrottleStrategy strategy, long value) {
-        Counter total = type == AsyncNetworkBandwidthLimiter.Type.INBOUND ? networkInboundUsageTotal : networkOutboundUsageTotal;
+    /**
+     * Configures broker-level network utilization calculation.
+     */
+    public void setup(long baselineBandwidth, NetworkBandwidthMode mode) {
+        this.networkBaselineBandwidth = baselineBandwidth;
+        this.networkBandwidthMode = mode;
+    }
+
+    public void recordNetworkUsageTotal(MeteredNetworkBandwidthLimiter.Direction direction, ThrottleStrategy strategy, long value) {
+        Counter total = direction == MeteredNetworkBandwidthLimiter.Direction.INBOUND ? networkInboundUsageTotal : networkOutboundUsageTotal;
         total.inc(value);
-        Map<ThrottleStrategy, Metrics.LongCounterBundle.LongCounter> stats = type == AsyncNetworkBandwidthLimiter.Type.INBOUND ? networkInboundUsageTotalStats : networkOutboundUsageTotalStats;
+        Map<ThrottleStrategy, Metrics.LongCounterBundle.LongCounter> stats = direction == MeteredNetworkBandwidthLimiter.Direction.INBOUND ? networkInboundUsageTotalStats : networkOutboundUsageTotalStats;
         Metrics.LongCounterBundle.LongCounter metric = stats.get(strategy);
         if (metric == null) {
-            if (type == AsyncNetworkBandwidthLimiter.Type.INBOUND) {
+            if (direction == MeteredNetworkBandwidthLimiter.Direction.INBOUND) {
                 metric = stats.computeIfAbsent(strategy, k -> NETWORK_INBOUND_USAGE.register(MetricsLevel.INFO, attributes(strategy)));
             } else {
                 metric = stats.computeIfAbsent(strategy, k -> NETWORK_OUTBOUND_USAGE.register(MetricsLevel.INFO, attributes(strategy)));
@@ -134,14 +133,35 @@ public class NetworkStats {
     }
 
     /**
-     * Returns the broker-level network utilization against the configured baseline bandwidth.
+     * Returns the total inbound and outbound network usage bytes per second.
      */
-    public double networkUtil(long baselineBandwidth) {
+    public double networkSharedRate() {
+        return networkInboundRate() + networkOutboundRate();
+    }
+
+    /**
+     * Returns broker-level network utilization using the latest configured baseline bandwidth and bandwidth mode.
+     * Returns {@link Double#NaN} before a valid network stats setup.
+     */
+    public double networkUtil() {
+        if (networkBaselineBandwidth <= 0) {
+            return Double.NaN;
+        }
+        return calculateNetworkUtil(networkInboundRate(), networkOutboundRate(), networkBaselineBandwidth, networkBandwidthMode);
+    }
+
+    /**
+     * Calculates network utilization from sampled directional rates and the configured bandwidth mode.
+     */
+    static double calculateNetworkUtil(double inboundRate, double outboundRate, long baselineBandwidth, NetworkBandwidthMode mode) {
         if (baselineBandwidth <= 0) {
             return Double.NaN;
         }
-        double inboundUtil = networkInboundRate() / baselineBandwidth;
-        double outboundUtil = networkOutboundRate() / baselineBandwidth;
+        double inboundUtil = inboundRate / baselineBandwidth;
+        double outboundUtil = outboundRate / baselineBandwidth;
+        if (mode == NetworkBandwidthMode.SHARED) {
+            return inboundUtil + outboundUtil;
+        }
         return Math.max(inboundUtil, outboundUtil);
     }
 
@@ -157,22 +177,32 @@ public class NetworkStats {
         return streamReadBytesStats;
     }
 
-    public void recordNetworkLimiterQueueTime(AsyncNetworkBandwidthLimiter.Type type, ThrottleStrategy strategy, long value) {
+    public void recordNetworkLimiterQueueTime(MeteredNetworkBandwidthLimiter.Direction direction, ThrottleStrategy strategy, long value) {
         DeltaHistogram metric;
-        if (type == AsyncNetworkBandwidthLimiter.Type.INBOUND) {
+        if (direction == MeteredNetworkBandwidthLimiter.Direction.INBOUND) {
             metric = networkInboundLimiterQueueTimeStatsMap.get(strategy);
             if (metric == null) {
                 metric = networkInboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy,
-                    k -> NETWORK_INBOUND_LIMITER_QUEUE_TIME.histogram(MetricsLevel.INFO, attributes(strategy)));
+                    k -> NetworkInboundLimiterQueueTimeMetric.BUNDLE.histogram(MetricsLevel.INFO, attributes(strategy)));
             }
         } else {
             metric = networkOutboundLimiterQueueTimeStatsMap.get(strategy);
             if (metric == null) {
                 metric = networkOutboundLimiterQueueTimeStatsMap.computeIfAbsent(strategy,
-                    k -> NETWORK_OUTBOUND_LIMITER_QUEUE_TIME.histogram(MetricsLevel.INFO, attributes(strategy)));
+                    k -> NetworkOutboundLimiterQueueTimeMetric.BUNDLE.histogram(MetricsLevel.INFO, attributes(strategy)));
             }
         }
         metric.record(value);
+    }
+
+    private static class NetworkInboundLimiterQueueTimeMetric {
+        private static final Metrics.HistogramBundle BUNDLE = Metrics.instance()
+            .histogram("kafka_stream_network_inbound_limiter_queue_time", "Network inbound limiter queue time", "nanoseconds");
+    }
+
+    private static class NetworkOutboundLimiterQueueTimeMetric {
+        private static final Metrics.HistogramBundle BUNDLE = Metrics.instance()
+            .histogram("kafka_stream_network_outbound_limiter_queue_time", "Network outbound limiter queue time", "nanoseconds");
     }
 
     private static Attributes attributes(ThrottleStrategy strategy) {

--- a/s3stream/src/main/java/com/automq/stream/s3/network/AsyncNetworkBandwidthLimiter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/AsyncNetworkBandwidthLimiter.java
@@ -19,9 +19,6 @@
 
 package com.automq.stream.s3.network;
 
-import com.automq.stream.s3.metrics.Metrics;
-import com.automq.stream.s3.metrics.MetricsLevel;
-import com.automq.stream.s3.metrics.stats.NetworkStats;
 import com.automq.stream.utils.LogContext;
 import com.automq.stream.utils.Threads;
 
@@ -40,34 +37,25 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.opentelemetry.api.common.Attributes;
 
 public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
     private static final Logger LOGGER = new LogContext().logger(AsyncNetworkBandwidthLimiter.class);
     private static final long MAX_TOKEN_PART_SIZE = 1024 * 1024;
-    private static final Metrics.LongGaugeBundle.LongGauge NETWORK_INBOUND_LIMITER_QUEUE_SIZE = Metrics.instance()
-        .longGauge("kafka_stream_network_inbound_limiter_queue_size", "Network inbound limiter queue size", "")
-        .register(MetricsLevel.DEBUG, Attributes.empty());
-    private static final Metrics.LongGaugeBundle.LongGauge NETWORK_OUTBOUND_LIMITER_QUEUE_SIZE = Metrics.instance()
-        .longGauge("kafka_stream_network_outbound_limiter_queue_size", "Network outbound limiter queue size", "")
-        .register(MetricsLevel.DEBUG, Attributes.empty());
     private final Lock lock = new ReentrantLock();
     private final Condition condition = lock.newCondition();
     private final long maxTokens;
     private final ScheduledExecutorService refillThreadPool;
     private final ExecutorService callbackThreadPool;
     private final Queue<BucketItem> queuedCallbacks;
-    private final Type type;
     private final long tokenSize;
     private final AtomicLong availableTokens;
 
-    public AsyncNetworkBandwidthLimiter(Type type, long tokenSize, int refillIntervalMs) {
-        this(type, tokenSize, refillIntervalMs, tokenSize);
+    public AsyncNetworkBandwidthLimiter(long tokenSize, int refillIntervalMs) {
+        this(tokenSize, refillIntervalMs, tokenSize);
     }
 
     @SuppressWarnings("this-escape")
-    public AsyncNetworkBandwidthLimiter(Type type, long tokenSize, int refillIntervalMs, long maxTokens) {
-        this.type = type;
+    public AsyncNetworkBandwidthLimiter(long tokenSize, int refillIntervalMs, long maxTokens) {
         this.tokenSize = tokenSize;
         this.availableTokens = new AtomicLong(this.tokenSize);
         this.maxTokens = maxTokens;
@@ -78,16 +66,6 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
         this.callbackThreadPool = Threads.newFixedFastThreadLocalThreadPoolWithMonitor(2, "callback-thread", true, LOGGER);
         this.callbackThreadPool.execute(this::run);
         this.refillThreadPool.scheduleAtFixedRate(this::refillToken, refillIntervalMs, refillIntervalMs, TimeUnit.MILLISECONDS);
-        switch (type) {
-            case INBOUND:
-                NETWORK_INBOUND_LIMITER_QUEUE_SIZE.record(this::getQueueSize);
-                break;
-            case OUTBOUND:
-                NETWORK_OUTBOUND_LIMITER_QUEUE_SIZE.record(this::getQueueSize);
-                break;
-        }
-        LOGGER.info("AsyncNetworkBandwidthLimiter initialized, type: {}, tokenSize: {}, maxTokens: {}, refillIntervalMs: {}",
-            type.getName(), tokenSize, maxTokens, refillIntervalMs);
     }
 
     private void run() {
@@ -146,6 +124,7 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
         return availableTokens.get();
     }
 
+    @Override
     public int getQueueSize() {
         lock.lock();
         try {
@@ -161,7 +140,6 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
 
     public CompletableFuture<Void> consume(ThrottleStrategy throttleStrategy, long size) {
         CompletableFuture<Void> cf = new CompletableFuture<>();
-        cf.whenComplete((v, e) -> NetworkStats.getInstance().recordNetworkUsageTotal(type, throttleStrategy, size));
         if (Objects.requireNonNull(throttleStrategy) == ThrottleStrategy.BYPASS) {
             forceConsume(size);
             cf.complete(null);
@@ -189,22 +167,7 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
         this.availableTokens.getAndUpdate(old -> Math.max(-maxTokens, old - size));
     }
 
-    public enum Type {
-        INBOUND("Inbound"),
-        OUTBOUND("Outbound");
-
-        private final String name;
-
-        Type(String name) {
-            this.name = name;
-        }
-
-        public String getName() {
-            return name;
-        }
-    }
-
-    private class BucketItem implements Comparable<BucketItem> {
+    private static class BucketItem implements Comparable<BucketItem> {
         private final ThrottleStrategy strategy;
         private final CompletableFuture<Void> cf;
         private final long timestamp;
@@ -229,7 +192,6 @@ public class AsyncNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
             size -= completeSize;
             if (size <= 0) {
                 executor.submit(() -> cf.complete(null));
-                NetworkStats.getInstance().recordNetworkLimiterQueueTime(type, strategy, System.nanoTime() - timestamp);
                 return true;
             }
             return false;

--- a/s3stream/src/main/java/com/automq/stream/s3/network/GlobalNetworkBandwidthLimiters.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/GlobalNetworkBandwidthLimiters.java
@@ -19,15 +19,24 @@
 
 package com.automq.stream.s3.network;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.automq.stream.s3.metrics.Metrics;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.stats.NetworkStats;
+import com.automq.stream.utils.LogContext;
+
+import org.slf4j.Logger;
+
+import io.opentelemetry.api.common.Attributes;
 
 public class GlobalNetworkBandwidthLimiters {
-    private final Map<AsyncNetworkBandwidthLimiter.Type, AsyncNetworkBandwidthLimiter> limiters = new HashMap<>();
+    private static final Logger LOGGER = new LogContext().logger(GlobalNetworkBandwidthLimiters.class);
+    private static final int OUTBOUND_MAX_TOKENS_MULTIPLIER = 5;
+    private static final int SHARED_MAX_TOKENS_MULTIPLIER = 2;
 
     private static final GlobalNetworkBandwidthLimiters INSTANCE = new GlobalNetworkBandwidthLimiters();
-    private NetworkBandwidthLimiter inboundLimiter = AsyncNetworkBandwidthLimiter.NOOP;
-    private NetworkBandwidthLimiter outboundLimiter = AsyncNetworkBandwidthLimiter.NOOP;
+    private volatile boolean setup = false;
+    private volatile NetworkBandwidthLimiter inboundLimiter = AsyncNetworkBandwidthLimiter.NOOP;
+    private volatile NetworkBandwidthLimiter outboundLimiter = AsyncNetworkBandwidthLimiter.NOOP;
 
     private GlobalNetworkBandwidthLimiters() {}
 
@@ -35,32 +44,74 @@ public class GlobalNetworkBandwidthLimiters {
         return INSTANCE;
     }
 
-    public void setup(AsyncNetworkBandwidthLimiter.Type type, long tokenSize, int refillIntervalMs, long maxTokens) {
-        if (limiters.containsKey(type)) {
-            throw new IllegalArgumentException(type + " is already setup");
+    /**
+     * Initializes global directional limiter views from the configured bandwidth mode.
+     */
+    public synchronized void setup(NetworkBandwidthMode mode, long bandwidth, int refillIntervalMs) {
+        if (setup) {
+            throw new IllegalArgumentException("Network bandwidth limiters are already setup");
         }
-        limiters.put(type, new AsyncNetworkBandwidthLimiter(type, tokenSize, refillIntervalMs, maxTokens));
-        if (type == AsyncNetworkBandwidthLimiter.Type.INBOUND) {
-            inboundLimiter = limiters.get(type);
-        } else if (type == AsyncNetworkBandwidthLimiter.Type.OUTBOUND) {
-            outboundLimiter = limiters.get(type);
+        long tokenSize = (long) (bandwidth * ((double) refillIntervalMs / 1000));
+        if (tokenSize <= 0) {
+            throw new IllegalArgumentException(String.format("tokenSize must be greater than 0, bandwidth: %d, refill period: %dms",
+                bandwidth, refillIntervalMs));
         }
+        NetworkStats.getInstance().setup(bandwidth, mode);
+
+        if (mode == NetworkBandwidthMode.SHARED) {
+            AsyncNetworkBandwidthLimiter physicalSharedLimiter = new AsyncNetworkBandwidthLimiter(
+                tokenSize, refillIntervalMs, bandwidth * SHARED_MAX_TOKENS_MULTIPLIER);
+            inboundLimiter = meter(MeteredNetworkBandwidthLimiter.Direction.INBOUND, physicalSharedLimiter);
+            outboundLimiter = meter(MeteredNetworkBandwidthLimiter.Direction.OUTBOUND, physicalSharedLimiter);
+            Metrics.LongGaugeBundle.LongGauge networkSharedAvailableBandwidthMetric =
+                NetworkSharedAvailableBandwidthMetric.BUNDLE.register(MetricsLevel.INFO, Attributes.empty());
+            networkSharedAvailableBandwidthMetric.record(() -> bandwidth - (long) NetworkStats.getInstance().networkSharedRate());
+        } else {
+            AsyncNetworkBandwidthLimiter physicalInboundLimiter = new AsyncNetworkBandwidthLimiter(
+                tokenSize, refillIntervalMs, bandwidth);
+            // Use a larger token pool for outbound traffic to avoid spikes caused by Upload WAL affecting
+            // tail-reading performance.
+            AsyncNetworkBandwidthLimiter physicalOutboundLimiter = new AsyncNetworkBandwidthLimiter(
+                tokenSize, refillIntervalMs, bandwidth * OUTBOUND_MAX_TOKENS_MULTIPLIER);
+            inboundLimiter = meter(MeteredNetworkBandwidthLimiter.Direction.INBOUND, physicalInboundLimiter);
+            outboundLimiter = meter(MeteredNetworkBandwidthLimiter.Direction.OUTBOUND, physicalOutboundLimiter);
+            Metrics.LongGaugeBundle.LongGauge networkInboundAvailableBandwidthMetric =
+                NetworkInboundAvailableBandwidthMetric.BUNDLE.register(MetricsLevel.INFO, Attributes.empty());
+            networkInboundAvailableBandwidthMetric.record(() -> bandwidth - (long) NetworkStats.getInstance().networkInboundRate());
+            Metrics.LongGaugeBundle.LongGauge networkOutboundAvailableBandwidthMetric =
+                NetworkOutboundAvailableBandwidthMetric.BUNDLE.register(MetricsLevel.INFO, Attributes.empty());
+            networkOutboundAvailableBandwidthMetric.record(() -> bandwidth - (long) NetworkStats.getInstance().networkOutboundRate());
+        }
+        setup = true;
+        LOGGER.info("Global network bandwidth limiters setup, mode: {}, bandwidth: {}, tokenSize: {}, refillIntervalMs: {}",
+            mode.getName(), bandwidth, tokenSize, refillIntervalMs);
     }
 
-    public NetworkBandwidthLimiter get(AsyncNetworkBandwidthLimiter.Type type) {
-        AsyncNetworkBandwidthLimiter limiter = limiters.get(type);
-        if (limiter == null) {
-            return AsyncNetworkBandwidthLimiter.NOOP;
-        }
-        return limiter;
+    private NetworkBandwidthLimiter meter(MeteredNetworkBandwidthLimiter.Direction direction, NetworkBandwidthLimiter delegate) {
+        return new MeteredNetworkBandwidthLimiter(direction, delegate);
     }
 
     public NetworkBandwidthLimiter inbound() {
         return inboundLimiter;
     }
 
-    public  NetworkBandwidthLimiter outbound() {
+    public NetworkBandwidthLimiter outbound() {
         return outboundLimiter;
+    }
+
+    private static class NetworkInboundAvailableBandwidthMetric {
+        private static final Metrics.LongGaugeBundle BUNDLE = Metrics.instance()
+            .longGauge("kafka_stream_network_inbound_available_bandwidth", "Network inbound available bandwidth", "bytes");
+    }
+
+    private static class NetworkOutboundAvailableBandwidthMetric {
+        private static final Metrics.LongGaugeBundle BUNDLE = Metrics.instance()
+            .longGauge("kafka_stream_network_outbound_available_bandwidth", "Network outbound available bandwidth", "bytes");
+    }
+
+    private static class NetworkSharedAvailableBandwidthMetric {
+        private static final Metrics.LongGaugeBundle BUNDLE = Metrics.instance()
+            .longGauge("kafka_stream_network_shared_available_bandwidth", "Network shared available bandwidth", "bytes");
     }
 
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/network/MeteredNetworkBandwidthLimiter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/MeteredNetworkBandwidthLimiter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.network;
+
+import com.automq.stream.s3.metrics.Metrics;
+import com.automq.stream.s3.metrics.MetricsLevel;
+import com.automq.stream.s3.metrics.stats.NetworkStats;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.opentelemetry.api.common.Attributes;
+
+/**
+ * Records directional network metrics while delegating throttling to another limiter.
+ */
+public class MeteredNetworkBandwidthLimiter implements NetworkBandwidthLimiter {
+    private final Direction direction;
+    private final NetworkBandwidthLimiter delegate;
+    private final Metrics.LongGaugeBundle.LongGauge queueSizeMetric;
+
+    @SuppressWarnings("this-escape")
+    public MeteredNetworkBandwidthLimiter(Direction direction, NetworkBandwidthLimiter delegate) {
+        this.direction = direction;
+        this.delegate = delegate;
+        this.queueSizeMetric = queueSizeMetric(direction);
+        this.queueSizeMetric.record(delegate::getQueueSize);
+    }
+
+    @Override
+    public CompletableFuture<Void> consume(ThrottleStrategy throttleStrategy, long size) {
+        long startNs = System.nanoTime();
+        CompletableFuture<Void> cf = delegate.consume(throttleStrategy, size);
+        boolean queued = !cf.isDone();
+        cf.whenComplete((v, e) -> {
+            NetworkStats.getInstance().recordNetworkUsageTotal(direction, throttleStrategy, size);
+            if (queued) {
+                NetworkStats.getInstance().recordNetworkLimiterQueueTime(
+                    direction, throttleStrategy, System.nanoTime() - startNs);
+            }
+        });
+        return cf;
+    }
+
+    @Override
+    public long getMaxTokens() {
+        return delegate.getMaxTokens();
+    }
+
+    @Override
+    public long getAvailableTokens() {
+        return delegate.getAvailableTokens();
+    }
+
+    @Override
+    public int getQueueSize() {
+        return delegate.getQueueSize();
+    }
+
+    @Override
+    public void shutdown() {
+        queueSizeMetric.close();
+        // The delegate owns its lifecycle.
+    }
+
+    private static Metrics.LongGaugeBundle.LongGauge queueSizeMetric(Direction direction) {
+        switch (direction) {
+            case INBOUND:
+                return NetworkInboundLimiterQueueSizeMetric.BUNDLE.register(MetricsLevel.DEBUG, Attributes.empty());
+            case OUTBOUND:
+                return NetworkOutboundLimiterQueueSizeMetric.BUNDLE.register(MetricsLevel.DEBUG, Attributes.empty());
+            default:
+                throw new IllegalArgumentException("Unsupported network bandwidth limiter direction: " + direction);
+        }
+    }
+
+    public enum Direction {
+        INBOUND,
+        OUTBOUND
+    }
+
+    private static class NetworkInboundLimiterQueueSizeMetric {
+        private static final Metrics.LongGaugeBundle BUNDLE = Metrics.instance()
+            .longGauge("kafka_stream_network_inbound_limiter_queue_size", "Network inbound limiter queue size", "");
+    }
+
+    private static class NetworkOutboundLimiterQueueSizeMetric {
+        private static final Metrics.LongGaugeBundle BUNDLE = Metrics.instance()
+            .longGauge("kafka_stream_network_outbound_limiter_queue_size", "Network outbound limiter queue size", "");
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/network/NetworkBandwidthLimiter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/NetworkBandwidthLimiter.java
@@ -45,6 +45,14 @@ public interface NetworkBandwidthLimiter {
 
     long getAvailableTokens();
 
+    /**
+     * Returns the current number of requests waiting for this limiter. Implementations without a
+     * backing queue return {@code 0}; wrappers may return the delegate's physical queue size.
+     */
+    default int getQueueSize() {
+        return 0;
+    }
+
     void shutdown();
 
 

--- a/s3stream/src/main/java/com/automq/stream/s3/network/NetworkBandwidthMode.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/network/NetworkBandwidthMode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.network;
+
+import java.util.Locale;
+
+/**
+ * Describes whether inbound and outbound network traffic use separate or shared bandwidth buckets.
+ */
+public enum NetworkBandwidthMode {
+    SEPARATE("separate"),
+    SHARED("shared");
+
+    private final String name;
+
+    NetworkBandwidthMode(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the config value used to select this mode.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Parses a config value into a network bandwidth mode.
+     *
+     * @throws IllegalArgumentException if the value is not a supported mode.
+     */
+    public static NetworkBandwidthMode parse(String value) {
+        String normalized = value == null ? null : value.trim().toLowerCase(Locale.ROOT);
+        for (NetworkBandwidthMode mode : values()) {
+            if (mode.name.equals(normalized)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException(String.format(Locale.ROOT,
+            "Unsupported network bandwidth mode: %s", value));
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/AsyncNetworkBandwidthLimiterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/AsyncNetworkBandwidthLimiterTest.java
@@ -35,7 +35,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testByPassConsume() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 5000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 5000);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.BYPASS, 1);
         Assertions.assertEquals(9, bucket.getAvailableTokens());
         Assertions.assertTrue(cf.isDone());
@@ -43,7 +43,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testByPassConsume2() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 1000);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.BYPASS, 20);
         Assertions.assertEquals(-10, bucket.getAvailableTokens());
         CompletableFuture<Void> result = cf.whenComplete((v, e) -> {
@@ -56,7 +56,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsume() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 1000);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.CATCH_UP, 1);
         Assertions.assertEquals(9, bucket.getAvailableTokens());
         Assertions.assertTrue(cf.isDone());
@@ -64,7 +64,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsume2() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 1000);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.CATCH_UP, 20);
         Assertions.assertEquals(-10, bucket.getAvailableTokens());
         CompletableFuture<Void> result = cf.whenComplete((v, e) -> {
@@ -77,7 +77,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsume3() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 1000);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.BYPASS, 20);
         Assertions.assertEquals(-10, bucket.getAvailableTokens());
         Assertions.assertTrue(cf.isDone());
@@ -93,8 +93,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsume4() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(
-            AsyncNetworkBandwidthLimiter.Type.INBOUND, 100, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(100, 1000);
         bucket.consume(ThrottleStrategy.BYPASS, 1000);
         Assertions.assertEquals(-100, bucket.getAvailableTokens());
         CompletableFuture<Boolean> firstCompleted = new CompletableFuture<>();
@@ -113,7 +112,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsume5() throws InterruptedException {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 10, 100, 200);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(10, 100, 200);
         bucket.consume(ThrottleStrategy.BYPASS, 1000);
         Assertions.assertEquals(-200, bucket.getAvailableTokens());
         Thread.sleep(500);
@@ -126,7 +125,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsumeWithPriority() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 100, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(100, 1000);
         bucket.consume(ThrottleStrategy.BYPASS, 1000);
         Assertions.assertEquals(-100, bucket.getAvailableTokens());
         bucket.consume(ThrottleStrategy.COMPACTION, 10);
@@ -147,7 +146,7 @@ public class AsyncNetworkBandwidthLimiterTest {
 
     @Test
     public void testThrottleConsumeWithPriority1() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 1024 * 1024, 1000);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(1024 * 1024, 1000);
         bucket.consume(ThrottleStrategy.BYPASS, 1024 * 1024);
         Assertions.assertEquals(0, bucket.getAvailableTokens());
         CompletableFuture<Void> cf2 = bucket.consume(ThrottleStrategy.CATCH_UP, 5 * 1024 * 1024);
@@ -166,7 +165,7 @@ public class AsyncNetworkBandwidthLimiterTest {
     @Test
     @Timeout(10)
     public void testThrottleConsumeWithLargeChunk() {
-        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(AsyncNetworkBandwidthLimiter.Type.INBOUND, 1024 * 1024, 100);
+        AsyncNetworkBandwidthLimiter bucket = new AsyncNetworkBandwidthLimiter(1024 * 1024, 100);
         CompletableFuture<Void> bypassCf = bucket.consume(ThrottleStrategy.BYPASS, 1024 * 1024);
         CompletableFuture<Void> cf = bucket.consume(ThrottleStrategy.CATCH_UP, 10 * 1024 * 1024);
         CompletableFuture<Void> result = cf.whenComplete((v, e) -> {

--- a/s3stream/src/test/java/com/automq/stream/s3/NetworkBandwidthModeTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/NetworkBandwidthModeTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3;
+
+import com.automq.stream.s3.network.NetworkBandwidthMode;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("S3Unit")
+public class NetworkBandwidthModeTest {
+
+    /**
+     * Given a config string, when parsing network bandwidth mode, then only supported mode names are accepted.
+     */
+    @Test
+    public void testParseNetworkBandwidthMode() {
+        assertEquals(NetworkBandwidthMode.SEPARATE, NetworkBandwidthMode.parse("separate"));
+        assertEquals(NetworkBandwidthMode.SHARED, NetworkBandwidthMode.parse("shared"));
+        assertEquals(NetworkBandwidthMode.SHARED, NetworkBandwidthMode.parse(" SHARED "));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBandwidthMode.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBandwidthMode.parse("mixed"));
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/metrics/stats/NetworkStatsTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/metrics/stats/NetworkStatsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.metrics.stats;
+
+import com.automq.stream.s3.network.MeteredNetworkBandwidthLimiter;
+import com.automq.stream.s3.network.NetworkBandwidthLimiter;
+import com.automq.stream.s3.network.NetworkBandwidthMode;
+import com.automq.stream.s3.network.ThrottleStrategy;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("S3Unit")
+public class NetworkStatsTest {
+
+    /**
+     * Given sampled inbound and outbound rates, when calculating shared utilization, then both directions are summed.
+     */
+    @Test
+    public void testSharedNetworkUtilUsesTotalRate() {
+        assertEquals(0.7, NetworkStats.calculateNetworkUtil(30, 40, 100, NetworkBandwidthMode.SHARED), 0.0001);
+    }
+
+    /**
+     * Given sampled inbound and outbound rates, when calculating separate utilization, then the busier direction is used.
+     */
+    @Test
+    public void testSeparateNetworkUtilUsesMaxDirectionalRate() {
+        assertEquals(0.4, NetworkStats.calculateNetworkUtil(30, 40, 100, NetworkBandwidthMode.SEPARATE), 0.0001);
+    }
+
+    /**
+     * Given NetworkStats setup stores bandwidth mode, when calculating network utilization, then callers do not pass bandwidth or mode repeatedly.
+     */
+    @Test
+    public void testSetupStoresNetworkUtilConfig() throws Exception {
+        NetworkStats.getInstance().setup(100, NetworkBandwidthMode.SHARED);
+
+        assertEquals(100L, fieldValue("networkBaselineBandwidth"));
+        assertEquals(NetworkBandwidthMode.SHARED, fieldValue("networkBandwidthMode"));
+    }
+
+    /**
+     * Given NetworkStats owns bandwidth mode, when inspecting public APIs, then old instance networkUtil overloads are not exposed.
+     */
+    @Test
+    public void testNetworkUtilDoesNotExposeOldInstanceOverloads() {
+        for (Method method : NetworkStats.class.getDeclaredMethods()) {
+            if (!method.getName().equals("networkUtil")) {
+                continue;
+            }
+            assertEquals(0, method.getParameterCount(), "NetworkStats instance networkUtil should not require bandwidth or mode");
+        }
+    }
+
+    private static Object fieldValue(String fieldName) throws Exception {
+        Field field = NetworkStats.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(NetworkStats.getInstance());
+    }
+
+    /**
+     * Given direction-metered limiter wrappers, when delegated consumption waits asynchronously, then queue time is recorded for that direction.
+     */
+    @Test
+    public void testMeteredLimiterRecordsQueueTimeOnlyWhenFutureIsNotDone() throws Exception {
+        long baseline = inboundQueueTimeCount();
+        CompletableFuture<Void> delayedFuture = new CompletableFuture<>();
+        MeteredNetworkBandwidthLimiter limiter = new MeteredNetworkBandwidthLimiter(
+            MeteredNetworkBandwidthLimiter.Direction.INBOUND, new TestLimiter(delayedFuture));
+
+        limiter.consume(ThrottleStrategy.CATCH_UP, 10);
+        assertEquals(baseline, inboundQueueTimeCount());
+
+        delayedFuture.complete(null);
+        assertEquals(baseline + 1, inboundQueueTimeCount());
+
+        limiter.consume(ThrottleStrategy.CATCH_UP, 10).join();
+        assertEquals(baseline + 1, inboundQueueTimeCount());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static long inboundQueueTimeCount() throws Exception {
+        Field field = NetworkStats.class.getDeclaredField("networkInboundLimiterQueueTimeStatsMap");
+        field.setAccessible(true);
+        Map<ThrottleStrategy, ?> metrics = (Map<ThrottleStrategy, ?>) field.get(NetworkStats.getInstance());
+        Object metric = metrics.get(ThrottleStrategy.CATCH_UP);
+        if (metric == null) {
+            return 0;
+        }
+        return (long) metric.getClass().getMethod("cumulativeCount").invoke(metric);
+    }
+
+    private static class TestLimiter implements NetworkBandwidthLimiter {
+        private final CompletableFuture<Void> future;
+
+        TestLimiter(CompletableFuture<Void> future) {
+            this.future = future;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ThrottleStrategy throttleStrategy, long size) {
+            return future;
+        }
+
+        @Override
+        public long getMaxTokens() {
+            return 0;
+        }
+
+        @Override
+        public long getAvailableTokens() {
+            return 0;
+        }
+
+        @Override
+        public void shutdown() {
+        }
+    }
+}


### PR DESCRIPTION
## Why

Some cloud and private environments account network ingress and egress against one shared bandwidth budget instead of independent inbound and outbound limits. The existing limiter model assumes separate inbound and outbound capacity, which matches environments such as AWS but can overestimate usable bandwidth when both directions compete for the same link. This change adds an explicit shared mode so data-plane S3 traffic can be throttled against a single network budget and reported with a mutually exclusive shared available-bandwidth metric.

## What

- add `s3.network.bandwidth.mode` with `separate` and `shared` modes, defaulting to `separate`
- centralize data-plane network limiter setup in `GlobalNetworkBandwidthLimiters`
- add shared available-bandwidth metric while keeping directional queue size/time and usage metrics
- move limiter usage/queue-time recording into directional metered wrappers
- configure `NetworkStats` with bandwidth mode for no-arg network utilization calculation

Cherry-picked from #3456 for the 1.7 branch.