### PR TITLE
test: add regression test for AutoMQ target-node partition change builder

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/ElasticPartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ElasticPartitionChangeBuilderTest.java
@@ -19,9 +19,11 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.es.ElasticStreamSwitch;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.Replicas;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,7 +32,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // TODO: add test for AutoMQ partition change
 @Timeout(60)
@@ -58,8 +64,18 @@ public class ElasticPartitionChangeBuilderTest {
         assertElectLeaderEquals(createRecoveringFOOBuilder().setElection(PartitionChangeBuilder.Election.PREFERRED).setTargetNode(100), 100, false);
         assertElectLeaderEquals(createRecoveringFOOBuilder().setTargetNode(101), 101, false);
         assertElectLeaderEquals(createRecoveringFOOBuilder().setElection(PartitionChangeBuilder.Election.UNCLEAN).setTargetNode(102), 102, false);
+    }
 
+    @Test
+    public void testBuildWithTargetNodeProducesSingleReplicaChangeRecord() {
+        Optional<ApiMessageAndVersion> change = createFooBuilder().setTargetNode(100).build();
 
+        assertTrue(change.isPresent());
+        PartitionChangeRecord record = (PartitionChangeRecord) change.get().message();
+        assertEquals(100, record.leader());
+        assertEquals(List.of(100), record.isr());
+        assertEquals(List.of(100), record.replicas());
+        assertEquals(LeaderRecoveryState.RECOVERED.value(), record.leaderRecoveryState());
     }
 
     private static final PartitionRegistration FOO = new PartitionRegistration.Builder()


### PR DESCRIPTION
This PR adds a regression test for the AutoMQ‑specific target‑node leader election path in the partition change builder.

**What Changed**
Introduced a new test in ElasticPartitionChangeBuilderTest.java that exercises the setTargetNode behavior through the change‑record build path.

The test verifies that the emitted change record:

- assigns the leader,
- sets the ISR to the target node,
- sets the replica list to the target node,
- marks leader recovery as recovered.

**Why This Is Useful**

- Strengthens coverage for AutoMQ‑specific partition change logic.
- Provides confidence in a critical leader election path.
- Helps prevent regressions without altering production code.

**Testing Strategy**

- Verified correctness through the new unit test.
- CI pipeline validation will ensure full test execution and integration.
