### PR TITLE
perf(zerozone): improve high-throughput routing

### DIFF
--- a/core/src/main/java/kafka/automq/zerozone/AsyncSender.java
+++ b/core/src/main/java/kafka/automq/zerozone/AsyncSender.java
@@ -22,13 +22,10 @@ package kafka.automq.zerozone;
 import kafka.server.KafkaConfig;
 
 import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ManualMetadataUpdater;
 import org.apache.kafka.clients.MetadataRecoveryStrategy;
 import org.apache.kafka.clients.NetworkClient;
-import org.apache.kafka.clients.NetworkClientUtils;
-import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ChannelBuilder;
@@ -40,22 +37,10 @@ import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.util.InterBrokerAsyncSender;
 
-import com.automq.stream.utils.Threads;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.SocketTimeoutException;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public interface AsyncSender {
 
@@ -69,11 +54,10 @@ public interface AsyncSender {
     void close();
 
     class BrokersAsyncSender implements AsyncSender {
-        private static final Logger LOGGER = LoggerFactory.getLogger(BrokersAsyncSender.class);
+        private static final int REQUEST_TIMEOUT_MS = 30_000;
+
         private final NetworkClient networkClient;
-        private final Time time;
-        private final ExecutorService executorService;
-        private final AtomicBoolean shouldRun = new AtomicBoolean(true);
+        private final org.apache.kafka.server.util.AsyncSender delegate;
 
         public BrokersAsyncSender(
             KafkaConfig brokerConfig,
@@ -123,76 +107,18 @@ public interface AsyncSender {
                 logContext,
                 MetadataRecoveryStrategy.REBOOTSTRAP
             );
-            this.time = time;
-            executorService = Threads.newFixedThreadPoolWithMonitor(1, metricGroupPrefix, true, LOGGER);
-            executorService.submit(this::run);
+            this.delegate = InterBrokerAsyncSender.create(
+                metricGroupPrefix,
+                networkClient,
+                REQUEST_TIMEOUT_MS,
+                time
+            );
         }
-
-        private final ConcurrentMap<Node, Queue<Request>> waitingSendRequests = new ConcurrentHashMap<>();
 
         @Override
         public <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(Node node,
             AbstractRequest.Builder<T> requestBuilder) {
-            CompletableFuture<ClientResponse> cf = new CompletableFuture<>();
-            waitingSendRequests.compute(node, (n, queue) -> {
-                if (queue == null) {
-                    queue = new ConcurrentLinkedQueue<>();
-                }
-                queue.add(new Request(requestBuilder, cf));
-                return queue;
-            });
-            return cf;
-        }
-
-        private void run() {
-            Map<Node, ConnectingState> connectingStates = new ConcurrentHashMap<>();
-            while (shouldRun.get()) {
-                // TODO: graceful shutdown
-                try {
-                    long now = time.milliseconds();
-                    waitingSendRequests.forEach((node, queue) -> {
-                        if (queue.isEmpty()) {
-                            return;
-                        }
-                        if (NetworkClientUtils.isReady(networkClient, node, now)) {
-                            connectingStates.remove(node);
-                            Request request = queue.poll();
-                            ClientRequest clientRequest = networkClient.newClientRequest(Integer.toString(node.id()), request.requestBuilder, now, true, 30000, new RequestCompletionHandler() {
-                                @Override
-                                public void onComplete(ClientResponse response) {
-                                    request.cf.complete(response);
-                                }
-                            });
-                            networkClient.send(clientRequest, now);
-                        } else {
-                            ConnectingState connectingState = connectingStates.get(node);
-                            if (connectingState == null) {
-                                networkClient.ready(node, now);
-                                connectingStates.put(node, new ConnectingState(now));
-                            } else {
-                                if (now - connectingState.startConnectNanos > 3000) {
-                                    for (; ; ) {
-                                        Request request = queue.poll();
-                                        if (request == null) {
-                                            break;
-                                        }
-                                        request.cf.completeExceptionally(new SocketTimeoutException(String.format("Cannot connect to node=%s", node)));
-                                    }
-                                    connectingStates.remove(node);
-                                } else if (now - connectingState.startConnectNanos > 1000 && connectingState.connectTimes < 2) {
-                                    // The broker network maybe slightly ready after the broker become UNFENCED.
-                                    // So we need to retry connect twice.
-                                    networkClient.ready(node, now);
-                                    connectingState.connectTimes = connectingState.connectTimes + 1;
-                                }
-                            }
-                        }
-                    });
-                    networkClient.poll(1, now);
-                } catch (Throwable e) {
-                    LOGGER.error("Processor get uncaught exception", e);
-                }
-            }
+            return delegate.sendRequest(node, requestBuilder);
         }
 
         @Override
@@ -202,28 +128,7 @@ public interface AsyncSender {
 
         @Override
         public void close() {
-            networkClient.close();
-            shouldRun.set(false);
-        }
-    }
-
-    class Request {
-        final AbstractRequest.Builder<?> requestBuilder;
-        final CompletableFuture<ClientResponse> cf;
-
-        public Request(AbstractRequest.Builder<?> requestBuilder, CompletableFuture<ClientResponse> cf) {
-            this.requestBuilder = requestBuilder;
-            this.cf = cf;
-        }
-    }
-
-    class ConnectingState {
-        final long startConnectNanos;
-        int connectTimes;
-
-        public ConnectingState(long startConnectNanos) {
-            this.startConnectNanos = startConnectNanos;
-            connectTimes = 1;
+            delegate.close();
         }
     }
 

--- a/core/src/main/java/kafka/automq/zerozone/ObjectRouterChannel.java
+++ b/core/src/main/java/kafka/automq/zerozone/ObjectRouterChannel.java
@@ -29,7 +29,10 @@ import com.automq.stream.s3.wal.impl.DefaultRecordOffset;
 import com.automq.stream.s3.wal.impl.object.ObjectWALService;
 import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.LogContext;
+import com.automq.stream.utils.Systems;
 import com.automq.stream.utils.Threads;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import org.slf4j.Logger;
 
@@ -40,6 +43,7 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -48,6 +52,10 @@ import io.netty.buffer.ByteBuf;
 public class ObjectRouterChannel implements RouterChannel {
     private static final ExecutorService ASYNC_EXECUTOR = Executors.newCachedThreadPool();
     private static final long OVER_CAPACITY_RETRY_DELAY_MS = 1000L;
+    private static final long CACHE_WEIGHT_UNIT = 100L << 20;
+    private static final long HEAP_PER_CACHE_WEIGHT_UNIT = 6L << 30;
+    private static final long CACHE_MAX_WEIGHT = cacheMaxWeight(Systems.HEAP_MEMORY_SIZE);
+    private static final long CACHE_EXPIRE_SECONDS = 10;
     // Owned by this class for the process lifetime so all router channels reuse the same slabs.
     private static final RecyclingByteBufSeqAlloc ALLOC =
         new RecyclingByteBufSeqAlloc(ByteBufAlloc.ROUTER_CHANNEL);
@@ -56,6 +64,18 @@ public class ObjectRouterChannel implements RouterChannel {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
     private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+    // The data written by the local router channel is cached to avoid reading it back from object storage.
+    private final Cache<ByteBuf /* channel offset */, CachedData> cache = CacheBuilder.newBuilder()
+        .expireAfterWrite(CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS)
+        .maximumWeight(CACHE_MAX_WEIGHT)
+        .weigher((ByteBuf k, CachedData v) -> v.readableBytes())
+        .removalListener(notification -> {
+            CachedData data = notification.getValue();
+            if (data != null) {
+                data.release();
+            }
+        })
+        .build();
 
     private final ObjectWALService wal;
     private final int nodeId;
@@ -66,6 +86,8 @@ public class ObjectRouterChannel implements RouterChannel {
     private final Map<Long, RecordOffset> channelEpoch2LastRecordOffset = new HashMap<>();
 
     private final CompletableFuture<Void> startCf;
+    private boolean closed;
+    private CompletableFuture<Void> closeCf;
 
     public ObjectRouterChannel(int nodeId, short channelId, ObjectWALService wal) {
         this.logger = new LogContext(String.format("[OBJECT_ROUTER_CHANNEL-%s-%s] ", channelId, nodeId)).logger(ObjectRouterChannel.class);
@@ -91,11 +113,19 @@ public class ObjectRouterChannel implements RouterChannel {
         // The record will be released after appending is done. Use the ALLOC to decrease the memory fragmentation.
         StreamRecordBatch record = StreamRecordBatch.of(targetNodeId, 0, mockOffset.incrementAndGet(), 1, data, ALLOC);
         for (; ; ) {
+            readLock.lock();
             try {
+                if (closed) {
+                    record.release();
+                    return CompletableFuture.failedFuture(new IllegalStateException("ObjectRouterChannel is closed"));
+                }
                 record.retain();
                 return wal.append(TraceContext.DEFAULT, record).thenApply(walRst -> {
                     readLock.lock();
                     try {
+                        if (closed) {
+                            throw new IllegalStateException("ObjectRouterChannel is closed");
+                        }
                         long epoch = this.channelEpoch;
                         ChannelOffset channelOffset = ChannelOffset.of(channelId, orderHint, nodeId, targetNodeId, walRst.recordOffset().buffer());
                         channelEpoch2LastRecordOffset.put(epoch, walRst.recordOffset());
@@ -103,7 +133,21 @@ public class ObjectRouterChannel implements RouterChannel {
                     } finally {
                         readLock.unlock();
                     }
-                }).whenComplete((r, e) -> record.release());
+                }).whenComplete((rst, ex) -> {
+                    readLock.lock();
+                    try {
+                        if (rst != null && !closed && targetNodeId != this.nodeId) {
+                            // The channel offset is an immutable unpooled buffer, so the cache key does not own a
+                            // reference. The cache owns the payload reference until a reader takes it or the entry is
+                            // removed.
+                            cache.put(rst.channelOffset().slice(), new CachedData(record.getPayload()));
+                        } else {
+                            record.release();
+                        }
+                    } finally {
+                        readLock.unlock();
+                    }
+                });
             } catch (OverCapacityException e) {
                 logger.warn("OverCapacityException occurred while appending, err={}", e.getMessage());
                 // Use block-based delayed retries for network backpressure.
@@ -112,6 +156,8 @@ public class ObjectRouterChannel implements RouterChannel {
                 logger.error("[UNEXPECTED], append wal fail", e);
                 record.release();
                 return CompletableFuture.failedFuture(e);
+            } finally {
+                readLock.unlock();
             }
         }
     }
@@ -122,6 +168,15 @@ public class ObjectRouterChannel implements RouterChannel {
     }
 
     CompletableFuture<ByteBuf> get0(ByteBuf channelOffset) {
+        CachedData cachedData = cache.getIfPresent(channelOffset);
+        if (cachedData != null) {
+            ByteBuf buf = cachedData.take();
+            if (buf != null) {
+                // Router channel data is read once, so the cache entry is no longer useful after a hit.
+                cache.invalidate(channelOffset);
+                return CompletableFuture.completedFuture(buf);
+            }
+        }
         return wal.get(DefaultRecordOffset.of(ChannelOffset.of(channelOffset).walRecordOffset())).thenApply(streamRecordBatch -> {
             ByteBuf payload = streamRecordBatch.getPayload().retainedSlice();
             streamRecordBatch.release();
@@ -168,7 +223,59 @@ public class ObjectRouterChannel implements RouterChannel {
     }
 
     @Override
-    public CompletableFuture<Void> close() {
-        return startCf.thenAcceptAsync(nil -> FutureUtil.suppress(wal::shutdownGracefully, logger), ASYNC_EXECUTOR);
+    public synchronized CompletableFuture<Void> close() {
+        if (closeCf != null) {
+            return closeCf;
+        }
+        closeCf = startCf.thenRunAsync(() -> {
+            writeLock.lock();
+            try {
+                closed = true;
+                cache.invalidateAll();
+                cache.cleanUp();
+            } finally {
+                writeLock.unlock();
+            }
+            FutureUtil.suppress(wal::shutdownGracefully, logger);
+        }, ASYNC_EXECUTOR);
+        return closeCf;
+    }
+
+    static final class CachedData {
+        private final ByteBuf data;
+        private final int readableBytes;
+        private boolean ownedByCache = true;
+
+        CachedData(ByteBuf data) {
+            this.data = data;
+            this.readableBytes = data.readableBytes();
+        }
+
+        synchronized ByteBuf take() {
+            if (!ownedByCache) {
+                return null;
+            }
+            ownedByCache = false;
+            return data;
+        }
+
+        synchronized void release() {
+            if (ownedByCache) {
+                ownedByCache = false;
+                data.release();
+            }
+        }
+
+        int readableBytes() {
+            return readableBytes;
+        }
+    }
+
+    static long cacheMaxWeight(long heapMemorySize) {
+        long units = heapMemorySize / HEAP_PER_CACHE_WEIGHT_UNIT;
+        if (heapMemorySize % HEAP_PER_CACHE_WEIGHT_UNIT != 0) {
+            units++;
+        }
+        return Math.max(units, 1) * CACHE_WEIGHT_UNIT;
     }
 }

--- a/core/src/main/java/kafka/automq/zerozone/RouterChannel.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterChannel.java
@@ -48,6 +48,10 @@ public interface RouterChannel {
             return epoch;
         }
 
+        /**
+         * Returns the immutable, unpooled channel offset. The buffer is GC-managed, so callers must not mutate or
+         * release it.
+         */
         public ByteBuf channelOffset() {
             return channelOffset;
         }

--- a/core/src/main/java/kafka/automq/zerozone/RouterInV2.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterInV2.java
@@ -35,24 +35,22 @@ import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.s3.AutomqZoneRouterResponse;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.Systems;
 import com.automq.stream.utils.threads.EventLoop;
-import com.yammer.metrics.core.Histogram;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
@@ -61,13 +59,8 @@ import io.netty.util.concurrent.FastThreadLocal;
 
 public class RouterInV2 implements NonBlockingLocalRouterHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RouterInV2.class);
-    private static final KafkaMetricsGroup METRICS_GROUP = new KafkaMetricsGroup(RouterInV2.class);
-    private static final Histogram APPEND_PERMIT_ACQUIRE_FAIL_TIME_HIST = METRICS_GROUP.newHistogram("RouterInAppendPermitAcquireFailTimeNanos");
-
-    private static final int APPEND_PERMIT = Systems.getEnvInt("AUTOMQ_APPEND_PERMIT_SIZE",
-        Integer.MAX_VALUE
-    );
-    private static final int PLACEHOLDER_PERMIT = Systems.getEnvInt("AUTOMQ_ROUTER_IN_PLACEHOLDER_PERMIT", 256);
+    private static final int ORDER_QUEUE_STRIPES_PER_CPU = 64;
+    private static final int MAX_ORDER_QUEUE_COUNT = 1 << Short.SIZE;
 
     static {
         // RouterIn will parallel append the records from one AutomqZoneRouterRequest.
@@ -80,7 +73,7 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
     private final String rack;
     private final RouterInProduceHandler localAppendHandler;
     private RouterInProduceHandler routerInProduceHandler;
-    private final BlockingQueue<PartitionProduceRequest> unpackLinkQueue = new ArrayBlockingQueue<>(Systems.CPU_CORES * 8192);
+    private final OrderQueue[] orderQueues;
     private final EventLoop[] appendEventLoops;
     private final FastThreadLocal<RequestLocal> requestLocals = new FastThreadLocal<>() {
         @Override
@@ -90,7 +83,6 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         }
     };
     private final Time time;
-    private final RouterPermitLimiter appendPermitLimiter;
 
     public RouterInV2(RouterChannelProvider channelProvider, ElasticKafkaApis kafkaApis, String rack, Time time) {
         this.channelProvider = channelProvider;
@@ -99,14 +91,12 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         this.localAppendHandler = kafkaApis::handleProduceAppendJavaCompatible;
         this.routerInProduceHandler = this.localAppendHandler;
         this.time = time;
-        this.appendPermitLimiter = new RouterPermitLimiter(
-            "[ROUTER_IN]",
-            time,
-            APPEND_PERMIT,
-            APPEND_PERMIT_ACQUIRE_FAIL_TIME_HIST,
-            LOGGER
-        );
 
+        this.orderQueues = new OrderQueue[Math.min(MAX_ORDER_QUEUE_COUNT,
+            Systems.CPU_CORES * ORDER_QUEUE_STRIPES_PER_CPU)];
+        for (int i = 0; i < orderQueues.length; i++) {
+            orderQueues[i] = new OrderQueue();
+        }
         this.appendEventLoops = new EventLoop[Systems.CPU_CORES];
         for (int i = 0; i < appendEventLoops.length; i++) {
             this.appendEventLoops[i] = new EventLoop("ROUTER_IN_V2_APPEND_" + i);
@@ -120,7 +110,11 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
             String str = String.format("The router request epoch %s is less than fenced epoch %s.", requestEpoch, channelProvider.epoch().getFenced());
             return CompletableFuture.failedFuture(new IllegalStateException(str));
         }
-        return handleZoneRouterRequest0(request);
+        long startNanos = time.nanoseconds();
+        CompletableFuture<AutomqZoneRouterResponse> cf = handleZoneRouterRequest0(request);
+        cf.whenComplete((rst, ex) ->
+            ZeroZoneMetricsManager.IN_HANDLE_REQUEST_LATENCY.record(time.nanoseconds() - startNanos));
+        return cf;
     }
 
     private CompletableFuture<AutomqZoneRouterResponse> handleZoneRouterRequest0(AutomqZoneRouterRequestData request) {
@@ -131,25 +125,18 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         long startNanos = time.nanoseconds();
         for (ByteBuf channelOffset : routerRecord.channelOffsets()) {
             PartitionProduceRequest partitionProduceRequest = new PartitionProduceRequest(ChannelOffset.of(channelOffset));
-            // Acquire placeholder permit upfront as admission control before data is fetched
-            int placeholderPermit = appendPermitLimiter.acquire(PLACEHOLDER_PERMIT);
-            AtomicInteger acquiredPermit = new AtomicInteger(placeholderPermit);
-            // Note: responseCf is guaranteed to be completed AFTER unpackLinkCf callback (in handleUnpackLink -> append0 chain).
-            // Therefore, the release callback registered on responseCf will always see the fully updated acquiredPermit value.
-            partitionProduceRequest.responseCf.whenComplete((resp, ex) -> appendPermitLimiter.release(acquiredPermit.get()));
             partitionProduceRequest.unpackLinkCf = routerChannel.get(channelOffset).whenComplete((rst, ex) -> {
                 if (ex == null) {
                     int actualSize = rst.readableBytes();
                     size.addAndGet(actualSize);
-                    // Try to acquire more permits based on actual data size (non-blocking)
-                    acquiredPermit.addAndGet(appendPermitLimiter.acquireUpTo(actualSize));
                 }
             });
-            addToUnpackLinkQueue(partitionProduceRequest);
+            OrderQueue orderQueue = orderQueue(partitionProduceRequest.channelOffset.orderHint());
+            orderQueue.add(partitionProduceRequest);
             // trigger unpack processing and record metrics
             partitionProduceRequest.unpackLinkCf.whenComplete((rst, ex) -> {
-                handleUnpackLink();
-                ZeroZoneMetricsManager.GET_CHANNEL_LATENCY.record(time.nanoseconds() - startNanos);
+                orderQueue.drain(this::scheduleAppend);
+                ZeroZoneMetricsManager.IN_GET_CHANNEL_LATENCY.record(time.nanoseconds() - startNanos);
             });
             subResponseList.add(partitionProduceRequest.responseCf);
         }
@@ -161,46 +148,31 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         });
     }
 
-    private void handleUnpackLink() {
-        if (unpackLinkQueue.isEmpty()) {
-            return;
-        }
-        synchronized (unpackLinkQueue) {
-            while (!unpackLinkQueue.isEmpty()) {
-                PartitionProduceRequest req = unpackLinkQueue.peek();
-                if (req.unpackLinkCf.isDone()) {
-                    EventLoop eventLoop = appendEventLoops[Math.abs(req.channelOffset.orderHint() % appendEventLoops.length)];
-                    req.unpackLinkCf.thenComposeAsync(buf -> {
-                        ZoneRouterProduceRequest zoneRouterProduceRequest = ZoneRouterPackReader.decodeDataBlock(buf).get(0);
-                        try {
-                            return append0(req.channelOffset, zoneRouterProduceRequest, false);
-                        } finally {
-                            buf.release();
-                        }
-                    }, eventLoop).whenComplete((resp, ex) -> {
-                        if (ex != null) {
-                            LOGGER.error("[ROUTER_IN],[FAILED]", ex);
-                            req.responseCf.completeExceptionally(ex);
-                            return;
-                        }
-                        req.responseCf.complete(resp);
-                    });
-                    unpackLinkQueue.poll();
-                } else {
-                    break;
-                }
+    private void scheduleAppend(PartitionProduceRequest req) {
+        EventLoop eventLoop = appendEventLoop(req.channelOffset.orderHint());
+        req.unpackLinkCf.thenComposeAsync(buf -> {
+            try {
+                ZoneRouterProduceRequest zoneRouterProduceRequest = ZoneRouterPackReader.decodeDataBlock(buf).get(0);
+                return append0(req.channelOffset, zoneRouterProduceRequest, false);
+            } finally {
+                buf.release();
             }
-        }
+        }, eventLoop).whenComplete((resp, ex) -> {
+            if (ex != null) {
+                LOGGER.error("[ROUTER_IN],[FAILED]", ex);
+                req.responseCf.completeExceptionally(ex);
+                return;
+            }
+            req.responseCf.complete(resp);
+        });
     }
 
-    private void addToUnpackLinkQueue(PartitionProduceRequest req) {
-        for (;;) {
-            try {
-                unpackLinkQueue.put(req);
-                return;
-            } catch (InterruptedException ignored) {
-            }
-        }
+    private OrderQueue orderQueue(short orderHint) {
+        return orderQueues[index(orderHint, orderQueues.length)];
+    }
+
+    private EventLoop appendEventLoop(short orderHint) {
+        return appendEventLoops[index(orderHint, appendEventLoops.length)];
     }
 
     @Override
@@ -209,7 +181,7 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         ZoneRouterProduceRequest zoneRouterProduceRequest
     ) {
         CompletableFuture<AutomqZoneRouterResponseData.Response> cf = new CompletableFuture<>();
-        appendEventLoops[Math.abs(channelOffset.orderHint() % appendEventLoops.length)].execute(() ->
+        appendEventLoop(channelOffset.orderHint()).execute(() ->
             FutureUtil.propagate(append0(channelOffset, zoneRouterProduceRequest, true), cf));
         return cf;
     }
@@ -219,6 +191,7 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         ZoneRouterProduceRequest zoneRouterProduceRequest,
         boolean local
     ) {
+        long startNanos = time.nanoseconds();
         ZoneRouterProduceRequest.Flag flag = new ZoneRouterProduceRequest.Flag(zoneRouterProduceRequest.flag());
         ProduceRequestData data = zoneRouterProduceRequest.data();
         if (LOGGER.isTraceEnabled()) {
@@ -231,7 +204,10 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         CompletableFuture<AutomqZoneRouterResponseData.Response> cf = new CompletableFuture<>();
         RouterInProduceHandler handler = local ? localAppendHandler : routerInProduceHandler;
         // We should release the request after append completed.
-        cf.whenComplete((resp, ex) -> FutureUtil.suppress(zoneRouterProduceRequest::close, LOGGER));
+        cf.whenComplete((resp, ex) -> {
+            ZeroZoneMetricsManager.IN_APPEND_PARTITION_LATENCY.record(time.nanoseconds() - startNanos);
+            FutureUtil.suppress(zoneRouterProduceRequest::close, LOGGER);
+        });
         handler.handleProduceAppend(
             ProduceRequestArgs.builder()
                 .clientId(buildClientId(realEntriesPerPartition))
@@ -281,6 +257,10 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         return null;
     }
 
+    static int index(short orderHint, int length) {
+        return Short.toUnsignedInt(orderHint) % length;
+    }
+
     static class PartitionProduceRequest {
         final ChannelOffset channelOffset;
         CompletableFuture<ByteBuf> unpackLinkCf;
@@ -288,6 +268,25 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
 
         public PartitionProduceRequest(ChannelOffset channelOffset) {
             this.channelOffset = channelOffset;
+        }
+    }
+
+    static class OrderQueue {
+        private final ArrayDeque<PartitionProduceRequest> queue = new ArrayDeque<>();
+
+        synchronized void add(PartitionProduceRequest request) {
+            queue.add(request);
+        }
+
+        synchronized void drain(Consumer<PartitionProduceRequest> consumer) {
+            while (!queue.isEmpty() && queue.peek().unpackLinkCf.isDone()) {
+                PartitionProduceRequest request = queue.poll();
+                try {
+                    consumer.accept(request);
+                } catch (RuntimeException t) {
+                    request.responseCf.completeExceptionally(t);
+                }
+            }
         }
     }
 

--- a/core/src/main/java/kafka/automq/zerozone/RouterOutV2.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterOutV2.java
@@ -33,11 +33,8 @@ import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.s3.AutomqZoneRouterRequest;
 import org.apache.kafka.common.requests.s3.AutomqZoneRouterResponse;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
-import com.automq.stream.utils.Systems;
 import com.automq.stream.utils.Threads;
-import com.yammer.metrics.core.Histogram;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,13 +60,6 @@ import io.netty.buffer.Unpooled;
 
 public class RouterOutV2 {
     private static final Logger LOGGER = LoggerFactory.getLogger(RouterOutV2.class);
-    private static final KafkaMetricsGroup METRICS_GROUP = new KafkaMetricsGroup(RouterOutV2.class);
-    private static final Histogram APPEND_PERMIT_ACQUIRE_FAIL_TIME_HIST = METRICS_GROUP.newHistogram("RouterOutAppendPermitAcquireFailTimeNanos");
-    // Disabled by default to avoid blocking request-handler threads.
-    // Blocking handlers prevents AUTOMQ_ZONE_ROUTER processing, causing produce requests to fail continuously.
-    private static final int APPEND_PERMIT = Systems.getEnvInt("AUTOMQ_APPEND_PERMIT_SIZE",
-        Integer.MAX_VALUE
-    );
 
     private final Node currentNode;
     private final RouterChannel routerChannel;
@@ -79,7 +69,6 @@ public class RouterOutV2 {
     private final GetRouterOutNode mapping;
     private final AsyncSender asyncSender;
     private final Time time;
-    private final RouterPermitLimiter appendPermitLimiter;
 
     public RouterOutV2(Node currentNode, RouterChannel routerChannel, GetRouterOutNode mapping,
         NonBlockingLocalRouterHandler localRouterHandler, AsyncSender asyncSender, Time time) {
@@ -89,13 +78,6 @@ public class RouterOutV2 {
         this.localProxy = new LocalProxy(localRouterHandler);
         this.asyncSender = asyncSender;
         this.time = time;
-        this.appendPermitLimiter = new RouterPermitLimiter(
-            "[ROUTER_OUT]",
-            time,
-            APPEND_PERMIT,
-            APPEND_PERMIT_ACQUIRE_FAIL_TIME_HIST,
-            LOGGER
-        );
     }
 
     public void handleProduceAppendProxy(ProduceRequestArgs args) {
@@ -115,19 +97,18 @@ public class RouterOutV2 {
             }
             short orderHint = orderHint(tp, args.clientId().connectionId());
             int recordSize = records.sizeInBytes();
-            int permits = appendPermitLimiter.acquire(recordSize);
             ZoneRouterProduceRequest zoneRouterProduceRequest = zoneRouterProduceRequest(args, flag, tp, records);
             CompletableFuture<RouterChannel.AppendResult> channelCf = routerChannel.append(node.id(), orderHint, ZoneRouterPackWriter.encodeDataBlock(List.of(zoneRouterProduceRequest)));
             CompletableFuture<Void> proxyCf = channelCf.thenCompose(channelRst -> {
                 long timeNanos = time.nanoseconds();
-                ZeroZoneMetricsManager.APPEND_CHANNEL_LATENCY.record(timeNanos - startNanos);
+                ZeroZoneMetricsManager.OUT_APPEND_CHANNEL_LATENCY.record(timeNanos - startNanos);
                 ProxyRequest proxyRequest = new ProxyRequest(tp, channelRst.epoch(), channelRst.channelOffset(), zoneRouterProduceRequest, recordSize, timeoutMillis);
                 sendProxyRequest(node, proxyRequest);
                 return proxyRequest.cf.thenAccept(response -> {
                     if (!acks0) {
                         responseMap.put(tp, response);
                     }
-                    ZeroZoneMetricsManager.PROXY_REQUEST_LATENCY.record(time.nanoseconds() - startNanos);
+                    ZeroZoneMetricsManager.OUT_HANDLE_REQUEST_LATENCY.record(time.nanoseconds() - startNanos);
                 });
             }).exceptionally(ex -> {
                 LOGGER.error("Exception in processing append proxies", ex);
@@ -135,11 +116,6 @@ public class RouterOutV2 {
                 responseMap.put(tp, errorPartitionResponse(Errors.LEADER_NOT_AVAILABLE));
                 return null;
             });
-            if (acks0) {
-                channelCf.whenComplete((rst, ex) -> appendPermitLimiter.release(permits));
-            } else {
-                proxyCf.whenComplete((rst, ex) -> appendPermitLimiter.release(permits));
-            }
             cfList.add(proxyCf);
         }
         Consumer<Map<TopicPartition, ProduceResponse.PartitionResponse>> responseCallback = args.responseCallback();
@@ -215,6 +191,9 @@ public class RouterOutV2 {
         }
 
         public synchronized void send(ProxyRequest request) {
+            long startNanos = time.nanoseconds();
+            request.cf.whenComplete((rst, ex) ->
+                ZeroZoneMetricsManager.OUT_REQUEST_TARGET_LATENCY.record(time.nanoseconds() - startNanos));
             ZeroZoneMetricsManager.recordRouterOutBytes(node.id(), request.recordSize);
             synchronized (this) {
                 if (requestBatch == null) {

--- a/core/src/main/java/kafka/automq/zerozone/SnapshotReadPartitionsManager.java
+++ b/core/src/main/java/kafka/automq/zerozone/SnapshotReadPartitionsManager.java
@@ -113,10 +113,14 @@ public class SnapshotReadPartitionsManager implements MetadataListener, ProxyTop
     }
 
     public synchronized void close() {
+        if (closed) {
+            return;
+        }
         closed = true;
         subscribers.forEach((k, s) -> s.close());
         CompletableFuture.allOf(closingSubscribers.toArray(new CompletableFuture[0])).join();
         subscribers.clear();
+        asyncSender.close();
     }
 
     @Override

--- a/core/src/main/java/kafka/automq/zerozone/ZeroZoneMetricsManager.java
+++ b/core/src/main/java/kafka/automq/zerozone/ZeroZoneMetricsManager.java
@@ -50,9 +50,22 @@ public class ZeroZoneMetricsManager {
         .build());
 
     private static final Metrics.HistogramBundle ROUTER_LATENCY = Metrics.instance().histogram(PREFIX + "router_latency", "ZeroZone route latency", "nanoseconds");
-    public static final DeltaHistogram APPEND_CHANNEL_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO, Attributes.of(AttributeKey.stringKey("operation"), "out", AttributeKey.stringKey("stage"), "append_channel"));
-    public static final DeltaHistogram PROXY_REQUEST_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO, Attributes.of(AttributeKey.stringKey("operation"), "out", AttributeKey.stringKey("stage"), "proxy_request"));
-    public static final DeltaHistogram GET_CHANNEL_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO, Attributes.of(AttributeKey.stringKey("operation"), "in", AttributeKey.stringKey("stage"), "get_channel"));
+    public static final DeltaHistogram OUT_HANDLE_REQUEST_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("out", "handle_request"));
+    public static final DeltaHistogram OUT_APPEND_CHANNEL_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("out", "append_channel"));
+    public static final DeltaHistogram OUT_REQUEST_TARGET_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("out", "request_target"));
+    public static final DeltaHistogram IN_HANDLE_REQUEST_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("in", "handle_request"));
+    public static final DeltaHistogram IN_GET_CHANNEL_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("in", "get_channel"));
+    public static final DeltaHistogram IN_APPEND_PARTITION_LATENCY = ROUTER_LATENCY.histogram(MetricsLevel.INFO,
+        latencyAttributes("in", "append_partition"));
+
+    private static Attributes latencyAttributes(String operation, String stage) {
+        return Attributes.of(AttributeKey.stringKey("operation"), operation, AttributeKey.stringKey("stage"), stage);
+    }
 
     public static void recordRouterOutBytes(int toNodeId, int bytes) {
         try {

--- a/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
+++ b/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
@@ -81,6 +81,7 @@ public class ZeroZoneTrafficInterceptor implements TrafficInterceptor, MetadataP
     private final RouterOutV2 routerOutV2;
     private final RouterInV2 routerInV2;
     private final CommittedEpochManager committedEpochManager;
+    private final AsyncSender asyncSender;
 
     private final SnapshotReadPartitionsManager snapshotReadPartitionsManager;
     private volatile AutoMQVersion version;
@@ -112,7 +113,7 @@ public class ZeroZoneTrafficInterceptor implements TrafficInterceptor, MetadataP
 
         Time time = Time.SYSTEM;
 
-        AsyncSender asyncSender = new AsyncSender.BrokersAsyncSender(kafkaConfig, kafkaApis.metrics(), "zone_router", time, ZoneRouterPack.ZONE_ROUTER_CLIENT_ID, new LogContext());
+        this.asyncSender = new AsyncSender.BrokersAsyncSender(kafkaConfig, kafkaApis.metrics(), "zone_router", time, ZoneRouterPack.ZONE_ROUTER_CLIENT_ID, new LogContext());
 
         this.config = kafkaConfig.automq().zoneRouterChannels().get();
 
@@ -152,6 +153,7 @@ public class ZeroZoneTrafficInterceptor implements TrafficInterceptor, MetadataP
         if (closed.compareAndSet(false, true)) {
             committedEpochManager.close();
             snapshotReadPartitionsManager.close();
+            asyncSender.close();
         }
     }
 

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
@@ -630,7 +630,13 @@ class ElasticLog(val metaStream: MetaStream,
 
             // AutoMQ inject start
             val (newSegment, newSegmentCf) = createAndSaveSegment(logSegmentManager, "", logIdent)(newOffset, _dir, config, streamSliceManager, time)
-            newSegmentCf.get()
+            // Segment metadata and subsequent data appends are persisted through the same ordered WAL. Do not block
+            // the append path on the metadata acknowledgement; a later append cannot be confirmed ahead of it.
+            newSegmentCf.whenComplete((_, ex) => {
+                if (ex != null) {
+                    recordLogWriteFailedIfUnexpected(FutureUtil.cause(ex))
+                }
+            })
             // AutoMQ inject end
             segments.add(newSegment)
 

--- a/core/src/test/java/kafka/automq/zerozone/RouterInV2Test.java
+++ b/core/src/test/java/kafka/automq/zerozone/RouterInV2Test.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.zerozone;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.buffer.Unpooled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Verifies the ordering and progress guarantees of RouterIn V2 read completion queues.
+ */
+@Tag("S3Unit")
+public class RouterInV2Test {
+
+    /**
+     * Given reads in one ordering stripe complete out of order, the queue must release them in arrival order.
+     */
+    @Test
+    public void testOrderQueuePreservesArrivalOrder() {
+        RouterInV2.OrderQueue queue = new RouterInV2.OrderQueue();
+        RouterInV2.PartitionProduceRequest first = request((short) 1);
+        RouterInV2.PartitionProduceRequest second = request((short) 1);
+        List<RouterInV2.PartitionProduceRequest> drained = new ArrayList<>();
+        queue.add(first);
+        queue.add(second);
+
+        second.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        queue.drain(drained::add);
+        assertEquals(List.of(), drained);
+
+        first.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        queue.drain(drained::add);
+        assertEquals(List.of(first, second), drained);
+    }
+
+    /**
+     * Given the head read fails, the completed failure must not prevent later requests from being released.
+     */
+    @Test
+    public void testOrderQueueAdvancesAfterReadFailure() {
+        RouterInV2.OrderQueue queue = new RouterInV2.OrderQueue();
+        RouterInV2.PartitionProduceRequest failed = request((short) 1);
+        RouterInV2.PartitionProduceRequest succeeded = request((short) 1);
+        List<RouterInV2.PartitionProduceRequest> drained = new ArrayList<>();
+        queue.add(failed);
+        queue.add(succeeded);
+
+        succeeded.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        failed.unpackLinkCf.completeExceptionally(new IllegalStateException("read failed"));
+        queue.drain(drained::add);
+
+        assertEquals(List.of(failed, succeeded), drained);
+    }
+
+    /**
+     * Given independent ordering stripes, a completed read must not wait for another stripe's head read.
+     */
+    @Test
+    public void testOrderQueuesDrainIndependently() {
+        RouterInV2.OrderQueue blockedQueue = new RouterInV2.OrderQueue();
+        RouterInV2.OrderQueue readyQueue = new RouterInV2.OrderQueue();
+        RouterInV2.PartitionProduceRequest blocked = request((short) 1);
+        RouterInV2.PartitionProduceRequest ready = request((short) 2);
+        List<RouterInV2.PartitionProduceRequest> drained = new ArrayList<>();
+        blockedQueue.add(blocked);
+        readyQueue.add(ready);
+
+        ready.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        readyQueue.drain(drained::add);
+
+        assertEquals(List.of(ready), drained);
+    }
+
+    /**
+     * Given scheduling one completed read fails, the queue must fail that request and continue draining.
+     */
+    @Test
+    public void testOrderQueueContinuesAfterSchedulingFailure() {
+        RouterInV2.OrderQueue queue = new RouterInV2.OrderQueue();
+        RouterInV2.PartitionProduceRequest failed = request((short) 1);
+        RouterInV2.PartitionProduceRequest succeeded = request((short) 1);
+        List<RouterInV2.PartitionProduceRequest> drained = new ArrayList<>();
+        failed.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        succeeded.unpackLinkCf.complete(Unpooled.EMPTY_BUFFER);
+        queue.add(failed);
+        queue.add(succeeded);
+
+        queue.drain(request -> {
+            if (request == failed) {
+                throw new IllegalStateException("scheduling failed");
+            }
+            drained.add(request);
+        });
+
+        assertInstanceOf(IllegalStateException.class, failed.responseCf.handle((rst, ex) -> ex).join());
+        assertEquals(List.of(succeeded), drained);
+    }
+
+    /**
+     * Given signed short order hints, indexing must use the complete unsigned 16-bit key space.
+     */
+    @Test
+    public void testOrderHintIndexUsesUnsignedValue() {
+        assertEquals(65535 % 3072, RouterInV2.index((short) -1, 3072));
+        assertEquals(32768 % 3072, RouterInV2.index(Short.MIN_VALUE, 3072));
+    }
+
+    private static RouterInV2.PartitionProduceRequest request(short orderHint) {
+        ChannelOffset channelOffset = ChannelOffset.of((short) 0, orderHint, 0, 0, Unpooled.EMPTY_BUFFER);
+        RouterInV2.PartitionProduceRequest request = new RouterInV2.PartitionProduceRequest(channelOffset);
+        request.unpackLinkCf = new CompletableFuture<>();
+        return request;
+    }
+}


### PR DESCRIPTION
## Motivation

ZeroZone routing can develop reciprocal backpressure under high bidirectional traffic because RouterIn and RouterOut acquire byte permits on Kafka request-handler threads. Once one peer slows down, blocked request handlers can prevent the reciprocal router requests required to release permits.

The routing path also has two additional sources of tail latency:

- RouterIn uses a global read-completion queue, so one slow RouterChannel read can block unrelated producers.
- A normal ElasticLog segment roll waits synchronously for segment metadata persistence before allowing append processing to continue.

## Changes

- Remove the blocking RouterIn and RouterOut permit limiters from the request path.
- Reuse `InterBrokerAsyncSender` for broker-to-broker request delivery.
- Add a bounded, heap-scaled, one-shot cache to `ObjectRouterChannel` so recently appended remote payloads can be consumed without reading them back from object storage.
- Replace the RouterIn global completion queue with fixed striped order queues:
  - preserve arrival order for the same `orderHint`;
  - allow independent ordering stripes to make progress concurrently;
  - use `min(65536, CPU cores * 64)` stripes;
  - map the complete unsigned 16-bit `orderHint` space consistently.
- Add detailed ZeroZone router latency stages:
  - `out/handle_request`
  - `out/append_channel`
  - `out/request_target`
  - `in/handle_request`
  - `in/get_channel`
  - `in/append_partition`
- Avoid blocking normal `ElasticLog.roll()` on segment metadata acknowledgement. Segment metadata and subsequent appends remain ordered by the same WAL, while asynchronous persistence failures continue to be reported.

## Correctness

Requests with the same `orderHint` are still submitted to the append EventLoop in receive order, preserving Kafka producer sequence ordering. A failed RouterChannel read or scheduling attempt advances its ordering stripe instead of blocking later requests indefinitely.

The ObjectRouterChannel cache transfers payload ownership exactly once: either to the first reader or to the removal path on expiration, eviction, or close.

This change does not alter the ZeroZone request protocol or require new configuration.