### PR TITLE
fix: memory leak in CompactionUploader during shutdown

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUploader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/CompactionUploader.java
@@ -64,6 +64,7 @@ public class CompactionUploader {
 
     public void shutdown() {
         this.isShutdown = true;
+        this.isAborted = true;
         this.streamSetObjectUploadPool.shutdown();
         try {
             if (!this.streamSetObjectUploadPool.awaitTermination(10, TimeUnit.SECONDS)) {
@@ -78,6 +79,15 @@ public class CompactionUploader {
                 this.streamObjectUploadPool.shutdownNow();
             }
         } catch (InterruptedException ignored) {
+        }
+
+        if (streamSetObjectWriter != null) {
+            streamSetObjectWriter.release().whenComplete((nil, ex) -> {
+                if (ex != null) {
+                    LOGGER.warn("Failed to release stream set object writer during shutdown", ex);
+                }
+            });
+            streamSetObjectWriter = null;
         }
     }
 
@@ -100,6 +110,10 @@ public class CompactionUploader {
             streamSetObjectIdCf = this.objectManager.prepareObject(1, TimeUnit.MINUTES.toMillis(CompactionConstants.S3_OBJECT_TTL_MINUTES));
         }
         return streamSetObjectIdCf.thenComposeAsync(objectId -> {
+            if (isAborted) {
+                compactedObject.streamDataBlocks().forEach(StreamDataBlock::release);
+                return CompletableFuture.completedFuture(null);
+            }
             if (streamSetObjectWriter == null) {
                 streamSetObjectWriter = new DataBlockWriter(objectId, objectStorage, config.objectPartSize());
             }
@@ -122,6 +136,13 @@ public class CompactionUploader {
                     return CompletableFuture.completedFuture(null);
                 }
                 DataBlockWriter dataBlockWriter = new DataBlockWriter(objectId, objectStorage, config.objectPartSize());
+                // Re-check isAborted after allocating the writer to handle the race where
+                // shutdown() is called between the first check and writer creation.
+                if (isAborted) {
+                    dataBlockWriter.release();
+                    compactedObject.streamDataBlocks().forEach(StreamDataBlock::release);
+                    return CompletableFuture.completedFuture(null);
+                }
                 CompletableFuture<Void> cf = CompactionUtils.chainWriteDataBlock(dataBlockWriter, compactedObject.streamDataBlocks(), streamObjectUploadPool);
                 return cf.thenCompose(nil -> dataBlockWriter.close()).thenApply(nil -> {
                     StreamObject streamObject = new StreamObject();


### PR DESCRIPTION
**Fix memory leak in CompactionUploader during shutdown**

*More detailed description of your change, if necessary.*

During shutdown, `CompactionUploader` leaked `ByteBuf` objects allocated by `ProxyWriter.ObjectWriter` because in-flight `writeStreamObject` operations were not aware that the uploader was shutting down.

Root cause: `shutdown()` never set `isAborted = true`. This allowed in-flight lambdas in `writeStreamObject` and `prepareObjectAndWrite` to pass the abort check, allocate a `DataBlockWriter` (which allocates a `CompositeByteBuf` internally), and then chain writes on a pool that was terminating. If pending `StreamDataBlock.getDataCf()` futures never completed (because upstream readers were also shutting down), the future chain hung indefinitely and the `whenComplete` cleanup handler was never invoked — leaking the writer's internal buffer.

Changes:
- Set `isAborted = true` in `shutdown()` so in-flight operations bail out early.
- Release `streamSetObjectWriter` after pools terminate in `shutdown()`.
- Add a double-check of `isAborted` in `writeStreamObject()` immediately after `DataBlockWriter` allocation to close the race window between the first check and writer creation.
- Add an `isAborted` guard in `prepareObjectAndWrite()` before writing to the stream-set object writer.

*Issue*

Fixes #2364

*Summary of testing strategy*

- Existing `CompactionUploaderTest` (unit tests for `writeStreamObject`, `chainWriteStreamSetObject`) continues to pass, confirming no regression in the happy path.
- The fix is a defensive shutdown guard — the race condition is inherently timing-dependent and difficult to reproduce deterministically in a unit test. Verification relies on the absence of `ResourceLeakDetector` LEAK warnings in integration/E2E runs under repeated compaction-shutdown cycles.
- Netty's `ResourceLeakDetector` (set to PARANOID in test environments) will surface any remaining leaks if the fix is incomplete.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)