### PR TITLE
fix: change log.dirs and s3.wal.path defaults away from /tmp

### DIFF
--- a/config/kraft/broker.properties
+++ b/config/kraft/broker.properties
@@ -72,7 +72,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kraft-broker-logs
+log.dirs=/var/kafka/kraft-broker-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/config/kraft/controller.properties
+++ b/config/kraft/controller.properties
@@ -70,7 +70,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kraft-controller-logs
+log.dirs=/var/kafka/kraft-controller-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/config/kraft/server.properties
+++ b/config/kraft/server.properties
@@ -75,7 +75,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kraft-combined-logs
+log.dirs=/var/kafka/kraft-combined-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 public class Config {
     private int nodeId;
     private List<BucketURI> dataBuckets;
-    private String walConfig = "0@file:///tmp/s3stream_wal";
+    private String walConfig = "0@file:///var/kafka/wal";
     private long walCacheSize = 200 * 1024 * 1024;
     private long walUploadThreshold = 100 * 1024 * 1024;
     // -1L means don't upload by time

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -35,7 +35,9 @@ public class ServerLogConfigs {
 
     public static final String LOG_DIRS_CONFIG = LOG_PREFIX + "dirs";
     public static final String LOG_DIR_CONFIG = LOG_PREFIX + "dir";
-    public static final String LOG_DIR_DEFAULT = "/tmp/kafka-logs";
+    // AutoMQ inject start: use a stable non-tmpfs directory as the default to avoid unexpected swap behaviour
+    public static final String LOG_DIR_DEFAULT = "/var/kafka/logs";
+    // AutoMQ inject end
     public static final String LOG_DIR_DOC = "The directory in which the log data is kept (supplemental for " + LOG_DIRS_CONFIG + " property)";
     public static final String LOG_DIRS_DOC = "A comma-separated list of the directories where the log data is stored. If not set, the value in " + LOG_DIR_CONFIG + " is used.";
 


### PR DESCRIPTION
## Summary

Fixes #683

Defaulting log.dirs and s3.wal.path to paths under /tmp is dangerous in production environments where /tmp is memory-backed (e.g., 	mpfs on Linux). Data written there is lost on reboot. This PR changes the defaults to /var/kafka/, which is the conventional stable directory for Kafka data on Linux.

## Changes

| File | Old default | New default |
|------|-------------|-------------|
| config/kraft/broker.properties | /tmp/kraft-broker-logs | /var/kafka/kraft-broker-logs |
| config/kraft/controller.properties | /tmp/kraft-controller-logs | /var/kafka/kraft-controller-logs |
| config/kraft/server.properties | /tmp/kraft-combined-logs | /var/kafka/kraft-combined-logs |
| server-common/.../ServerLogConfigs.java | /tmp/kafka-logs | /var/kafka/logs |
| s3stream/.../Config.java | 