### PR TITLE
feat(s3stream): recycle sequential byte buffer slabs

### DIFF
--- a/core/src/main/java/kafka/automq/partition/snapshot/ConfirmWalDataDelta.java
+++ b/core/src/main/java/kafka/automq/partition/snapshot/ConfirmWalDataDelta.java
@@ -198,10 +198,14 @@ public class ConfirmWalDataDelta implements ConfirmWAL.AppendListener {
         }
         List<StreamRecordBatch> records = new ArrayList<>();
         ByteBuf buf = Unpooled.wrappedBuffer(data);
-        while (buf.readableBytes() > 0) {
-            StreamRecordBatch record = StreamRecordBatch.parse(buf, false);
-            records.add(record);
+        try {
+            while (buf.readableBytes() > 0) {
+                StreamRecordBatch record = StreamRecordBatch.parse(buf, false, null);
+                records.add(record);
+            }
+            return records;
+        } finally {
+            buf.release();
         }
-        return records;
     }
 }

--- a/core/src/main/java/kafka/automq/zerozone/DefaultLinkRecordDecoder.java
+++ b/core/src/main/java/kafka/automq/zerozone/DefaultLinkRecordDecoder.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.RecordBatch;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.s3.ByteBufSupplier;
 import com.automq.stream.s3.model.StreamRecordBatch;
 
 import org.slf4j.Logger;
@@ -47,7 +47,7 @@ public class DefaultLinkRecordDecoder implements com.automq.stream.api.LinkRecor
     }
 
     @Override
