### PR TITLE
perf(jvm): enable generational ZGC on JDK 21

### DIFF
--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -30,6 +30,18 @@ calculate_max_heap_kb() {
     fi
 }
 
+# AutoMQ inject start
+get_java_major_version() {
+    local java
+    if [[ -z "$JAVA_HOME" ]]; then
+        java="java"
+    else
+        java="$JAVA_HOME/bin/java"
+    fi
+    "$java" -version 2>&1 | sed -E -n 's/.* version "([0-9]+).*$/\1/p'
+}
+# AutoMQ inject end
+
 if [ $# -lt 1 ];
 then
 	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
@@ -45,6 +57,20 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     max_heap_kb=$(calculate_max_heap_kb)
     export KAFKA_HEAP_OPTS="-Xmx${max_heap_kb}k -Xms${max_heap_kb}k -XX:MetaspaceSize=96m"
 fi
+
+# AutoMQ inject start
+if [ "x$KAFKA_JVM_PERFORMANCE_OPTS" = "x" ]; then
+    java_major_version=$(get_java_major_version)
+    if [[ "$java_major_version" -ge 23 ]]; then
+        gc_opts="-XX:+UseZGC -XX:ZCollectionIntervalMinor=5"
+    elif [[ "$java_major_version" -ge 21 ]]; then
+        gc_opts="-XX:+UseZGC -XX:+ZGenerational -XX:ZCollectionIntervalMinor=5"
+    else
+        gc_opts="-XX:+UseZGC -XX:ZCollectionInterval=5"
+    fi
+    export KAFKA_JVM_PERFORMANCE_OPTS="-server $gc_opts -Djava.awt.headless=true"
+fi
+# AutoMQ inject end
 
 if [ "x$KAFKA_OPTS" = "x" ]; then
     export KAFKA_OPTS="-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -Dio.netty.allocator.maxOrder=11"

--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG jdk_version=eclipse-temurin:17-jdk-jammy
+ARG jdk_version=eclipse-temurin:21-jdk-jammy
 FROM $jdk_version
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/devkit/README.md
+++ b/devkit/README.md
@@ -210,7 +210,7 @@ just shell      # Enter node-0 shell — jstack, jmap, jcmd available
 just shell 1    # Enter node-1 shell
 ```
 
-> To change JVM heap size, edit `HEAP_OPTS` in `justfile` (default: `-Xms256m -Xmx256m`).
+> To change the broker JVM heap size, set `KAFKA_HEAP_OPTS` before starting DevKit. The default is `-Xms1g -Xmx4g -XX:MetaspaceSize=96m`.
 
 ## IDEA Remote Debugging
 

--- a/devkit/docker-compose.yml
+++ b/devkit/docker-compose.yml
@@ -1,4 +1,5 @@
 x-automq-common: &automq-common
+  image: automq-devkit:jdk21
   build:
     context: .
     dockerfile: Dockerfile
@@ -14,8 +15,7 @@ x-automq-common: &automq-common
   environment:
     - KAFKA_S3_ACCESS_KEY=${KAFKA_S3_ACCESS_KEY}
     - KAFKA_S3_SECRET_KEY=${KAFKA_S3_SECRET_KEY}
-    - KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS:--Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G}
-    - KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseZGC -XX:ZCollectionInterval=5
+    - KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS:--Xms1g -Xmx4g -XX:MetaspaceSize=96m}
     - LOG_DIR=/tmp/kafka-logs
   depends_on:
     mc:


### PR DESCRIPTION
## Summary

- select ZGC collection interval options based on the runtime JDK version
- enable Generational ZGC with a five-second minor collection interval on JDK 21 and 22
- upgrade the DevKit broker runtime to JDK 21 and use heap-backed allocation without a direct-memory limit
- version the DevKit image by JDK and document the broker heap override