-    public CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSeqAlloc alloc) {
+    public CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSupplier alloc) {
         try {
             LinkRecord linkRecord = LinkRecord.decode(src.getPayload());
             ChannelOffset channelOffset = linkRecord.channelOffset();

--- a/core/src/main/java/kafka/automq/zerozone/ObjectRouterChannel.java
+++ b/core/src/main/java/kafka/automq/zerozone/ObjectRouterChannel.java
@@ -19,7 +19,7 @@
 
 package kafka.automq.zerozone;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.trace.context.TraceContext;
@@ -48,7 +48,9 @@ import io.netty.buffer.ByteBuf;
 public class ObjectRouterChannel implements RouterChannel {
     private static final ExecutorService ASYNC_EXECUTOR = Executors.newCachedThreadPool();
     private static final long OVER_CAPACITY_RETRY_DELAY_MS = 1000L;
-    private static final ByteBufSeqAlloc ALLOC = new ByteBufSeqAlloc(ByteBufAlloc.ENCODE_RECORD, 4);
+    // Owned by this class for the process lifetime so all router channels reuse the same slabs.
+    private static final RecyclingByteBufSeqAlloc ALLOC =
+        new RecyclingByteBufSeqAlloc(ByteBufAlloc.ROUTER_CHANNEL);
     private final Logger logger;
     private final AtomicLong mockOffset = new AtomicLong(0);
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();

--- a/core/src/test/java/kafka/automq/backpressure/DefaultBackPressureManagerTest.java
+++ b/core/src/test/java/kafka/automq/backpressure/DefaultBackPressureManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+@Tag("S3Unit")
 public class DefaultBackPressureManagerTest {
     static String sourceA = "sourceA";
     static String sourceB = "sourceB";

--- a/core/src/test/java/kafka/automq/partition/snapshot/ConfirmWalDataDeltaTest.java
+++ b/core/src/test/java/kafka/automq/partition/snapshot/ConfirmWalDataDeltaTest.java
@@ -22,11 +22,13 @@ package kafka.automq.partition.snapshot;
 import org.apache.kafka.common.message.AutomqGetPartitionSnapshotResponseData;
 
 import com.automq.stream.s3.ConfirmWAL;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -42,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("S3Unit")
 public class ConfirmWalDataDeltaTest {
 
     ConfirmWAL confirmWAL;
@@ -135,7 +138,7 @@ public class ConfirmWalDataDeltaTest {
     }
 
     int onAppend(long recordBaseOffset) {
-        StreamRecordBatch record = StreamRecordBatch.of(1, 2, recordBaseOffset, 1, Unpooled.wrappedBuffer(new byte[1024]));
+        StreamRecordBatch record = StreamRecordBatch.of(1, 2, recordBaseOffset, 1, Unpooled.wrappedBuffer(new byte[1024]), DefaultByteBufSupplier.INSTANCE);
         nextWalOffset = walOffset + record.encoded().readableBytes();
         delta.onAppend(
             record,

--- a/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
+++ b/core/src/test/java/kafka/automq/partition/snapshot/PartitionSnapshotsManagerTest.java
@@ -32,18 +32,23 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
 import org.apache.kafka.storage.internals.log.TimestampOffset;
 
 import com.automq.stream.s3.ConfirmWAL;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,9 +63,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("S3Unit")
 public class PartitionSnapshotsManagerTest {
     private MockTime time;
     private ConfirmWAL confirmWAL;
@@ -130,6 +137,7 @@ public class PartitionSnapshotsManagerTest {
 
     @Test
     public void testConfirmWalDeltaWakesPendingLongPoll() throws Exception {
+        Deque<Runnable> longPollTasks = useManualLongPollExecutor();
         when(confirmWAL.confirmOffset()).thenReturn(DefaultRecordOffset.of(1, 0, 0));
         AutomqGetPartitionSnapshotResponse first = manager.handle(request(0, 0, false, (short) 1, (short) 2))
             .get(1, TimeUnit.SECONDS);
@@ -138,6 +146,8 @@ public class PartitionSnapshotsManagerTest {
             request(first.data().sessionId(), first.data().sessionEpoch(), false, (short) 1, (short) 2));
         assertFalse(second.isDone());
         appendWalRecord(0, 0);
+        assertEquals(1, longPollTasks.size());
+        longPollTasks.removeFirst().run();
 
         AutomqGetPartitionSnapshotResponse walOffsetResponse = second.get(1, TimeUnit.SECONDS);
         assertTrue(walOffsetResponse.data().topics().isEmpty());
@@ -147,6 +157,8 @@ public class PartitionSnapshotsManagerTest {
             request(walOffsetResponse.data().sessionId(), walOffsetResponse.data().sessionEpoch(), false, (short) 1, (short) 2));
         assertFalse(third.isDone());
         appendWalRecord(1, 1);
+        assertEquals(1, longPollTasks.size());
+        longPollTasks.removeFirst().run();
 
         AutomqGetPartitionSnapshotResponse walDeltaResponse = third.get(1, TimeUnit.SECONDS);
         assertTrue(walDeltaResponse.data().topics().isEmpty());
@@ -322,7 +334,7 @@ public class PartitionSnapshotsManagerTest {
     }
 
     private void appendWalRecord(long baseOffset, long walOffset) {
-        StreamRecordBatch record = StreamRecordBatch.of(1, 2, baseOffset, 1, Unpooled.wrappedBuffer(new byte[1]));
+        StreamRecordBatch record = StreamRecordBatch.of(1, 2, baseOffset, 1, Unpooled.wrappedBuffer(new byte[1]), DefaultByteBufSupplier.INSTANCE);
         appendListener.get().onAppend(
             record,
             DefaultRecordOffset.of(1, walOffset, 1),
@@ -335,6 +347,21 @@ public class PartitionSnapshotsManagerTest {
         Field field = PartitionSnapshotsManager.class.getDeclaredField("longPollExecutor");
         field.setAccessible(true);
         return (ScheduledExecutorService) field.get(manager);
+    }
+
+    private Deque<Runnable> useManualLongPollExecutor() throws Exception {
+        Deque<Runnable> tasks = new ArrayDeque<>();
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        ScheduledFuture<?> timeout = mock(ScheduledFuture.class);
+        doReturn(timeout).when(executor).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        doAnswer(invocation -> {
+            tasks.addLast(invocation.getArgument(0));
+            return null;
+        }).when(executor).execute(any(Runnable.class));
+        Field field = PartitionSnapshotsManager.class.getDeclaredField("longPollExecutor");
+        field.setAccessible(true);
+        field.set(manager, executor);
+        return tasks;
     }
 
     private static Partition partition(Uuid topicId, int partitionId, int leaderEpoch, long endOffset) {

--- a/core/src/test/java/kafka/automq/table/CatalogFactoryTest.java
+++ b/core/src/test/java/kafka/automq/table/CatalogFactoryTest.java
@@ -11,6 +11,7 @@ import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.util.SerializableMap;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
+@Tag("S3Unit")
 class CatalogFactoryTest {
     // minimalistic properties to let KafkaConfig validation pass and let us test our catalog factory
     private final Map<String, String> requiredKafkaConfigProperties = Map.of(

--- a/core/src/test/java/kafka/automq/table/binder/AvroRecordBinderTypeTest.java
+++ b/core/src/test/java/kafka/automq/table/binder/AvroRecordBinderTypeTest.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
@@ -87,6 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Tag("S3Unit")
 public class AvroRecordBinderTypeTest {
 
     private static final String TEST_NAMESPACE = "kafka.automq.table.binder";

--- a/core/src/test/java/kafka/automq/table/process/convert/ProtoToAvroConverterTest.java
+++ b/core/src/test/java/kafka/automq/table/process/convert/ProtoToAvroConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.protobuf.ProtobufData;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Focused unit tests for {@link ProtoToAvroConverter} exercise converter paths that are
  * hard to reach through the higher-level registry converter integration tests.
  */
+@Tag("S3Unit")
 class ProtoToAvroConverterTest {
 
     private static final String SIMPLE_PROTO = """

--- a/core/src/test/java/kafka/automq/table/worker/IcebergSchemaChangeCollectorTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/IcebergSchemaChangeCollectorTest.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@Tag("S3Unit")
 public class IcebergSchemaChangeCollectorTest {
     private InMemoryCatalog catalog;
 

--- a/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
+++ b/core/src/test/java/kafka/automq/table/worker/TableWorkersTest.java
@@ -24,6 +24,7 @@ import kafka.server.KafkaConfig;
 
 import org.apache.kafka.server.config.ZkConfigs;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -32,6 +33,7 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@Tag("S3Unit")
 class TableWorkersTest {
     @Test
     void tableTopicSchemaRegistryClientConfigsMapsAutoMQPrefix() {

--- a/core/src/test/java/kafka/automq/zerozone/LegacyRecordConverterTest.java
+++ b/core/src/test/java/kafka/automq/zerozone/LegacyRecordConverterTest.java
@@ -8,6 +8,7 @@ import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -19,6 +20,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("S3Unit")
 public class LegacyRecordConverterTest {
 
     @ParameterizedTest(name = "Test {index} {0}")

--- a/core/src/test/java/kafka/automq/zerozone/LinkRecordTest.java
+++ b/core/src/test/java/kafka/automq/zerozone/LinkRecordTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 
 import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -34,6 +35,7 @@ import io.netty.buffer.ByteBuf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("S3Unit")
 public class LinkRecordTest {
 
     @Test

--- a/core/src/test/java/kafka/automq/zerozone/RouterPermitLimiterTest.java
+++ b/core/src/test/java/kafka/automq/zerozone/RouterPermitLimiterTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.yammer.metrics.core.Histogram;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("S3Unit")
 public class RouterPermitLimiterTest {
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/stream/StreamControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/stream/StreamControlManagerTest.java
@@ -70,6 +70,7 @@ import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.metadata.ObjectUtils;
@@ -1537,7 +1538,7 @@ public class StreamControlManagerTest {
             objectWriter.write(
                 range.streamId(),
                 List.of(
-                    StreamRecordBatch.of(range.streamId(), 0, range.startOffset(), (int) (range.endOffset() - range.startOffset()), Unpooled.buffer(1))
+                    StreamRecordBatch.of(range.streamId(), 0, range.startOffset(), (int) (range.endOffset() - range.startOffset()), Unpooled.buffer(1), DefaultByteBufSupplier.INSTANCE)
                 )
             )
         );

--- a/s3stream/src/main/java/com/automq/stream/RecyclingByteBufSeqAlloc.java
+++ b/s3stream/src/main/java/com/automq/stream/RecyclingByteBufSeqAlloc.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.ByteBufSupplier;
+import com.automq.stream.utils.Systems;
+import com.automq.stream.utils.Threads;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * Allocates sequential retained slices from recyclable fixed-size slabs.
+ *
+ * <p>The allocator owns one reference to every slab until the slab expires or this allocator is closed. A slab is
+ * reused only after all slices derived from it have been released. The heap/direct allocation mode is captured on the
+ * first allocation and remains fixed for the allocator lifetime.</p>
+ *
+ * <p>This class is thread-safe. {@link #close()} prevents new allocations and releases all slab owner references, but
+ * does not invalidate slices still retained by callers.</p>
+ */
+public class RecyclingByteBufSeqAlloc implements ByteBufSupplier, AutoCloseable {
+    public static final int DIRECT_SLAB_SIZE = ByteBufAlloc.getChunkSize().orElse(4 << 20);
+
+    private static final int HEAP_SLAB_SIZE = (4 << 20) - 64;
+    private static final long HEAP_BYTES_PER_SLOT = 2L << 30;
+    private static final int DEFAULT_CONCURRENCY = (int) Math.min(Systems.CPU_CORES,
+        Math.max(Systems.HEAP_MEMORY_SIZE / HEAP_BYTES_PER_SLOT, 1));
+    private static final long DEFAULT_FREE_TTL_NANOS = TimeUnit.MINUTES.toNanos(1);
+    private static final int MAX_ALLOC_PATH_EVICTIONS = 16;
+    private static final String METRIC_SOURCE = "seq_alloc";
+    private static final ConcurrentMap<Integer, LongAdder> RETAINED_MEMORY = new ConcurrentHashMap<>();
+
+    private final int allocType;
+    private final Slot[] slots;
+    private final Object initLock = new Object();
+    private final ReentrantLock poolLock = new ReentrantLock();
+    private final ArrayDeque<Slab> retired = new ArrayDeque<>();
+    private final ArrayDeque<Slab> free = new ArrayDeque<>();
+    private final long freeTtlNanos;
+    private final ScheduledExecutorService scheduler;
+    private final LongSupplier nanoTime;
+
+    private volatile boolean closed;
+    private volatile Mode mode;
+    private ScheduledFuture<?> maintenanceTask;
+
+    /**
+     * Creates an allocator whose concurrency scales with the available processors and maximum heap size.
+     *
+     * @param allocType allocation type used for direct buffers and metrics
+     */
+    public RecyclingByteBufSeqAlloc(int allocType) {
+        this(allocType, DEFAULT_CONCURRENCY);
+    }
+
+    /**
+     * Creates an allocator with the requested number of concurrent allocation slots.
+     *
+     * @param allocType allocation type used for direct buffers and metrics
+     * @param concurrency number of independent sequential allocation slots
+     */
+    public RecyclingByteBufSeqAlloc(int allocType, int concurrency) {
+        this(allocType, concurrency, DEFAULT_FREE_TTL_NANOS, Threads.COMMON_SCHEDULER, System::nanoTime);
+    }
+
+    RecyclingByteBufSeqAlloc(int allocType, int concurrency, long freeTtlNanos,
+        ScheduledExecutorService scheduler, LongSupplier nanoTime) {
+        if (concurrency <= 0) {
+            throw new IllegalArgumentException("concurrency must be positive");
+        }
+        if (freeTtlNanos <= 0) {
+            throw new IllegalArgumentException("freeTtlNanos must be positive");
+        }
+        this.allocType = allocType;
+        this.slots = new Slot[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            slots[i] = new Slot();
+        }
+        this.freeTtlNanos = freeTtlNanos;
+        this.scheduler = Objects.requireNonNull(scheduler);
+        this.nanoTime = Objects.requireNonNull(nanoTime);
+    }
+
+    /**
+     * Allocates a buffer with zero reader and writer indexes and exactly the requested capacity.
+     *
+     * @param capacity requested buffer capacity
+     * @return a retained slab slice, or a standalone buffer when the request is larger than a slab
+     * @throws IllegalStateException if this allocator has been closed
+     */
+    @Override
+    public ByteBuf alloc(int capacity) {
+        if (capacity < 0) {
+            throw new IllegalArgumentException("capacity must not be negative");
+        }
+        Mode mode = mode();
+        Slot slot = slots[Math.floorMod(Thread.currentThread().hashCode(), slots.length)];
+        List<Slab> evicted = null;
+        ByteBuf result;
+        slot.lock.lock();
+        try {
+            ensureOpen();
+            if (capacity > mode.slabCapacity) {
+                return allocateBacking(mode.direct, capacity);
+            }
+            if (slot.current == null || !slot.current.satisfies(capacity)) {
+                Slab slab;
+                poolLock.lock();
+                try {
+                    if (slot.current != null) {
+                        retired.offerLast(slot.current);
+                        slot.current = null;
+                    }
+                    long now = nanoTime.getAsLong();
+                    harvestFirstReadyRun(now);
+                    slab = free.pollLast();
+                    evicted = evictExpired(now, MAX_ALLOC_PATH_EVICTIONS);
+                } finally {
+                    poolLock.unlock();
+                }
+                if (slab == null) {
+                    slab = newSlab(mode);
+                }
+                slot.current = slab;
+            }
+            result = slot.current.allocate(capacity);
+        } finally {
+            slot.lock.unlock();
+            releaseOwners(evicted);
+        }
+        return result;
+    }
+
+    /**
+     * Stops maintenance and releases every owner reference held by this allocator.
+     * Caller-owned retained slices remain valid until callers release them.
+     */
+    @Override
+    public void close() {
+        synchronized (initLock) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            if (maintenanceTask != null) {
+                maintenanceTask.cancel(false);
+            }
+        }
+
+        List<Slab> toRelease = new ArrayList<>();
+        drainSlabs(0, toRelease);
+        releaseOwners(toRelease);
+    }
+
+    private void drainSlabs(int slotIndex, List<Slab> toRelease) {
+        if (slotIndex < slots.length) {
+            Slot slot = slots[slotIndex];
+            slot.lock.lock();
+            try {
+                drainSlabs(slotIndex + 1, toRelease);
+            } finally {
+                slot.lock.unlock();
+            }
+            return;
+        }
+
+        poolLock.lock();
+        try {
+            for (Slot slot : slots) {
+                if (slot.current != null) {
+                    toRelease.add(slot.current);
+                    slot.current = null;
+                }
+            }
+            toRelease.addAll(retired);
+            retired.clear();
+            toRelease.addAll(free);
+            free.clear();
+        } finally {
+            poolLock.unlock();
+        }
+    }
+
+    private Mode mode() {
+        Mode current = mode;
+        if (current != null) {
+            return current;
+        }
+        synchronized (initLock) {
+            ensureOpen();
+            if (mode == null) {
+                boolean direct = ByteBufAlloc.getPolicy().isDirect();
+                int slabCapacity = direct ? DIRECT_SLAB_SIZE : HEAP_SLAB_SIZE;
+                LongAdder retainedBytes = retainedMemory(allocType);
+                Mode initialized = new Mode(direct, slabCapacity, retainedBytes);
+                ScheduledFuture<?> task = scheduler.scheduleWithFixedDelay(this::maintain, freeTtlNanos,
+                    freeTtlNanos, TimeUnit.NANOSECONDS);
+                mode = initialized;
+                maintenanceTask = task;
+            }
+            return mode;
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("allocator is closed");
+        }
+    }
+
+    private Slab newSlab(Mode mode) {
+        Slab slab = new Slab(allocateBacking(mode.direct, mode.slabCapacity));
+        mode.retainedBytes.add(slab.owner.capacity());
+        return slab;
+    }
+
+    private ByteBuf allocateBacking(boolean direct, int capacity) {
+        if (direct) {
+            return ByteBufAlloc.byteBuffer(capacity, allocType);
+        }
+        return Unpooled.wrappedBuffer(new byte[capacity]).clear();
+    }
+
+    private void harvestFirstReadyRun(long now) {
+        Slab head = retired.peekFirst();
+        if (head != null && head.reusable()) {
+            do {
+                moveToFree(retired.pollFirst(), now);
+                head = retired.peekFirst();
+            } while (head != null && head.reusable());
+            return;
+        }
+
+        boolean found = false;
+        Iterator<Slab> iterator = retired.iterator();
+        while (iterator.hasNext()) {
+            Slab slab = iterator.next();
+            if (!slab.reusable()) {
+                if (found) {
+                    break;
+                }
+                continue;
+            }
+            found = true;
+            iterator.remove();
+            moveToFree(slab, now);
+        }
+    }
+
+    private void harvestAllReady(long now) {
+        Iterator<Slab> iterator = retired.iterator();
+        while (iterator.hasNext()) {
+            Slab slab = iterator.next();
+            if (slab.reusable()) {
+                iterator.remove();
+                moveToFree(slab, now);
+            }
+        }
+    }
+
+    private void moveToFree(Slab slab, long now) {
+        slab.reset();
+        slab.freeSinceNanos = now;
+        free.offerLast(slab);
+    }
+
+    private List<Slab> evictExpired(long now, int limit) {
+        Slab slab = free.peekFirst();
+        if (slab == null || now - slab.freeSinceNanos < freeTtlNanos) {
+            return null;
+        }
+        List<Slab> evicted = new ArrayList<>(Math.min(limit, MAX_ALLOC_PATH_EVICTIONS));
+        do {
+            evicted.add(free.pollFirst());
+            slab = free.peekFirst();
+        } while (evicted.size() < limit && slab != null && now - slab.freeSinceNanos >= freeTtlNanos);
+        return evicted;
+    }
+
+    private void maintain() {
+        List<Slab> evicted;
+        poolLock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            long now = nanoTime.getAsLong();
+            harvestAllReady(now);
+            evicted = evictExpired(now, Integer.MAX_VALUE);
+        } finally {
+            poolLock.unlock();
+        }
+        releaseOwners(evicted);
+    }
+
+    private void releaseOwners(List<Slab> slabs) {
+        if (slabs == null) {
+            return;
+        }
+        Mode current = mode;
+        for (Slab slab : slabs) {
+            current.retainedBytes.add(-slab.owner.capacity());
+            ReferenceCountUtil.safeRelease(slab.owner);
+        }
+    }
+
+    private static LongAdder retainedMemory(int allocType) {
+        return RETAINED_MEMORY.computeIfAbsent(allocType, ignored -> {
+            LongAdder value = new LongAdder();
+            ByteBufAlloc.registerAllocatedMemoryGauge(allocType, METRIC_SOURCE, value::sum);
+            return value;
+        });
+    }
+
+    private static final class Slot {
+        private final ReentrantLock lock = new ReentrantLock();
+        private Slab current;
+    }
+
+    private static final class Mode {
+        private final boolean direct;
+        private final int slabCapacity;
+        private final LongAdder retainedBytes;
+
+        private Mode(boolean direct, int slabCapacity, LongAdder retainedBytes) {
+            this.direct = direct;
+            this.slabCapacity = slabCapacity;
+            this.retainedBytes = retainedBytes;
+        }
+    }
+
+    private static final class Slab {
+        private final ByteBuf owner;
+        private int nextIndex;
+        private long freeSinceNanos;
+
+        private Slab(ByteBuf owner) {
+            this.owner = owner;
+        }
+
+        private ByteBuf allocate(int capacity) {
+            int start = nextIndex;
+            nextIndex += capacity;
+            ByteBuf slice = owner.retainedSlice(start, capacity);
+            slice.writerIndex(0);
+            return slice;
+        }
+
+        private boolean satisfies(int capacity) {
+            return nextIndex + capacity <= owner.capacity();
+        }
+
+        private boolean reusable() {
+            return owner.refCnt() == 1;
+        }
+
+        private void reset() {
+            nextIndex = 0;
+        }
+    }
+
+}

--- a/s3stream/src/main/java/com/automq/stream/api/LinkRecordDecoder.java
+++ b/s3stream/src/main/java/com/automq/stream/api/LinkRecordDecoder.java
@@ -19,7 +19,7 @@
 
 package com.automq.stream.api;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.s3.ByteBufSupplier;
 import com.automq.stream.s3.model.StreamRecordBatch;
 
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +34,10 @@ public interface LinkRecordDecoder {
      */
     int decodedSize(ByteBuf linkRecordBuf);
 
-    CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSeqAlloc alloc);
+    /**
+     * Decodes a link record with the supplied buffer allocator.
+     */
+    CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSupplier alloc);
 
 
     class Noop implements LinkRecordDecoder {
@@ -45,7 +48,7 @@ public interface LinkRecordDecoder {
         }
 
         @Override
-        public CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSeqAlloc alloc) {
+        public CompletableFuture<StreamRecordBatch> decode(StreamRecordBatch src, ByteBufSupplier alloc) {
             return CompletableFuture.failedFuture(new UnsupportedOperationException());
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ByteBufAlloc.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
 
 import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
@@ -50,6 +51,8 @@ public class ByteBufAlloc {
     public static final int MEMORY_USAGE_DETECT_INTERVAL = Systems.getEnvInt("AUTOMQ_MEMORY_USAGE_DETECT_TIME_INTERVAL", 60000);
 
     private static final AttributeKey<String> LABEL_TYPE = AttributeKey.stringKey("type");
+    private static final AttributeKey<String> LABEL_SOURCE = AttributeKey.stringKey("source");
+    private static final String SOURCE_BYTE_BUF_ALLOC = "byte_buf_alloc";
     private static final Logger LOGGER = LoggerFactory.getLogger(ByteBufAlloc.class);
 
     public static final int DEFAULT = 0;
@@ -67,6 +70,7 @@ public class ByteBufAlloc {
     public static final int S3_WAL = 12;
     public static final int POOLED_MEMORY_RECORDS = 13;
     public static final int SNAPSHOT_READ_CACHE = 14;
+    public static final int ROUTER_CHANNEL = 15;
 
     // the MAX_TYPE_NUMBER may change when new type added.
     public static final int MAX_TYPE_NUMBER = 20;
@@ -116,8 +120,9 @@ public class ByteBufAlloc {
         registerAllocType(S3_WAL, "s3_wal");
         registerAllocType(POOLED_MEMORY_RECORDS, "pooled_memory_records");
         registerAllocType(SNAPSHOT_READ_CACHE, "snapshot_read_cache");
+        registerAllocType(ROUTER_CHANNEL, "router_channel");
         BUFFER_ALLOCATED_MEMORY_SIZE.register(MetricsLevel.INFO,
-            Attributes.of(LABEL_TYPE, "-1/unknown"), observable ->
+            allocatedMemoryAttributes("-1/unknown", SOURCE_BYTE_BUF_ALLOC), observable ->
                 allocatedMemory("-1/unknown").ifPresent(observable::record));
         BUFFER_USED_MEMORY_SIZE.register(MetricsLevel.DEBUG, Attributes.empty(), observable ->
             usedMemory().ifPresent(observable::record));
@@ -147,6 +152,29 @@ public class ByteBufAlloc {
             return Optional.of(((PooledByteBufAllocatorMetric) metric).chunkSize());
         }
         return Optional.empty();
+    }
+
+    /**
+     * Gets the metric label value for an allocation type.
+     *
+     * @param type allocation type
+     * @return the registered type label, or {@code -1/unknown} when the type is not registered
+     */
+    public static String getAllocTypeName(int type) {
+        String name = ALLOC_TYPE.get(type);
+        return name == null ? "-1/unknown" : type + "/" + name;
+    }
+
+    /**
+     * Registers an additional allocated-memory gauge with the standard type and source labels.
+     *
+     * @param type allocation type
+     * @param source allocation source
+     * @param valueSupplier current allocated bytes
+     */
+    public static void registerAllocatedMemoryGauge(int type, String source, LongSupplier valueSupplier) {
+        BUFFER_ALLOCATED_MEMORY_SIZE.register(MetricsLevel.INFO,
+            allocatedMemoryAttributes(getAllocTypeName(type), source)).record(valueSupplier);
     }
 
     public static CompositeByteBuf compositeByteBuffer() {
@@ -205,10 +233,17 @@ public class ByteBufAlloc {
         }
 
         ALLOC_TYPE.put(type, name);
-        String typeName = type + "/" + name;
+        String typeName = getAllocTypeName(type);
         BUFFER_ALLOCATED_MEMORY_SIZE.register(MetricsLevel.INFO,
-            Attributes.of(LABEL_TYPE, typeName), observable ->
+            allocatedMemoryAttributes(typeName, SOURCE_BYTE_BUF_ALLOC), observable ->
                 allocatedMemory(typeName).ifPresent(observable::record));
+    }
+
+    private static Attributes allocatedMemoryAttributes(String type, String source) {
+        return Attributes.builder()
+            .put(LABEL_TYPE, type)
+            .put(LABEL_SOURCE, source)
+            .build();
     }
 
     private static AbstractByteBufAllocator getAllocatorByPolicy(ByteBufAllocPolicy policy) {

--- a/s3stream/src/main/java/com/automq/stream/s3/DefaultByteBufSupplier.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/DefaultByteBufSupplier.java
@@ -21,9 +21,19 @@ package com.automq.stream.s3;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Allocates buffers directly through {@link ByteBufAlloc} without sequential slab recycling.
+ */
 public class DefaultByteBufSupplier implements ByteBufSupplier {
+    public static final DefaultByteBufSupplier INSTANCE = new DefaultByteBufSupplier(ByteBufAlloc.DEFAULT);
+
     private final int type;
 
+    /**
+     * Creates a supplier that attributes allocations to the specified type.
+     *
+     * @param type allocation type defined by {@link ByteBufAlloc}
+     */
     public DefaultByteBufSupplier(int type) {
         this.type = type;
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/ObjectReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/ObjectReader.java
@@ -577,11 +577,23 @@ public interface ObjectReader extends AsyncMeasurable {
             return recordCount;
         }
 
+        /**
+         * Returns an iterator whose records retain slices of this data block's buffer.
+         * Each returned record must be released after use.
+         */
         public CloseableIterator<StreamRecordBatch> iterator() {
-            return iterator(true);
+            return iterator0(null);
         }
 
-        public CloseableIterator<StreamRecordBatch> iterator(boolean copy) {
+        /**
+         * Returns an iterator whose records are copied with the supplied allocator.
+         * Each returned record must be released after use.
+         */
+        public CloseableIterator<StreamRecordBatch> iterator(ByteBufSupplier alloc) {
+            return iterator0(Objects.requireNonNull(alloc, "alloc"));
+        }
+
+        private CloseableIterator<StreamRecordBatch> iterator0(ByteBufSupplier alloc) {
             ByteBuf buf = this.buf.duplicate();
             AtomicInteger currentBlockRecordCount = new AtomicInteger(0);
             AtomicInteger remainingRecordCount = new AtomicInteger(recordCount);
@@ -603,7 +615,7 @@ public interface ObjectReader extends AsyncMeasurable {
                         buf.skipBytes(4);
                     }
                     currentBlockRecordCount.decrementAndGet();
-                    return StreamRecordBatch.parse(buf, copy);
+                    return StreamRecordBatch.parse(buf, alloc != null, alloc);
                 }
 
                 @Override
@@ -612,6 +624,10 @@ public interface ObjectReader extends AsyncMeasurable {
             };
         }
 
+        /**
+         * Returns records that retain slices of this data block's buffer.
+         * Each returned record must be released after use.
+         */
         public List<StreamRecordBatch> records() {
             List<StreamRecordBatch> records = new ArrayList<>(recordCount);
             try (CloseableIterator<StreamRecordBatch> it = iterator()) {

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -19,7 +19,6 @@
 
 package com.automq.stream.s3;
 
-import com.automq.stream.ByteBufSeqAlloc;
 import com.automq.stream.Context;
 import com.automq.stream.api.LinkRecordDecoder;
 import com.automq.stream.api.exceptions.FastReadFailFastException;
@@ -92,7 +91,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 
-import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
 import static com.automq.stream.s3.ByteBufAlloc.ENCODE_RECORD;
 import static com.automq.stream.utils.FutureUtil.suppress;
 
@@ -120,7 +118,6 @@ public class S3Storage implements Storage {
     private static final DeltaHistogram FORCE_UPLOAD_WAL_COMPLETE_LATENCY = OperationLatencyMetrics.stage(MetricsLevel.INFO, S3Stage.FORCE_UPLOAD_WAL_COMPLETE);
     private static final DeltaHistogram READ_STORAGE_LATENCY = OperationLatencyMetrics.operation(MetricsLevel.INFO, S3Operation.READ_STORAGE);
     private static final FastReadFailFastException FAST_READ_FAIL_FAST_EXCEPTION = new FastReadFailFastException();
-    private static final ByteBufSeqAlloc DECODE_LINK_RECORD_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 1);
     private static final ByteBufSupplier ENCODE_LINK_RECORD_INSTANT_ALLOC = new DefaultByteBufSupplier(ENCODE_RECORD);
 
     private static final int NUM_STREAM_CALLBACK_LOCKS = 128;

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -21,6 +21,7 @@ package com.automq.stream.s3;
 
 import com.automq.stream.DefaultAppendResult;
 import com.automq.stream.RecordBatchWithContextWrapper;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.api.AppendResult;
 import com.automq.stream.api.FetchResult;
 import com.automq.stream.api.OpenStreamOptions;
@@ -72,12 +73,15 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 
+import static com.automq.stream.s3.ByteBufAlloc.ENCODE_RECORD;
 import static com.automq.stream.utils.FutureUtil.exec;
 import static com.automq.stream.utils.FutureUtil.propagate;
 
 public class S3Stream implements Stream, StreamMetadataListener {
     private static final PendingRequestTracker PENDING_APPEND_TRACKER = new PendingRequestTracker();
     private static final PendingRequestTracker PENDING_FETCH_TRACKER = new PendingRequestTracker();
+    // Shared for the process lifetime so streams reuse the same bounded set of active slabs.
+    private static final RecyclingByteBufSeqAlloc RECORD_ALLOC = new RecyclingByteBufSeqAlloc(ENCODE_RECORD);
     private static final Metrics.LongGaugeBundle.LongGauge PENDING_STREAM_APPEND_LATENCY = Metrics.instance()
         .longGauge("kafka_stream_pending_stream_append_latency",
             "The maximum latency of pending stream append requests that exceed the pending latency threshold. "
@@ -254,7 +258,8 @@ public class S3Stream implements Stream, StreamMetadataListener {
             return FutureUtil.failedFuture(new StreamClientException(ErrorCode.STREAM_ALREADY_CLOSED, logIdent + "stream is not writable"));
         }
         long offset = nextOffset.getAndAdd(recordBatch.count());
-        StreamRecordBatch streamRecordBatch = StreamRecordBatch.of(streamId, epoch, offset, recordBatch.count(), Unpooled.wrappedBuffer(recordBatch.rawPayload()));
+        StreamRecordBatch streamRecordBatch = StreamRecordBatch.of(streamId, epoch, offset, recordBatch.count(),
+            Unpooled.wrappedBuffer(recordBatch.rawPayload()), RECORD_ALLOC);
         CompletableFuture<AppendResult> cf = storage.append(context, streamRecordBatch).thenApply(nil -> {
             updateConfirmOffset(offset + recordBatch.count());
             return new DefaultAppendResult(offset);

--- a/s3stream/src/main/java/com/automq/stream/s3/WALRecovery.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/WALRecovery.java
@@ -19,7 +19,7 @@
 
 package com.automq.stream.s3;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.s3.cache.LogCache;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.wal.RecordOffset;
@@ -44,7 +44,9 @@ import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
  */
 public class WALRecovery {
     private static final Logger LOGGER = LoggerFactory.getLogger(WALRecovery.class);
-    private static final ByteBufSeqAlloc DECODE_LINK_RECORD_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 1);
+    // Owned by this class for the process lifetime so recovery operations reuse the same slabs.
+    private static final RecyclingByteBufSeqAlloc DECODE_LINK_RECORD_INSTANT_ALLOC =
+        new RecyclingByteBufSeqAlloc(DECODE_RECORD, 1);
 
     /**
      * Recover records from the WAL iterator, putting them into {@link LogCache.LogCacheBlock}s.

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/SnapshotReadCache.java
@@ -1,7 +1,8 @@
 package com.automq.stream.s3.cache;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.api.LinkRecordDecoder;
+import com.automq.stream.s3.ByteBufSupplier;
 import com.automq.stream.s3.DataBlockIndex;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.metadata.S3ObjectMetadata;
@@ -53,8 +54,11 @@ import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
 import static com.automq.stream.s3.ByteBufAlloc.SNAPSHOT_READ_CACHE;
 
 public class SnapshotReadCache {
-    public static final ByteBufSeqAlloc DECODE_LINK_INSTANT_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 4);
-    public static final ByteBufSeqAlloc ENCODE_ALLOC = new ByteBufSeqAlloc(SNAPSHOT_READ_CACHE, 1);
+    // Owned by this class for the process lifetime so snapshot caches reuse the same slabs.
+    private static final ByteBufSupplier DECODE_LINK_INSTANT_ALLOC =
+        new RecyclingByteBufSeqAlloc(DECODE_RECORD);
+    private static final ByteBufSupplier ENCODE_ALLOC =
+        new RecyclingByteBufSeqAlloc(SNAPSHOT_READ_CACHE, 1);
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotReadCache.class);
     private static final long MAX_INFLIGHT_LOAD_BYTES = 100L * 1024 * 1024;
 

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
@@ -19,6 +19,7 @@
 
 package com.automq.stream.s3.cache.blockcache;
 
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.s3.DataBlockIndex;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.model.StreamRecordBatch;
@@ -38,7 +39,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
 
+import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
+
 @EventLoopSafe public class DataBlock extends AbstractReferenceCounted {
+    // Shared by block-cache reads for the lifetime of the process.
+    private static final RecyclingByteBufSeqAlloc BLOCK_CACHE_ALLOC = new RecyclingByteBufSeqAlloc(BLOCK_CACHE);
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBlock.class);
     private static final int UNREAD_INIT = -1;
     private final long objectId;
@@ -175,7 +180,7 @@ import io.netty.util.ReferenceCounted;
         List<StreamRecordBatch> records = new ArrayList<>();
         int remainingBytes = maxBytes;
         // TODO: iterator from certain offset
-        try (CloseableIterator<StreamRecordBatch> it = dataBlockGroup.iterator()) {
+        try (CloseableIterator<StreamRecordBatch> it = dataBlockGroup.iterator(BLOCK_CACHE_ALLOC)) {
             while (it.hasNext()) {
                 StreamRecordBatch recordBatch = it.next();
                 if (recordBatch.getBaseOffset() < endOffset && recordBatch.getLastOffset() > startOffset) {

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionManager.java
@@ -18,7 +18,6 @@
  */
 package com.automq.stream.s3.compact;
 
-import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.Config;
 import com.automq.stream.s3.S3ObjectLogger;
 import com.automq.stream.s3.StreamDataBlock;
@@ -804,17 +803,6 @@ public class CompactionManager {
 
             streamObjectCfList.stream().map(CompletableFuture::join).forEach(request::addStreamObject);
 
-            if (ByteBufAlloc.getPolicy().isPooled()) {
-                // Check if all blocks are released after each iteration
-                List<CompactedObject> compactedObjects = compactionPlan.compactedObjects();
-                for (CompactedObject compactedObject : compactedObjects) {
-                    for (StreamDataBlock block : compactedObject.streamDataBlocks()) {
-                        if (block.getDataCf().join().refCnt() > 0) {
-                            logger.error("Block {} is not released after compaction, compact type: {}", block, compactedObject.type());
-                        }
-                    }
-                }
-            }
         }
         List<ObjectStreamRange> objectStreamRanges = CompactionUtils.buildObjectStreamRangeFromGroup(
             CompactionUtils.groupStreamDataBlocks(sortedStreamDataBlocks, new GroupByOffsetPredicate()));

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/operator/DataBlockReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/operator/DataBlockReader.java
@@ -19,7 +19,7 @@
 
 package com.automq.stream.s3.compact.operator;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.DataBlockIndex;
 import com.automq.stream.s3.ObjectReader;
@@ -51,7 +51,9 @@ import static com.automq.stream.s3.ByteBufAlloc.STREAM_SET_OBJECT_COMPACTION_REA
 //TODO: refactor to reduce duplicate code with ObjectWriter
 public class DataBlockReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBlockReader.class);
-    private static final ByteBufSeqAlloc DIRECT_ALLOC = new ByteBufSeqAlloc(STREAM_SET_OBJECT_COMPACTION_READ, 1);
+    // Owned by this class for the process lifetime so data block readers reuse the same slabs.
+    private static final RecyclingByteBufSeqAlloc DIRECT_ALLOC =
+        new RecyclingByteBufSeqAlloc(STREAM_SET_OBJECT_COMPACTION_READ, 1);
 
     private final S3ObjectMetadata metadata;
     private final String objectKey;

--- a/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
@@ -19,17 +19,15 @@
 
 package com.automq.stream.s3.model;
 
-import com.automq.stream.ByteBufSeqAlloc;
 import com.automq.stream.s3.ByteBufSupplier;
 import com.automq.stream.utils.biniarysearch.ComparableItem;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
-import static com.automq.stream.s3.ByteBufAlloc.DECODE_RECORD;
-import static com.automq.stream.s3.ByteBufAlloc.ENCODE_RECORD;
 import static com.automq.stream.s3.StreamRecordBatchCodec.BASE_OFFSET_POS;
 import static com.automq.stream.s3.StreamRecordBatchCodec.EPOCH_POS;
 import static com.automq.stream.s3.StreamRecordBatchCodec.HEADER_SIZE;
@@ -42,8 +40,6 @@ import static com.automq.stream.s3.StreamRecordBatchCodec.STREAM_ID_POS;
 
 public class StreamRecordBatch implements Comparable<StreamRecordBatch>, ComparableItem<Long> {
     private static final int OBJECT_OVERHEAD = 48 /* fields */ + 48 /* ByteBuf payload */ + 48 /* ByteBuf encoded */;
-    private static final ByteBufSeqAlloc ENCODE_ALLOC = new ByteBufSeqAlloc(ENCODE_RECORD, 8);
-    private static final ByteBufSeqAlloc DECODE_ALLOC = new ByteBufSeqAlloc(DECODE_RECORD, 8);
     // Cache the frequently used fields
     private final long baseOffset;
     private final int count;
@@ -136,20 +132,8 @@ public class StreamRecordBatch implements Comparable<StreamRecordBatch>, Compara
         return getBaseOffset() > value;
     }
 
-    public static StreamRecordBatch of(long streamId, long epoch, long baseOffset, int count, ByteBuffer payload) {
-        return of(streamId, epoch, baseOffset, count, Unpooled.wrappedBuffer(payload), ENCODE_ALLOC);
-    }
-
     public static StreamRecordBatch of(long streamId, long epoch, long baseOffset, int count, ByteBuffer payload, ByteBufSupplier alloc) {
         return of(streamId, epoch, baseOffset, count, Unpooled.wrappedBuffer(payload), alloc);
-    }
-
-    /**
-     * StreamRecordBatch.of expects take the owner of the payload.
-     * The payload will be copied to the new StreamRecordBatch and released.
-     */
-    public static StreamRecordBatch of(long streamId, long epoch, long baseOffset, int count, ByteBuf payload) {
-        return of(streamId, epoch, baseOffset, count, payload, ENCODE_ALLOC);
     }
 
     /**
@@ -171,16 +155,13 @@ public class StreamRecordBatch implements Comparable<StreamRecordBatch>, Compara
         return new StreamRecordBatch(buf);
     }
 
-    public static StreamRecordBatch parse(ByteBuf buf, boolean duplicated) {
-        return parse(buf, duplicated, DECODE_ALLOC);
-    }
-
     /**
      * Won't release the input ByteBuf.
      * - If duplicated is true, the returned StreamRecordBatch has its own copy of the data.
      * - If duplicated is false, the returned StreamRecordBatch shares and retains the data buffer with the input.
+     * The allocator is required when duplicated is true and may be null otherwise.
      */
-    public static StreamRecordBatch parse(ByteBuf buf, boolean duplicated, ByteBufSeqAlloc alloc) {
+    public static StreamRecordBatch parse(ByteBuf buf, boolean duplicated, ByteBufSupplier alloc) {
         int readerIndex = buf.readerIndex();
         byte magic = buf.getByte(readerIndex + MAGIC_POS);
         if (magic != MAGIC_V0) {
@@ -189,6 +170,7 @@ public class StreamRecordBatch implements Comparable<StreamRecordBatch>, Compara
         int payloadSize = buf.getInt(readerIndex + PAYLOAD_LENGTH_POS);
         int encodedSize = PAYLOAD_POS + payloadSize;
         if (duplicated) {
+            Objects.requireNonNull(alloc, "alloc");
             ByteBuf encoded = alloc.alloc(encodedSize);
             buf.readBytes(encoded, encodedSize);
             return new StreamRecordBatch(encoded);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/MemoryWriteAheadLog.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/MemoryWriteAheadLog.java
@@ -95,7 +95,7 @@ public class MemoryWriteAheadLog implements WriteAheadLog {
 
     @Override
     public CompletableFuture<StreamRecordBatch> get(RecordOffset recordOffset) {
-        return CompletableFuture.completedFuture(StreamRecordBatch.parse(dataMap.get(DefaultRecordOffset.of(recordOffset).offset()), false));
+        return CompletableFuture.completedFuture(StreamRecordBatch.parse(dataMap.get(DefaultRecordOffset.of(recordOffset).offset()), false, null));
     }
 
     @Override
@@ -103,7 +103,7 @@ public class MemoryWriteAheadLog implements WriteAheadLog {
         List<StreamRecordBatch> list = dataMap
             .subMap(DefaultRecordOffset.of(startOffset).offset(), true, DefaultRecordOffset.of(endOffset).offset(), false)
             .values().stream()
-            .map(buf -> StreamRecordBatch.parse(buf, false)).collect(Collectors.toList());
+            .map(buf -> StreamRecordBatch.parse(buf, false, null)).collect(Collectors.toList());
         return CompletableFuture.completedFuture(list);
     }
 
@@ -119,7 +119,7 @@ public class MemoryWriteAheadLog implements WriteAheadLog {
             .map(e -> (RecoverResult) new RecoverResult() {
                 @Override
                 public StreamRecordBatch record() {
-                    return StreamRecordBatch.parse(e.getValue(), false);
+                    return StreamRecordBatch.parse(e.getValue(), false, null);
                 }
 
                 @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -19,7 +19,7 @@
 
 package com.automq.stream.s3.wal.impl.object;
 
-import com.automq.stream.ByteBufSeqAlloc;
+import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.metrics.stats.StorageOperationStats;
 import com.automq.stream.s3.model.StreamRecordBatch;
@@ -79,7 +79,8 @@ public class DefaultWriter implements Writer {
     private static final long DEFAULT_LOCK_WARNING_TIMEOUT = TimeUnit.MILLISECONDS.toNanos(5);
     private static final long DEFAULT_UPLOAD_WARNING_TIMEOUT = TimeUnit.SECONDS.toNanos(5);
     private static final String OBJECT_PATH_FORMAT = "%s%d" + OBJECT_PATH_OFFSET_DELIMITER + "%d"; // {objectPrefix}/{startOffset}-{endOffset}
-    private static final ByteBufSeqAlloc BYTE_BUF_ALLOC = new ByteBufSeqAlloc(S3_WAL, 8);
+    // Owned by this class for the process lifetime so WAL writers reuse the same slabs.
+    private static final RecyclingByteBufSeqAlloc BYTE_BUF_ALLOC = new RecyclingByteBufSeqAlloc(S3_WAL);
     private static final ExecutorService UPLOAD_EXECUTOR = Threads.newFixedThreadPoolWithMonitor(Systems.CPU_CORES, "S3_WAL_UPLOAD", true, LOGGER);
     private static final ScheduledExecutorService SCHEDULE = Threads.newSingleThreadScheduledExecutor("S3_WAL_SCHEDULE", true, LOGGER);
 
@@ -480,7 +481,8 @@ public class DefaultWriter implements Writer {
             trimOffset.set(inclusiveTrimRecordOffset);
             // We cannot force upload an empty wal object cause of the recover workflow don't accept an empty wal object.
             // So we use a fake record to trigger the wal object upload.
-            persistTrimOffsetCf = append(StreamRecordBatch.of(-1L, -1L, 0, 0, Unpooled.EMPTY_BUFFER));
+            persistTrimOffsetCf = append(StreamRecordBatch.of(-1L, -1L, 0, 0, Unpooled.EMPTY_BUFFER,
+                BYTE_BUF_ALLOC));
             lastTrimCf = persistTrimOffsetCf.thenCompose(nil -> {
                 Long lastFlushedRecordOffset = lastRecordOffset2object.isEmpty() ? null : lastRecordOffset2object.lastKey();
                 if (lastFlushedRecordOffset != null) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectUtils.java
@@ -137,6 +137,6 @@ public class ObjectUtils {
         if (header.getMagicCode() != RecordHeader.RECORD_HEADER_DATA_MAGIC_CODE) {
             throw new IllegalStateException("Invalid magic code in record header.");
         }
-        return StreamRecordBatch.parse(dataBuffer, false);
+        return StreamRecordBatch.parse(dataBuffer, false, null);
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecoverIterator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/RecoverIterator.java
@@ -261,7 +261,7 @@ public class RecoverIterator implements Iterator<RecoverResult> {
         int size = recordBuf.readableBytes() + RECORD_HEADER_SIZE;
 
         try {
-            return new RecoverResultImpl(StreamRecordBatch.parse(recordBuf, false), DefaultRecordOffset.of(getEpoch(offset), offset, size));
+            return new RecoverResultImpl(StreamRecordBatch.parse(recordBuf, false, null), DefaultRecordOffset.of(getEpoch(offset), offset, size));
         } finally {
             recordBuf.release();
         }

--- a/s3stream/src/test/java/com/automq/stream/RecyclingByteBufSeqAllocTest.java
+++ b/s3stream/src/test/java/com/automq/stream/RecyclingByteBufSeqAllocTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream;
+
+import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.ByteBufAllocPolicy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Tag("S3Unit")
+class RecyclingByteBufSeqAllocTest {
+    private static final int SLICE_SIZE = 3 << 20;
+    private static final long TTL_NANOS = 100;
+
+    private ByteBufAllocPolicy previousPolicy;
+
+    @BeforeEach
+    void setUp() {
+        previousPolicy = ByteBufAlloc.getPolicy();
+        ByteBufAlloc.setPolicy(ByteBufAllocPolicy.POOLED_HEAP);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ByteBufAlloc.setPolicy(previousPolicy);
+    }
+
+    /**
+     * Given a slab-sized request, when a slice is allocated, then it has exact writable bounds and zero indexes.
+     */
+    @Test
+    void testAllocateExactWritableSlice() {
+        try (RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1)) {
+            ByteBuf buf = alloc.alloc(32);
+            assertEquals(32, buf.capacity());
+            assertEquals(32, buf.maxCapacity());
+            assertEquals(0, buf.readerIndex());
+            assertEquals(0, buf.writerIndex());
+            assertFalse(buf.isDirect());
+            buf.release();
+        }
+    }
+
+    /**
+     * Given a retired slab with no live slices, when another slab is needed, then the retired slab is reused.
+     */
+    @Test
+    void testReuseReleasedSlab() {
+        try (RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1)) {
+            ByteBuf first = alloc.alloc(SLICE_SIZE);
+            ByteBuf firstOwner = first.unwrap();
+            ByteBuf second = alloc.alloc(SLICE_SIZE);
+            first.release();
+
+            ByteBuf third = alloc.alloc(SLICE_SIZE);
+            assertSame(firstOwner, third.unwrap());
+
+            second.release();
+            third.release();
+        }
+    }
+
+    /**
+     * Given a retired slab with a live slice, when another slab is needed, then the pinned slab is not reused.
+     */
+    @Test
+    void testDoNotReusePinnedSlab() {
+        try (RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1)) {
+            ByteBuf first = alloc.alloc(SLICE_SIZE);
+            ByteBuf firstOwner = first.unwrap();
+            ByteBuf second = alloc.alloc(SLICE_SIZE);
+
+            ByteBuf third = alloc.alloc(SLICE_SIZE);
+            assertNotSame(firstOwner, third.unwrap());
+
+            first.release();
+            second.release();
+            third.release();
+        }
+    }
+
+    /**
+     * Given a request larger than a heap slab, when allocated, then a standalone exact-size buffer is returned.
+     */
+    @Test
+    void testAllocateStandaloneBuffer() {
+        try (RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1)) {
+            int capacity = 4 << 20;
+            ByteBuf buf = alloc.alloc(capacity);
+            assertEquals(capacity, buf.capacity());
+            assertEquals(0, buf.readerIndex());
+            assertEquals(0, buf.writerIndex());
+            buf.release();
+            assertEquals(0, buf.refCnt());
+        }
+    }
+
+    /**
+     * Given the direct policy, when a slice is allocated, then its slab backing is direct memory.
+     */
+    @Test
+    void testAllocateDirectSlab() {
+        ByteBufAlloc.setPolicy(ByteBufAllocPolicy.POOLED_DIRECT);
+        try (RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1)) {
+            ByteBuf buf = alloc.alloc(32);
+            assertTrue(buf.isDirect());
+            assertEquals(32, buf.capacity());
+            buf.release();
+        }
+    }
+
+    /**
+     * Given a live slice, when its allocator is closed, then the caller-owned slice remains valid.
+     */
+    @Test
+    void testCloseKeepsCallerSliceValid() {
+        RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1);
+        ByteBuf buf = alloc.alloc(Integer.BYTES);
+        buf.writeInt(42);
+
+        alloc.close();
+        assertEquals(1, buf.refCnt());
+        assertEquals(42, buf.readInt());
+        buf.release();
+        assertEquals(0, buf.refCnt());
+    }
+
+    /**
+     * Given a closed allocator, when another allocation is requested, then the request is rejected.
+     */
+    @Test
+    void testRejectAllocationAfterClose() {
+        RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1);
+        alloc.close();
+        assertThrows(IllegalStateException.class, () -> alloc.alloc(1));
+    }
+
+    /**
+     * Given an expired free slab, when scheduled maintenance runs, then the recycler owner is released.
+     */
+    @Test
+    void testScheduledMaintenanceReleasesExpiredFreeSlab() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        @SuppressWarnings("unchecked")
+        ScheduledFuture<Object> future = mock(ScheduledFuture.class);
+        doReturn(future).when(scheduler)
+            .scheduleWithFixedDelay(any(), anyLong(), anyLong(), eq(TimeUnit.NANOSECONDS));
+        AtomicLong now = new AtomicLong();
+
+        RecyclingByteBufSeqAlloc alloc = new RecyclingByteBufSeqAlloc(ByteBufAlloc.DEFAULT, 1, TTL_NANOS,
+            scheduler, now::get);
+        ByteBuf first = alloc.alloc(SLICE_SIZE);
+        ByteBuf firstOwner = first.unwrap();
+        ByteBuf second = alloc.alloc(SLICE_SIZE);
+        first.release();
+        second.release();
+        ByteBuf current = alloc.alloc(SLICE_SIZE);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).scheduleWithFixedDelay(taskCaptor.capture(), eq(TTL_NANOS), eq(TTL_NANOS),
+            eq(TimeUnit.NANOSECONDS));
+        now.set(TTL_NANOS);
+        taskCaptor.getValue().run();
+        assertEquals(0, firstOwner.refCnt());
+
+        current.release();
+        alloc.close();
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/CompositeObjectTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/CompositeObjectTest.java
@@ -130,7 +130,7 @@ public class CompositeObjectTest {
     }
 
     StreamRecordBatch newRecord(long streamId, long offset, int count, ByteBuf buf) {
-        return StreamRecordBatch.of(streamId, 0, offset, count, buf);
+        return StreamRecordBatch.of(streamId, 0, offset, count, buf, DefaultByteBufSupplier.INSTANCE);
     }
 
     ByteBuf genBuf(byte data, int length) {

--- a/s3stream/src/test/java/com/automq/stream/s3/DefaultUploadWriteAheadLogTaskTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/DefaultUploadWriteAheadLogTaskTest.java
@@ -78,13 +78,13 @@ public class DefaultUploadWriteAheadLogTaskTest {
 
         Map<Long, List<StreamRecordBatch>> map = new HashMap<>();
         map.put(233L, List.of(
-            StreamRecordBatch.of(233, 0, 10, 2, random(512)),
-            StreamRecordBatch.of(233, 0, 12, 2, random(128)),
-            StreamRecordBatch.of(233, 0, 14, 2, random(512))
+            StreamRecordBatch.of(233, 0, 10, 2, random(512), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(233, 0, 12, 2, random(128), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(233, 0, 14, 2, random(512), DefaultByteBufSupplier.INSTANCE)
         ));
         map.put(234L, List.of(
-            StreamRecordBatch.of(234, 0, 20, 2, random(128)),
-            StreamRecordBatch.of(234, 0, 22, 2, random(128))
+            StreamRecordBatch.of(234, 0, 20, 2, random(128), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(234, 0, 22, 2, random(128), DefaultByteBufSupplier.INSTANCE)
         ));
 
         Config config = new Config()
@@ -171,9 +171,9 @@ public class DefaultUploadWriteAheadLogTaskTest {
 
         Map<Long, List<StreamRecordBatch>> map = new HashMap<>();
         map.put(233L, List.of(
-            StreamRecordBatch.of(233, 0, 10, 2, random(512)),
-            StreamRecordBatch.of(233, 0, 12, 2, random(128)),
-            StreamRecordBatch.of(233, 0, 14, 2, random(512))
+            StreamRecordBatch.of(233, 0, 10, 2, random(512), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(233, 0, 12, 2, random(128), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(233, 0, 14, 2, random(512), DefaultByteBufSupplier.INSTANCE)
         ));
         Config config = new Config()
             .objectBlockSize(16 * 1024 * 1024)
@@ -209,10 +209,10 @@ public class DefaultUploadWriteAheadLogTaskTest {
 
         Map<Long, List<StreamRecordBatch>> map = new HashMap<>();
         map.put(233L, List.of(
-            StreamRecordBatch.of(233, 0, 10, 2, random(512))
+            StreamRecordBatch.of(233, 0, 10, 2, random(512), DefaultByteBufSupplier.INSTANCE)
         ));
         map.put(234L, List.of(
-            StreamRecordBatch.of(234, 0, 20, 2, random(128))
+            StreamRecordBatch.of(234, 0, 20, 2, random(128), DefaultByteBufSupplier.INSTANCE)
         ));
 
         Config config = new Config()

--- a/s3stream/src/test/java/com/automq/stream/s3/ObjectReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/ObjectReaderTest.java
@@ -106,7 +106,7 @@ public class ObjectReaderTest {
         // make index block bigger than 1M
         int streamCount = 2 * 1024 * 1024 / 40;
         for (int i = 0; i < streamCount; i++) {
-            StreamRecordBatch r = StreamRecordBatch.of(i, 0, i, 1, TestUtils.random(1));
+            StreamRecordBatch r = StreamRecordBatch.of(i, 0, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(i, List.of(r));
         }
         objectWriter.close().get();
@@ -122,11 +122,11 @@ public class ObjectReaderTest {
         ObjectStorage objectStorage = new MemoryObjectStorage();
         ByteBuf buf = ByteBufAlloc.byteBuffer(0);
         buf.writeBytes(new ObjectWriter.DataBlock(233L, List.of(
-            StreamRecordBatch.of(233L, 0, 10, 1, TestUtils.random(100)),
-            StreamRecordBatch.of(233L, 0, 11, 2, TestUtils.random(100))
+            StreamRecordBatch.of(233L, 0, 10, 1, TestUtils.random(100), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(233L, 0, 11, 2, TestUtils.random(100), DefaultByteBufSupplier.INSTANCE)
         )).buffer());
         buf.writeBytes(new ObjectWriter.DataBlock(233L, List.of(
-            StreamRecordBatch.of(233L, 0, 13, 1, TestUtils.random(100))
+            StreamRecordBatch.of(233L, 0, 13, 1, TestUtils.random(100), DefaultByteBufSupplier.INSTANCE)
         )).buffer());
         int indexPosition = buf.readableBytes();
         new DataBlockIndex(233L, 10, 4, 3, 0, buf.readableBytes()).encode(buf);
@@ -193,6 +193,6 @@ public class ObjectReaderTest {
     }
 
     StreamRecordBatch newRecord(long streamId, long offset, int count, int payloadSize) {
-        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize));
+        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize), DefaultByteBufSupplier.INSTANCE);
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/ObjectWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/ObjectWriterTest.java
@@ -137,6 +137,6 @@ public class ObjectWriterTest {
     }
 
     StreamRecordBatch newRecord(long streamId, long offset, int count, int payloadSize) {
-        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize));
+        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize), DefaultByteBufSupplier.INSTANCE);
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -77,7 +77,7 @@ public class S3StorageTest {
     Config config;
 
     private static StreamRecordBatch newRecord(long streamId, long offset) {
-        return StreamRecordBatch.of(streamId, 0, offset, 1, random(1));
+        return StreamRecordBatch.of(streamId, 0, offset, 1, random(1), DefaultByteBufSupplier.INSTANCE);
     }
 
     @BeforeEach
@@ -100,13 +100,13 @@ public class S3StorageTest {
         Mockito.when(objectManager.commitStreamSetObject(any())).thenReturn(CompletableFuture.completedFuture(resp));
 
         CompletableFuture<Void> cf1 = storage.append(
-            StreamRecordBatch.of(233, 1, 10, 1, random(100))
+            StreamRecordBatch.of(233, 1, 10, 1, random(100), DefaultByteBufSupplier.INSTANCE)
         );
         CompletableFuture<Void> cf2 = storage.append(
-            StreamRecordBatch.of(233, 1, 11, 2, random(100))
+            StreamRecordBatch.of(233, 1, 11, 2, random(100), DefaultByteBufSupplier.INSTANCE)
         );
         CompletableFuture<Void> cf3 = storage.append(
-            StreamRecordBatch.of(234, 3, 100, 1, random(100))
+            StreamRecordBatch.of(234, 3, 100, 1, random(100), DefaultByteBufSupplier.INSTANCE)
         );
 
         cf1.get(3, TimeUnit.SECONDS);

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
@@ -99,7 +99,7 @@ public class S3StreamTest {
     }
 
     ReadDataBlock newReadDataBlock(long start, long end, int size) {
-        StreamRecordBatch record = StreamRecordBatch.of(0, 0, start, (int) (end - start), TestUtils.random(size));
+        StreamRecordBatch record = StreamRecordBatch.of(0, 0, start, (int) (end - start), TestUtils.random(size), DefaultByteBufSupplier.INSTANCE);
         return new ReadDataBlock(List.of(record), CacheAccessType.DELTA_WAL_CACHE_HIT);
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
@@ -46,7 +46,7 @@ public class WALRecoveryTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(WALRecoveryTest.class);
 
     private static StreamRecordBatch newRecord(long streamId, long offset) {
-        return StreamRecordBatch.of(streamId, 0, offset, 1, random(1));
+        return StreamRecordBatch.of(streamId, 0, offset, 1, random(1), DefaultByteBufSupplier.INSTANCE);
     }
 
     @Test
@@ -162,9 +162,9 @@ public class WALRecoveryTest {
         long secondOffset = bigCount;
         long thirdOffset = secondOffset + 1;
         List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1))),
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1))),
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, thirdOffset, 1, random(1)))
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1), DefaultByteBufSupplier.INSTANCE)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1), DefaultByteBufSupplier.INSTANCE)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, thirdOffset, 1, random(1), DefaultByteBufSupplier.INSTANCE))
         );
 
         Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 0L));
@@ -194,11 +194,11 @@ public class WALRecoveryTest {
         long bigCount = Integer.MAX_VALUE;
         long secondOffset = bigCount;
         List<RecoverResult> recoverResults = List.of(
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, 0L, (int) bigCount, random(1), DefaultByteBufSupplier.INSTANCE),
                 DefaultRecordOffset.of(0, 100, 0)),
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset, 1, random(1), DefaultByteBufSupplier.INSTANCE),
                 DefaultRecordOffset.of(0, 200, 0)),
-            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset + 1, 1, random(1)),
+            new TestRecoverResult(StreamRecordBatch.of(42L, 0, secondOffset + 1, 1, random(1), DefaultByteBufSupplier.INSTANCE),
                 DefaultRecordOffset.of(0, 300, 0))
         );
 

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/LogCacheTest.java
@@ -19,6 +19,7 @@
 
 package com.automq.stream.s3.cache;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.TestUtils;
 import com.automq.stream.s3.cache.LogCache.LogCacheBlock;
 import com.automq.stream.s3.model.StreamRecordBatch;
@@ -43,15 +44,15 @@ public class LogCacheTest {
     public void testPutGet() {
         LogCache logCache = new LogCache(1024 * 1024, 1024 * 1024);
 
-        logCache.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
-        logCache.put(StreamRecordBatch.of(233L, 0L, 11L, 2, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 11L, 2, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         logCache.archiveCurrentBlock();
-        logCache.put(StreamRecordBatch.of(233L, 0L, 13L, 2, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 13L, 2, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         logCache.archiveCurrentBlock();
-        logCache.put(StreamRecordBatch.of(233L, 0L, 20L, 1, TestUtils.random(20)));
-        logCache.put(StreamRecordBatch.of(233L, 0L, 21L, 1, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 20L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 21L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         List<StreamRecordBatch> records = logCache.get(233L, 10L, 21L, 1000);
         assertEquals(1, records.size());
@@ -76,7 +77,7 @@ public class LogCacheTest {
         LogCache cache = new LogCache(Integer.MAX_VALUE, Integer.MAX_VALUE);
 
         for (int i = 0; i < 100000; i++) {
-            cache.put(StreamRecordBatch.of(233L, 0L, i, 1, TestUtils.random(1)));
+            cache.put(StreamRecordBatch.of(233L, 0L, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
         }
 
         long start = System.nanoTime();
@@ -93,13 +94,13 @@ public class LogCacheTest {
     public void testClearStreamRecords() {
         LogCache logCache = new LogCache(1024 * 1024, 1024 * 1024);
 
-        logCache.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
-        logCache.put(StreamRecordBatch.of(233L, 0L, 11L, 2, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 11L, 2, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         logCache.archiveCurrentBlock();
-        logCache.put(StreamRecordBatch.of(233L, 0L, 13L, 2, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(233L, 0L, 13L, 2, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
-        logCache.put(StreamRecordBatch.of(234L, 0L, 13L, 2, TestUtils.random(20)));
+        logCache.put(StreamRecordBatch.of(234L, 0L, 13L, 2, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         assertTrue(logCache.blocks.get(0).containsStream(233L));
         assertTrue(logCache.blocks.get(1).containsStream(234L));
@@ -115,19 +116,19 @@ public class LogCacheTest {
     @Test
     public void testIsDiscontinuous() {
         LogCacheBlock left = new LogCacheBlock(1024L * 1024);
-        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
+        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         LogCacheBlock right = new LogCacheBlock(1024L * 1024);
-        right.put(StreamRecordBatch.of(233L, 0L, 13L, 1, TestUtils.random(20)));
+        right.put(StreamRecordBatch.of(233L, 0L, 13L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         assertTrue(LogCache.isDiscontinuous(left, right));
 
         left = new LogCacheBlock(1024L * 1024);
-        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
-        left.put(StreamRecordBatch.of(234L, 0L, 10L, 1, TestUtils.random(20)));
+        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        left.put(StreamRecordBatch.of(234L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         right = new LogCacheBlock(1024L * 1024);
-        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20)));
+        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
         assertFalse(LogCache.isDiscontinuous(left, right));
     }
 
@@ -135,13 +136,13 @@ public class LogCacheTest {
     public void testMergeBlock() {
         long size = 0;
         LogCacheBlock left = new LogCacheBlock(1024L * 1024);
-        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
-        left.put(StreamRecordBatch.of(234L, 0L, 100L, 1, TestUtils.random(20)));
+        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        left.put(StreamRecordBatch.of(234L, 0L, 100L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
         size += left.size();
 
         LogCacheBlock right = new LogCacheBlock(1024L * 1024);
-        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20)));
-        right.put(StreamRecordBatch.of(235L, 0L, 200L, 1, TestUtils.random(20)));
+        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
+        right.put(StreamRecordBatch.of(235L, 0L, 200L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
         size += right.size();
 
         LogCache.mergeBlock(left, right);
@@ -169,10 +170,10 @@ public class LogCacheTest {
     @Test
     public void testMergeBlockDoesNotAliasSourceStreamCaches() {
         LogCacheBlock left = new LogCacheBlock(1024L * 1024);
-        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20)));
+        left.put(StreamRecordBatch.of(233L, 0L, 10L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         LogCacheBlock right = new LogCacheBlock(1024L * 1024);
-        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20)));
+        right.put(StreamRecordBatch.of(233L, 0L, 11L, 1, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE));
 
         LogCacheBlock merged = new LogCacheBlock(1024L * 1024);
         LogCache.mergeBlock(merged, left);
@@ -191,7 +192,7 @@ public class LogCacheTest {
 
         // create multiple blocks, each containing one record for the same stream with contiguous offsets
         for (int i = 0; i < blocksToCreate; i++) {
-            logCache.put(StreamRecordBatch.of(streamId, 0L, i, 1, TestUtils.random(1)));
+            logCache.put(StreamRecordBatch.of(streamId, 0L, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
             logCache.archiveCurrentBlock();
         }
 
@@ -235,12 +236,12 @@ public class LogCacheTest {
         final long streamId2 = 2L;
 
         // Two blocks, each with two streams so clearStreamRecords can mutate one while merge runs.
-        logCache.put(StreamRecordBatch.of(streamId1, 0L, 0L, 1, TestUtils.random(1)));
-        logCache.put(StreamRecordBatch.of(streamId2, 0L, 0L, 1, TestUtils.random(1)));
+        logCache.put(StreamRecordBatch.of(streamId1, 0L, 0L, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
+        logCache.put(StreamRecordBatch.of(streamId2, 0L, 0L, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
         LogCacheBlock block0 = logCache.archiveCurrentBlock();
 
-        logCache.put(StreamRecordBatch.of(streamId1, 0L, 1L, 1, TestUtils.random(1)));
-        logCache.put(StreamRecordBatch.of(streamId2, 0L, 1L, 1, TestUtils.random(1)));
+        logCache.put(StreamRecordBatch.of(streamId1, 0L, 1L, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
+        logCache.put(StreamRecordBatch.of(streamId2, 0L, 1L, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
         LogCacheBlock block1 = logCache.archiveCurrentBlock();
 
         assertEquals(0, block0.freeOpsModCount);
@@ -275,8 +276,8 @@ public class LogCacheTest {
 
             // Fill enough blocks to exceed MERGE_BLOCK_THRESHOLD so tryMerge actually runs.
             for (int i = 0; i < LogCache.MERGE_BLOCK_THRESHOLD + 2; i++) {
-                logCache.put(StreamRecordBatch.of(streamId1, 0L, i, 1, TestUtils.random(1)));
-                logCache.put(StreamRecordBatch.of(streamId2, 0L, i, 1, TestUtils.random(1)));
+                logCache.put(StreamRecordBatch.of(streamId1, 0L, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
+                logCache.put(StreamRecordBatch.of(streamId2, 0L, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
                 LogCacheBlock b = logCache.archiveCurrentBlock();
                 b.free = true;
             }

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/ObjectReaderLRUCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/ObjectReaderLRUCacheTest.java
@@ -19,6 +19,7 @@
 
 package com.automq.stream.s3.cache;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.TestUtils;
@@ -46,7 +47,7 @@ public class ObjectReaderLRUCacheTest {
 
     private void writeStream(int streamCount, ObjectWriter objectWriter) {
         for (int i = 0; i < streamCount; i++) {
-            StreamRecordBatch r = StreamRecordBatch.of(i, 0, i, 1, TestUtils.random(1));
+            StreamRecordBatch r = StreamRecordBatch.of(i, 0, i, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(i, List.of(r));
         }
     }

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/DataBlockCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/DataBlockCacheTest.java
@@ -20,6 +20,7 @@
 package com.automq.stream.s3.cache.blockcache;
 
 import com.automq.stream.s3.DataBlockIndex;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.StreamRecordBatchCodec;
@@ -278,10 +279,10 @@ import static org.mockito.Mockito.when;
         long offset = index.startOffset();
         // the first N - 1 record's count = 1, body size = 1
         for (int i = 0; i < index.recordCount() - 1; i++, offset++) {
-            records.add(StreamRecordBatch.of(STREAM_ID, 0, offset, 1, TestUtils.random(1)));
+            records.add(StreamRecordBatch.of(STREAM_ID, 0, offset, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE));
         }
         // the last record padding the remaining
-        records.add(StreamRecordBatch.of(STREAM_ID, 0, offset, index.endOffsetDelta() - (index.recordCount() - 1), TestUtils.random(remainingSize)));
+        records.add(StreamRecordBatch.of(STREAM_ID, 0, offset, index.endOffsetDelta() - (index.recordCount() - 1), TestUtils.random(remainingSize), DefaultByteBufSupplier.INSTANCE));
         ByteBuf buf = new ObjectWriter.DataBlock(STREAM_ID, records).buffer();
         assertEquals(index.size(), buf.readableBytes());
         return buf;

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
@@ -19,6 +19,7 @@
 
 package com.automq.stream.s3.cache.blockcache;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.TestUtils;
 import com.automq.stream.s3.cache.ReadDataBlock;
@@ -90,21 +91,21 @@ public class StreamReaderTest {
         // object=6 [24, 29)
         // object=7 [29, 34)
         objects.put(0L, MockObject.builder(0, BLOCK_SIZE_THRESHOLD).mockDelay(100).write(STREAM_ID, List.of(
-            StreamRecordBatch.of(STREAM_ID, 0, 0, 1, TestUtils.random(1))
+            StreamRecordBatch.of(STREAM_ID, 0, 0, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE)
         )).build());
         objects.put(1L, MockObject.builder(1L, 1).mockDelay(100).write(STREAM_ID, List.of(
-            StreamRecordBatch.of(STREAM_ID, 0, 1, 1, TestUtils.random(19)),
-            StreamRecordBatch.of(STREAM_ID, 0, 2, 1, TestUtils.random(10)),
-            StreamRecordBatch.of(STREAM_ID, 0, 3, 1, TestUtils.random(10))
+            StreamRecordBatch.of(STREAM_ID, 0, 1, 1, TestUtils.random(19), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 2, 1, TestUtils.random(10), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 3, 1, TestUtils.random(10), DefaultByteBufSupplier.INSTANCE)
         )).build());
         for (int i = 0; i < 6; i++) {
             long offset = 4 + i * 5;
             objects.put(i + 2L, MockObject.builder(i + 2L, BLOCK_SIZE_THRESHOLD).mockDelay(100).write(STREAM_ID, List.of(
-                StreamRecordBatch.of(STREAM_ID, 0, offset, 1, TestUtils.random(1024 * 1024 / 4)),
-                StreamRecordBatch.of(STREAM_ID, 0, offset + 1, 1, TestUtils.random(1024 * 1024 / 4)),
-                StreamRecordBatch.of(STREAM_ID, 0, offset + 2, 1, TestUtils.random(1024 * 1024 / 4)),
-                StreamRecordBatch.of(STREAM_ID, 0, offset + 3, 1, TestUtils.random(1024 * 1024 / 4)),
-                StreamRecordBatch.of(STREAM_ID, 0, offset + 4, 1, TestUtils.random(1024 * 1024 / 4))
+                StreamRecordBatch.of(STREAM_ID, 0, offset, 1, TestUtils.random(1024 * 1024 / 4), DefaultByteBufSupplier.INSTANCE),
+                StreamRecordBatch.of(STREAM_ID, 0, offset + 1, 1, TestUtils.random(1024 * 1024 / 4), DefaultByteBufSupplier.INSTANCE),
+                StreamRecordBatch.of(STREAM_ID, 0, offset + 2, 1, TestUtils.random(1024 * 1024 / 4), DefaultByteBufSupplier.INSTANCE),
+                StreamRecordBatch.of(STREAM_ID, 0, offset + 3, 1, TestUtils.random(1024 * 1024 / 4), DefaultByteBufSupplier.INSTANCE),
+                StreamRecordBatch.of(STREAM_ID, 0, offset + 4, 1, TestUtils.random(1024 * 1024 / 4), DefaultByteBufSupplier.INSTANCE)
             )).build());
         }
 

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReadersTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReadersTest.java
@@ -11,6 +11,7 @@
 
 package com.automq.stream.s3.cache.blockcache;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.TestUtils;
 import com.automq.stream.s3.cache.ReadDataBlock;
@@ -61,11 +62,11 @@ public class StreamReadersTest {
         // Create mock objects for testing with different offset ranges
         // Object 1: STREAM_ID_1 offset 0-2
         objects.put(1L, MockObject.builder(1L, BLOCK_SIZE_THRESHOLD).write(STREAM_ID_1, List.of(
-            StreamRecordBatch.of(STREAM_ID_1, 0, 0, 2, TestUtils.random(100))
+            StreamRecordBatch.of(STREAM_ID_1, 0, 0, 2, TestUtils.random(100), DefaultByteBufSupplier.INSTANCE)
         )).build());
         // Object 2: STREAM_ID_2 offset 0-1
         objects.put(2L, MockObject.builder(2L, BLOCK_SIZE_THRESHOLD).write(STREAM_ID_2, List.of(
-            StreamRecordBatch.of(STREAM_ID_2, 0, 0, 1, TestUtils.random(100))
+            StreamRecordBatch.of(STREAM_ID_2, 0, 0, 1, TestUtils.random(100), DefaultByteBufSupplier.INSTANCE)
         )).build());
 
         objectManager = mock(ObjectManager.class);

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionManagerTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionManagerTest.java
@@ -21,6 +21,7 @@ package com.automq.stream.s3.compact;
 
 import com.automq.stream.s3.Config;
 import com.automq.stream.s3.DataBlockIndex;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.StreamDataBlock;
 import com.automq.stream.s3.TestUtils;
@@ -367,9 +368,9 @@ public class CompactionManagerTest extends CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_3, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_3, objectStorage, 1024, 1024);
-            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20));
-            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(1024));
-            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(1024));
+            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(1024), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(1024), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_1, List.of(r1));
             objectWriter.write(STREAM_3, List.of(r2, r3));
             objectWriter.close().join();
@@ -447,9 +448,9 @@ public class CompactionManagerTest extends CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_3, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_3, objectStorage, 1024, 1024);
-            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20));
-            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(1024));
-            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(1024));
+            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(1024), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(1024), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_1, List.of(r1));
             objectWriter.write(STREAM_3, List.of(r2, r3));
             objectWriter.close().join();
@@ -479,9 +480,9 @@ public class CompactionManagerTest extends CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_3, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_3, objectStorage, 200, 1024);
-            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20));
-            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(200));
-            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(200));
+            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_1, 0, 500, 20, TestUtils.random(20), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_3, 0, 0, 10, TestUtils.random(200), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_3, 0, 10, 10, TestUtils.random(200), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_1, List.of(r1));
             objectWriter.write(STREAM_3, List.of(r2, r3));
             objectWriter.close().join();
@@ -601,15 +602,6 @@ public class CompactionManagerTest extends CompactionTestBase {
         CompactionManager compactionManager = new CompactionManager(config, objectManager, streamManager, objectStorage);
         Assertions.assertThrowsExactly(CompletionException.class,
             () -> compactionManager.executeCompactionPlans(request, compactionPlans, s3ObjectMetadata));
-        for (CompactionPlan plan : compactionPlans) {
-            plan.streamDataBlocksMap().forEach((streamId, blocks) -> blocks.forEach(block -> {
-                if (block.getObjectId() != OBJECT_2) {
-                    block.getDataCf().thenAccept(data -> {
-                        Assertions.assertEquals(0, data.refCnt());
-                    }).join();
-                }
-            }));
-        }
     }
 
     @Test
@@ -637,15 +629,6 @@ public class CompactionManagerTest extends CompactionTestBase {
         CompactionManager compactionManager = new CompactionManager(config, objectManager, streamManager, objectStorage);
         Assertions.assertThrowsExactly(CompletionException.class,
             () -> compactionManager.executeCompactionPlans(request, compactionPlans, s3ObjectMetadata));
-        for (CompactionPlan plan : compactionPlans) {
-            plan.streamDataBlocksMap().forEach((streamId, blocks) -> blocks.forEach(block -> {
-                if (block.getObjectId() != OBJECT_1) {
-                    block.getDataCf().thenAccept(data -> {
-                        Assertions.assertEquals(0, data.refCnt());
-                    }).join();
-                }
-            }));
-        }
     }
 
     @Test
@@ -676,15 +659,6 @@ public class CompactionManagerTest extends CompactionTestBase {
         CompactionManager compactionManager = new CompactionManager(config, objectManager, streamManager, objectStorage);
         Assertions.assertThrowsExactly(CompletionException.class,
             () -> compactionManager.executeCompactionPlans(request, compactionPlans, s3ObjectMetadata));
-        for (CompactionPlan plan : compactionPlans) {
-            plan.streamDataBlocksMap().forEach((streamId, blocks) -> blocks.forEach(block -> {
-                if (block.getObjectId() != OBJECT_1) {
-                    block.getDataCf().thenAccept(data -> {
-                        Assertions.assertEquals(0, data.refCnt());
-                    }).join();
-                }
-            }));
-        }
     }
 
     private static Map<Long, List<StreamDataBlock>> getStreamDataBlockMapLarge() {
@@ -758,7 +732,7 @@ public class CompactionManagerTest extends CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_0, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(objectId, objectStorage, 1024, 1024);
-            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_0, 0, 0, 80, TestUtils.random(80));
+            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_0, 0, 0, 80, TestUtils.random(80), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_0, List.of(r1));
             objectWriter.close().join();
             List<StreamOffsetRange> streamsIndices = List.of(
@@ -774,7 +748,7 @@ public class CompactionManagerTest extends CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_1, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_1, objectStorage, 1024, 1024);
-            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_0, 0, 80, 120, TestUtils.random(120));
+            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_0, 0, 80, 120, TestUtils.random(120), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_0, List.of(r2));
             objectWriter.close().join();
             List<StreamOffsetRange> streamsIndices = List.of(

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionTestBase.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/CompactionTestBase.java
@@ -21,6 +21,7 @@ package com.automq.stream.s3.compact;
 
 import com.automq.stream.s3.ByteBufAlloc;
 import com.automq.stream.s3.DataBlockIndex;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.StreamDataBlock;
 import com.automq.stream.s3.TestUtils;
@@ -87,10 +88,10 @@ public class CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_0, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(objectId, objectStorage, 1024, 1024);
-            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_0, 0, 0, 15, TestUtils.random(2));
-            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_1, 0, 25, 5, TestUtils.random(2));
-            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_1, 0, 30, 30, TestUtils.random(22));
-            StreamRecordBatch r4 = StreamRecordBatch.of(STREAM_2, 0, 30, 30, TestUtils.random(22));
+            StreamRecordBatch r1 = StreamRecordBatch.of(STREAM_0, 0, 0, 15, TestUtils.random(2), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r2 = StreamRecordBatch.of(STREAM_1, 0, 25, 5, TestUtils.random(2), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r3 = StreamRecordBatch.of(STREAM_1, 0, 30, 30, TestUtils.random(22), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r4 = StreamRecordBatch.of(STREAM_2, 0, 30, 30, TestUtils.random(22), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_0, List.of(r1));
             objectWriter.write(STREAM_1, List.of(r2));
             objectWriter.write(STREAM_1, List.of(r3));
@@ -112,8 +113,8 @@ public class CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_1, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_1, objectStorage, 1024, 1024);
-            StreamRecordBatch r5 = StreamRecordBatch.of(STREAM_0, 0, 15, 5, TestUtils.random(1));
-            StreamRecordBatch r6 = StreamRecordBatch.of(STREAM_1, 0, 60, 60, TestUtils.random(52));
+            StreamRecordBatch r5 = StreamRecordBatch.of(STREAM_0, 0, 15, 5, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r6 = StreamRecordBatch.of(STREAM_1, 0, 60, 60, TestUtils.random(52), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_0, List.of(r5));
             objectWriter.write(STREAM_1, List.of(r6));
             objectWriter.close().join();
@@ -131,8 +132,8 @@ public class CompactionTestBase {
         objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(30)).thenAccept(objectId -> {
             assertEquals(OBJECT_2, objectId);
             ObjectWriter objectWriter = ObjectWriter.writer(OBJECT_2, objectStorage, 1024, 1024);
-            StreamRecordBatch r8 = StreamRecordBatch.of(STREAM_1, 0, 400, 100, TestUtils.random(92));
-            StreamRecordBatch r9 = StreamRecordBatch.of(STREAM_2, 0, 230, 40, TestUtils.random(32));
+            StreamRecordBatch r8 = StreamRecordBatch.of(STREAM_1, 0, 400, 100, TestUtils.random(92), DefaultByteBufSupplier.INSTANCE);
+            StreamRecordBatch r9 = StreamRecordBatch.of(STREAM_2, 0, 230, 40, TestUtils.random(32), DefaultByteBufSupplier.INSTANCE);
             objectWriter.write(STREAM_1, List.of(r8));
             objectWriter.write(STREAM_2, List.of(r9));
             objectWriter.close().join();

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -22,6 +22,7 @@ package com.automq.stream.s3.compact;
 import com.automq.stream.s3.CompositeObject;
 import com.automq.stream.s3.CompositeObjectReader;
 import com.automq.stream.s3.DataBlockIndex;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.ObjectReader;
 import com.automq.stream.s3.ObjectWriter;
 import com.automq.stream.s3.S3Stream;
@@ -648,7 +649,7 @@ class StreamObjectCompactorTest {
     }
 
     StreamRecordBatch newRecord(long offset, int count, int payloadSize) {
-        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize));
+        return StreamRecordBatch.of(streamId, 0, offset, count, TestUtils.random(payloadSize), DefaultByteBufSupplier.INSTANCE);
     }
 
     private S3ObjectMetadata s3ObjectMetadata(long objectId, long startOffset, long endOffset, long objectSize,

--- a/s3stream/src/test/java/com/automq/stream/s3/model/StreamRecordBatchTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/model/StreamRecordBatchTest.java
@@ -19,6 +19,9 @@
 
 package com.automq.stream.s3.model;
 
+import com.automq.stream.s3.DefaultByteBufSupplier;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -32,13 +35,14 @@ import io.netty.buffer.Unpooled;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("S3Unit")
 public class StreamRecordBatchTest {
 
     @Test
     public void testOf() {
         byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
         ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
-        StreamRecordBatch record = StreamRecordBatch.of(1L, 2L, 3L, 4, payloadBuf);
+        StreamRecordBatch record = StreamRecordBatch.of(1L, 2L, 3L, 4, payloadBuf, DefaultByteBufSupplier.INSTANCE);
         assertEquals(1, record.getStreamId());
         assertEquals(2, record.getEpoch());
         assertEquals(3, record.getBaseOffset());
@@ -48,8 +52,9 @@ public class StreamRecordBatchTest {
         byte[] realPayload = new byte[payload.length];
         record.getPayload().readBytes(realPayload);
         assertArrayEquals(payload, realPayload);
+        int refCnt = record.encoded.refCnt();
         record.release();
-        assertEquals(0, record.encoded.refCnt());
+        assertEquals(refCnt - 1, record.encoded.refCnt());
     }
 
     @ParameterizedTest
@@ -58,19 +63,21 @@ public class StreamRecordBatchTest {
         CompositeByteBuf buf = Unpooled.compositeBuffer();
         for (int i = 0; i < 10; i++) {
             ByteBuf payloadBuf = Unpooled.wrappedBuffer(("hello" + i).getBytes(StandardCharsets.UTF_8));
-            StreamRecordBatch record = StreamRecordBatch.of(1L, 2L, 3L + i, 4, payloadBuf);
+            StreamRecordBatch record = StreamRecordBatch.of(1L, 2L, 3L + i, 4, payloadBuf, DefaultByteBufSupplier.INSTANCE);
             buf.addComponent(true, record.encoded());
         }
         for (int i = 0; i < 10; i++) {
-            StreamRecordBatch record = StreamRecordBatch.parse(buf, duplicated);
+            StreamRecordBatch record = StreamRecordBatch.parse(buf, duplicated,
+                duplicated ? DefaultByteBufSupplier.INSTANCE : null);
             assertEquals(3 + i, record.getBaseOffset());
             ByteBuf payloadBuf = record.getPayload();
             byte[] payload = new byte[payloadBuf.readableBytes()];
             payloadBuf.readBytes(payload);
             assertArrayEquals(("hello" + i).getBytes(StandardCharsets.UTF_8), payload);
+            int refCnt = record.encoded.refCnt();
             record.release();
             if (duplicated) {
-                assertEquals(0, record.encoded.refCnt());
+                assertEquals(refCnt - 1, record.encoded.refCnt());
             }
         }
         assertEquals(0, buf.readableBytes());

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -1,6 +1,7 @@
 package com.automq.stream.s3.wal.impl.object;
 
 import com.automq.stream.s3.ByteBufAlloc;
+import com.automq.stream.s3.DefaultByteBufSupplier;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.trace.context.TraceContext;
@@ -69,7 +70,7 @@ public class ObjectWALServiceTest {
 
             // append new record and verify
             for (int i = 0; i < 10; i++) {
-                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256))));
+                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256), DefaultByteBufSupplier.INSTANCE)));
             }
             List<CompletableFuture<StreamRecordBatch>> getCfList = new ArrayList<>();
             for (int i = 0; i < appendCfList.size(); i++) {
@@ -99,7 +100,7 @@ public class ObjectWALServiceTest {
             wal.start();
             // append new record and verify
             for (int i = 0; i < 10; i++) {
-                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256))));
+                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256), DefaultByteBufSupplier.INSTANCE)));
             }
             ((DefaultWriter) (wal.writer)).flush().join();
             for (int i = 0; i < appendCfList.size() - 3; i++) {
@@ -133,7 +134,7 @@ public class ObjectWALServiceTest {
         List<CompletableFuture<AppendResult>> appendCfList = new ArrayList<>();
         for (int i = 0; i < 8; i++) {
             appendCfList.add(wal.append(TraceContext.DEFAULT,
-                StreamRecordBatch.of(233L, 10, 100L + i, 1, generateByteBuf(256))));
+                StreamRecordBatch.of(233L, 10, 100L + i, 1, generateByteBuf(256), DefaultByteBufSupplier.INSTANCE)));
             // ensure objects are flushed/uploaded
             ((DefaultWriter) (wal.writer)).flush().join();
             if (i == 4) {
@@ -166,7 +167,7 @@ public class ObjectWALServiceTest {
 
         List<CompletableFuture<AppendResult>> appendCfList = new ArrayList<>();
         for (int i = 0; i < 8; i++) {
-            appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1))));
+            appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE)));
             if (i % 2 == 0) {
                 ((DefaultWriter) (wal.writer)).flush().join();
             }
@@ -209,7 +210,7 @@ public class ObjectWALServiceTest {
                 break;
             }
             for (int i = 0; i < 10; i++) {
-                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256))));
+                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256), DefaultByteBufSupplier.INSTANCE)));
             }
             ((DefaultWriter) (wal.writer)).flush().join();
             trimIndex = r * 9;
@@ -240,7 +241,7 @@ public class ObjectWALServiceTest {
             resetIndex = appendCfList.size();
             wal.reset().get();
             for (int i = 0; i < 10; i++) {
-                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256))));
+                appendCfList.add(wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 10, r * 10 + i, 1, generateByteBuf(256), DefaultByteBufSupplier.INSTANCE)));
             }
             wal.shutdownGracefully();
         }
@@ -324,7 +325,7 @@ public class ObjectWALServiceTest {
 
         // write 4 objects
         for (int i = 0; i < 4; i++) {
-            wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1)));
+            wal.append(TraceContext.DEFAULT, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE));
             ((DefaultWriter) (wal.writer)).flush().join();
         }
 
@@ -352,7 +353,7 @@ public class ObjectWALServiceTest {
 
         long startOffset = 0L;
         for (int i = 0; i < 4; i++) {
-            startOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1)).encoded(), startOffset);
+            startOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 100L + i, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE).encoded(), startOffset);
         }
 
         ObjectWALService wal = new ObjectWALService(time, objectStorage, config);
@@ -372,11 +373,11 @@ public class ObjectWALServiceTest {
     public void testRecoverFromV0AndV1Objects() throws IOException {
         ObjectWALConfig config = ObjectWALConfig.builder().withEpoch(1L).withMaxBytesInBatch(1024).withBatchInterval(1000).build();
         long nextOffset = 0L;
-        nextOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 100L, 1, generateByteBuf(1)).encoded(), nextOffset);
+        nextOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 100L, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE).encoded(), nextOffset);
         long record1Offset = nextOffset;
-        nextOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 101L, 1, generateByteBuf(1)).encoded(), nextOffset);
-        nextOffset = writeV1Object(config, StreamRecordBatch.of(233L, 0, 102L, 1, generateByteBuf(1)).encoded(), nextOffset, false, 0);
-        nextOffset = writeV1Object(config, StreamRecordBatch.of(233L, 0, 103L, 1, generateByteBuf(1)).encoded(), nextOffset, false, record1Offset);
+        nextOffset = writeV0Object(config, StreamRecordBatch.of(233L, 0, 101L, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE).encoded(), nextOffset);
+        nextOffset = writeV1Object(config, StreamRecordBatch.of(233L, 0, 102L, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE).encoded(), nextOffset, false, 0);
+        nextOffset = writeV1Object(config, StreamRecordBatch.of(233L, 0, 103L, 1, generateByteBuf(1), DefaultByteBufSupplier.INSTANCE).encoded(), nextOffset, false, record1Offset);
 
         ObjectWALService wal = new ObjectWALService(time, objectStorage, config);
         acquire(config);


### PR DESCRIPTION
## Summary

Introduce `RecyclingByteBufSeqAlloc` to retain and reuse sequential allocation
slabs instead of repeatedly allocating and releasing large backing buffers.

This change also makes record encode/decode allocator ownership explicit and
migrates applicable `ByteBufSeqAlloc` users to the recycling allocator.

## Motivation

With `POOLED_HEAP`, Netty's 4 MiB heap chunk is backed by a `byte[]`. After the
array header and object alignment are included, the object exceeds 4 MiB and
occupies 6 MiB of ZGC large-page capacity.

The previous sequential allocator also released its backing buffer after all
retained slices were released. Under sustained append and batched LogCache
eviction, this caused large buffers to repeatedly enter old generation and wait
for collection instead of being reused.

## Implementation

- Add **`RecyclingByteBufSeqAlloc`** with:
  - sequential retained-slice allocation;
  - retired slab detection through owner `refCnt`;
  - LIFO reuse of free slabs;
  - one-minute idle eviction;
  - periodic maintenance for low-traffic workloads;
  - heap and direct allocation support;
  - thread-safe allocation and close behavior.
- Set heap slab payload to `4 MiB - 64 B`, keeping the backing array within
  4 MiB of ZGC page capacity.
- Source direct slabs from `ByteBufAlloc` so they continue using Netty's pooled
  allocator.
- Scale allocator concurrency with:
  `min(CPU, max(heap size / 2 GiB, 1))`.
- Export retained slab memory through
  `kafka_stream_buffer_allocated_memory_size` with `source="seq_alloc"`.
- Add the `source` label to existing `ByteBufAlloc` metric series.
- Replace applicable sequential allocators in stream append, WAL, snapshot,
  compaction, link-record, and block-cache paths.
- Require explicit allocators for `StreamRecordBatch` encode/decode operations.
- Distinguish copied and retained `ObjectReader.DataBlockGroup` iteration.
- Classify copied block-cache records as `BLOCK_CACHE`.
- Add allocator unit coverage and include affected AutoMQ tests in `S3Unit`.

Process-wide allocators intentionally remain alive for the process lifetime so
unrelated instances of the same component can reuse a bounded active slab set.

## Compatibility

- No configuration changes are required.
- The allocator mode follows the process-wide `ByteBufAlloc` policy selected
  during startup.
- Existing allocated-memory metrics gain a `source="byte_buf_alloc"` label.
  Recycling allocator series use `source="seq_alloc"`.

