### PR TITLE
fix(s3stream): improve V1 stream object compaction convergence

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3StreamClient.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3StreamClient.java
@@ -68,6 +68,7 @@ import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.
 import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.MAJOR_V1;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.MINOR;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.MINOR_V1;
+import static com.automq.stream.s3.compact.StreamObjectCompactor.MINOR_COMPACTION_SIZE_THRESHOLD;
 import static com.automq.stream.s3.compact.StreamObjectCompactor.MINOR_V1_COMPACTION_SIZE_THRESHOLD;
 
 public class S3StreamClient implements StreamClient {
@@ -436,29 +437,42 @@ public class S3StreamClient implements StreamClient {
         }
 
         private void compactV1(CompactionHint hint, long now) {
-            if (now - lastMajorV1CompactionTimestamp > MAJOR_V1_COMPACTION_INTERVAL ||
-                shouldRunMajorV1CompactionByObjectCount(hint.objectsCount, MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD)) {
-                compact(MAJOR_V1, hint);
-                lastMajorV1CompactionTimestamp = System.currentTimeMillis();
-            } else if (now - lastMinorV1CompactionTimestamp > MINOR_V1_COMPACTION_INTERVAL) {
-                compact(MINOR_V1, hint);
-                lastMinorV1CompactionTimestamp = System.currentTimeMillis();
-            } else {
-                compact(CLEANUP_V1, hint);
+            boolean majorDue = now - lastMajorV1CompactionTimestamp > MAJOR_V1_COMPACTION_INTERVAL;
+            boolean minorDue = now - lastMinorV1CompactionTimestamp > MINOR_V1_COMPACTION_INTERVAL;
+            boolean majorRequiredByObjectCount = shouldRunMajorV1CompactionByObjectCount(hint.objectsCount,
+                MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD);
+            for (StreamObjectCompactor.CompactionType compactionType : v1CompactionTypes(majorDue, minorDue,
+                majorRequiredByObjectCount)) {
+                compact(compactionType, hint);
+                if (MAJOR_V1.equals(compactionType)) {
+                    lastMajorV1CompactionTimestamp = System.currentTimeMillis();
+                } else if (MINOR_V1.equals(compactionType)) {
+                    lastMinorV1CompactionTimestamp = System.currentTimeMillis();
+                }
             }
         }
 
         private void compact(StreamObjectCompactor.CompactionType compactionType, CompactionHint hint) {
+            // Select the policy-specific threshold here so StreamObjectCompactor only applies the grouping behavior of
+            // each compaction type and does not reconstruct size configuration from unrelated parameters.
+            long groupSizeThreshold;
+            if (MINOR.equals(compactionType)) {
+                groupSizeThreshold = MINOR_COMPACTION_SIZE_THRESHOLD;
+            } else if (MINOR_V1.equals(compactionType)) {
+                groupSizeThreshold = MINOR_V1_COMPACTION_SIZE;
+            } else {
+                groupSizeThreshold = config.streamObjectCompactionMaxSizeBytes();
+            }
+            // Under normal object counts, leave small normal objects to MINOR_V1. Disable the filter under object-count
+            // pressure so MAJOR_V1 can reduce metadata even before MINOR_V1 has enlarged every small object.
+            long majorV1MinNormalObjectSize = hint != null
+                && hint.objectsCount < MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD ? MINOR_V1_COMPACTION_SIZE : 0;
             StreamObjectCompactor.Builder taskBuilder = StreamObjectCompactor.builder()
                 .objectManager(objectManager)
                 .stream(this)
                 .objectStorage(objectStorage)
-                .maxStreamObjectSize(config.streamObjectCompactionMaxSizeBytes())
-                .minorV1CompactionThreshold(MINOR_V1_COMPACTION_SIZE);
-
-            if (hint != null) {
-                taskBuilder.majorV1CompactionSkipSmallObject(hint.objectsCount < MAJOR_V1_COMPACTION_MAX_OBJECT_THRESHOLD);
-            }
+                .groupSizeThreshold(groupSizeThreshold)
+                .majorV1MinNormalObjectSize(majorV1MinNormalObjectSize);
 
             taskBuilder.build().compact(compactionType);
         }
@@ -466,6 +480,24 @@ public class S3StreamClient implements StreamClient {
 
     static boolean shouldRunMajorV1CompactionByObjectCount(int objectsCount, int maxObjectThreshold) {
         return objectsCount >= (int) Math.ceil(maxObjectThreshold * MAJOR_V1_COMPACTION_OBJECT_COUNT_SOFT_THRESHOLD_RATIO);
+    }
+
+    static List<StreamObjectCompactor.CompactionType> v1CompactionTypes(boolean majorDue, boolean minorDue,
+        boolean majorRequiredByObjectCount) {
+        StreamObjectCompactor.CompactionType scheduledType;
+        if (majorDue) {
+            scheduledType = MAJOR_V1;
+        } else if (minorDue) {
+            scheduledType = MINOR_V1;
+        } else {
+            scheduledType = CLEANUP_V1;
+        }
+        // Object-count pressure accelerates MAJOR_V1 after the regular lifecycle task instead of starving MINOR_V1
+        // or CLEANUP_V1. A regularly scheduled MAJOR_V1 already satisfies the pressure request.
+        if (majorRequiredByObjectCount && !MAJOR_V1.equals(scheduledType)) {
+            return List.of(scheduledType, MAJOR_V1);
+        }
+        return List.of(scheduledType);
     }
 
     static class CompactionHint {

--- a/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/compact/StreamObjectCompactor.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
@@ -98,31 +98,28 @@ public class StreamObjectCompactor {
         EnumSet.of(MINOR, MAJOR, MINOR_V1, MAJOR_V1);
 
     private final Logger s3ObjectLogger;
-    private final long maxStreamObjectSize;
+    private final long groupSizeThreshold;
     private final Stream stream;
     private final ObjectManager objectManager;
     private final ObjectStorage objectStorage;
     private final int dataBlockGroupSizeThreshold;
-    private final long minorV1CompactionThreshold;
-    private final boolean majorV1CompactionSkipSmallObject;
+    private final long majorV1MinNormalObjectSize;
     private CompactStreamObjectRequest request;
 
     private StreamObjectCompactor(ObjectManager objectManager,
                                   ObjectStorage objectStorage,
                                   Stream stream,
-                                  long maxStreamObjectSize,
+                                  long groupSizeThreshold,
                                   int dataBlockGroupSizeThreshold,
-                                  long minorV1CompactionThreshold,
-                                  boolean majorV1CompactionSkipSmallObject) {
+                                  long majorV1MinNormalObjectSize) {
         this.objectManager = objectManager;
         this.objectStorage = objectStorage;
         this.stream = stream;
-        this.maxStreamObjectSize = Math.min(maxStreamObjectSize, Writer.MAX_OBJECT_SIZE);
+        this.groupSizeThreshold = Math.min(groupSizeThreshold, Writer.MAX_OBJECT_SIZE);
         String logIdent = "[StreamObjectsCompactionTask streamId=" + stream.streamId() + "] ";
         this.s3ObjectLogger = S3ObjectLogger.logger(logIdent);
         this.dataBlockGroupSizeThreshold = dataBlockGroupSizeThreshold;
-        this.minorV1CompactionThreshold = minorV1CompactionThreshold;
-        this.majorV1CompactionSkipSmallObject = majorV1CompactionSkipSmallObject;
+        this.majorV1MinNormalObjectSize = majorV1MinNormalObjectSize;
     }
 
     public void compact(CompactionType compactionType) {
@@ -141,26 +138,46 @@ public class StreamObjectCompactor {
         }
     }
 
-    protected static Predicate<S3ObjectMetadata> getObjectFilter(CompactionType compactionType, long minMajorV1CompactionSize) {
+    protected static BiPredicate<List<S3ObjectMetadata>, Integer> getObjectFilter(CompactionType compactionType,
+        long majorV1MinNormalObjectSize) {
         boolean includeCompositeObject = MAJOR_V1.equals(compactionType);
 
-        return object -> {
+        return (objects, index) -> {
+            S3ObjectMetadata object = objects.get(index);
             ObjectAttributes.Type objectType = ObjectAttributes.from(object.attributes()).type();
             if (!includeCompositeObject && objectType == Composite) {
                 return false;
             }
 
-            // MAJOR_V1 compaction won't compact small object into composite object.
-            // let MINOR_V1 handle small object merge.
-            // set minMajorV1CompactionSize = 0 to disable this.
+            // Normally leave small normal objects to MINOR_V1 to avoid repeatedly linking them into composite objects.
+            // A small normal object between two continuous composite objects is retained because filtering it would
+            // create an artificial offset gap and permanently prevent the two composite objects from being grouped.
+            // Set majorV1MinNormalObjectSize to zero to disable the size filter.
             if (MAJOR_V1.equals(compactionType) &&
                 objectType == Normal &&
-                object.objectSize() < minMajorV1CompactionSize) {
-                return false;
+                object.objectSize() < majorV1MinNormalObjectSize) {
+                return isMajorV1BridgeObject(objects, index);
             }
 
             return true;
         };
+    }
+
+    /**
+     * Detect a normal object that bridges two composite objects in the offset-ordered, unfiltered object list.
+     */
+    static boolean isMajorV1BridgeObject(List<S3ObjectMetadata> objects, int index) {
+        if (index == 0 || index == objects.size() - 1) {
+            return false;
+        }
+        S3ObjectMetadata previous = objects.get(index - 1);
+        S3ObjectMetadata current = objects.get(index);
+        S3ObjectMetadata next = objects.get(index + 1);
+        return ObjectAttributes.from(previous.attributes()).type() == Composite
+            && ObjectAttributes.from(current.attributes()).type() == Normal
+            && ObjectAttributes.from(next.attributes()).type() == Composite
+            && previous.endOffset() == current.startOffset()
+            && current.endOffset() == next.startOffset();
     }
 
     void compact0(CompactionType compactionType) throws ExecutionException, InterruptedException {
@@ -193,8 +210,9 @@ public class StreamObjectCompactor {
             objectGroups = cleanupV1Groups(livingObjects, startOffset);
         } else {
             objectGroups = group0(livingObjects,
-                getMaxGroupSize(compactionType),
-                getObjectFilter(compactionType, majorV1CompactionSkipSmallObject ? minorV1CompactionThreshold : 0));
+                groupSizeThreshold,
+                compactionType,
+                getObjectFilter(compactionType, majorV1MinNormalObjectSize));
         }
 
         for (List<S3ObjectMetadata> objectGroup : objectGroups) {
@@ -217,21 +235,6 @@ public class StreamObjectCompactor {
             request = requestOpt.get();
             objectManager.compactStreamObject(request).get();
             s3ObjectLogger.info("Compact stream finished, {} {} cost {}ms", compactionType, request, start.elapsedAs(TimeUnit.MILLISECONDS));
-        }
-    }
-
-    long getMaxGroupSize(CompactionType compactionType) {
-        switch (compactionType) {
-            case MINOR:
-                return MINOR_COMPACTION_SIZE_THRESHOLD;
-            case MAJOR:
-                return this.maxStreamObjectSize;
-            case MINOR_V1:
-                return this.minorV1CompactionThreshold;
-            case MAJOR_V1:
-                return this.maxStreamObjectSize;
-            default:
-                throw new IllegalArgumentException("Unsupported compaction type: " + compactionType);
         }
     }
 
@@ -518,8 +521,9 @@ public class StreamObjectCompactor {
     }
 
     static List<List<S3ObjectMetadata>> group0(List<S3ObjectMetadata> objects,
-                                               long maxStreamObjectSize,
-                                               Predicate<S3ObjectMetadata> objectFilter) {
+                                               long groupSizeThreshold,
+                                               CompactionType compactionType,
+                                               BiPredicate<List<S3ObjectMetadata>, Integer> objectFilter) {
         objects = deduplicateObjectsById(objects, "stream object compaction");
         // TODO: switch to include/exclude composite object
         List<List<S3ObjectMetadata>> objectGroups = new LinkedList<>();
@@ -528,8 +532,10 @@ public class StreamObjectCompactor {
         long groupNextOffset = -1L;
         List<S3ObjectMetadata> group = new LinkedList<>();
         int partCount = 0;
-        for (S3ObjectMetadata object : objects) {
-            if (!objectFilter.test(object)) {
+        boolean softGroupSizeThreshold = isSoftGroupSizeThreshold(compactionType);
+        for (int index = 0; index < objects.size(); index++) {
+            S3ObjectMetadata object = objects.get(index);
+            if (!objectFilter.test(objects, index)) {
                 continue;
             }
 
@@ -543,8 +549,11 @@ public class StreamObjectCompactor {
             }
             // group the objects when the object's range is continuous
             if (groupNextOffset != object.startOffset()
-                // the group object size is less than maxStreamObjectSize
-                || (groupSize + object.objectSize() > maxStreamObjectSize && !group.isEmpty())
+                // MINOR_V1 allows crossing the threshold once so small objects can reach the minimum size consumed by
+                // MAJOR_V1. Once a group has reached the threshold, the next object starts a new group.
+                || (!group.isEmpty() && (softGroupSizeThreshold
+                    ? groupSize >= groupSizeThreshold
+                    : groupSize + object.objectSize() > groupSizeThreshold))
                 // object count in a group is larger than MAX_OBJECT_GROUP_COUNT
                 || group.size() >= MAX_OBJECT_GROUP_COUNT
                 || partCount + objectPartCount > Writer.MAX_PART_COUNT
@@ -570,6 +579,11 @@ public class StreamObjectCompactor {
         return objectGroups;
     }
 
+    static boolean isSoftGroupSizeThreshold(CompactionType compactionType) {
+        // The soft threshold is part of MINOR_V1 behavior, not a caller-tunable size policy.
+        return MINOR_V1.equals(compactionType);
+    }
+
     // no operation for now.
     public void close() {
     }
@@ -582,10 +596,9 @@ public class StreamObjectCompactor {
         private ObjectManager objectManager;
         private ObjectStorage objectStorage;
         private Stream stream;
-        private long maxStreamObjectSize;
+        private long groupSizeThreshold;
         private int dataBlockGroupSizeThreshold = DEFAULT_DATA_BLOCK_GROUP_SIZE_THRESHOLD;
-        private long minorV1CompactionThreshold = MINOR_V1_COMPACTION_SIZE_THRESHOLD;
-        private boolean majorV1CompactionSkipSmallObject = false;
+        private long majorV1MinNormalObjectSize;
 
         public Builder objectManager(ObjectManager objectManager) {
             this.objectManager = objectManager;
@@ -603,15 +616,15 @@ public class StreamObjectCompactor {
         }
 
         /**
-         * Set compacted stream object max size.
+         * Set the stream object compaction group size threshold.
          *
-         * @param maxStreamObjectSize compacted stream object max size in bytes.
-         *                            If it is bigger than {@link Writer#MAX_OBJECT_SIZE},
-         *                            it will be set to {@link Writer#MAX_OBJECT_SIZE}.
+         * @param groupSizeThreshold compaction group size threshold in bytes. If it is bigger than
+         *                           {@link Writer#MAX_OBJECT_SIZE}, it will be set to
+         *                           {@link Writer#MAX_OBJECT_SIZE}.
          * @return builder.
          */
-        public Builder maxStreamObjectSize(long maxStreamObjectSize) {
-            this.maxStreamObjectSize = maxStreamObjectSize;
+        public Builder groupSizeThreshold(long groupSizeThreshold) {
+            this.groupSizeThreshold = groupSizeThreshold;
             return this;
         }
 
@@ -620,33 +633,35 @@ public class StreamObjectCompactor {
             return this;
         }
 
-        public Builder minorV1CompactionThreshold(long minorV1CompactionThreshold) {
-            this.minorV1CompactionThreshold = minorV1CompactionThreshold;
-            return this;
-        }
-
-        public Builder majorV1CompactionSkipSmallObject(boolean majorV1CompactionSkipSmallObject) {
-            this.majorV1CompactionSkipSmallObject = majorV1CompactionSkipSmallObject;
+        /**
+         * Set the minimum normal object size included in MAJOR_V1 compaction.
+         *
+         * @param majorV1MinNormalObjectSize minimum normal object size in bytes; zero disables size filtering.
+         * @return builder.
+         */
+        public Builder majorV1MinNormalObjectSize(long majorV1MinNormalObjectSize) {
+            this.majorV1MinNormalObjectSize = majorV1MinNormalObjectSize;
             return this;
         }
 
         public StreamObjectCompactor build() {
-            return new StreamObjectCompactor(objectManager, objectStorage, stream, maxStreamObjectSize, dataBlockGroupSizeThreshold, minorV1CompactionThreshold, majorV1CompactionSkipSmallObject);
+            return new StreamObjectCompactor(objectManager, objectStorage, stream, groupSizeThreshold,
+                dataBlockGroupSizeThreshold, majorV1MinNormalObjectSize);
         }
     }
 
     public enum CompactionType {
         // cleanup: remove the expired objects.
         CLEANUP,
-        // minor: 1. CLEANUP; 2. physical merge the object to a large object with max group size MINOR_COMPACTION_SIZE_THRESHOLD
+        // minor: 1. CLEANUP; 2. physically merge objects with a hard group size threshold
         MINOR,
-        // major: 1. CLEANUP; 2. physical merge the object to a large object with max group size maxStreamObjectSize
+        // major: 1. CLEANUP; 2. physical merge the object to a large object with a hard group size threshold
         MAJOR,
         // cleanup v1: 1. CLEANUP; 2. cleanup the composite object which dirty data exceed MAX_DIRTY_BYTES
         CLEANUP_V1,
-        // minor v1: 1. CLEANUP; 2. physical merge the small object to a large object with max group size MINOR_V1_COMPACTION_SIZE_THRESHOLD
+        // minor v1: 1. CLEANUP; 2. physically merge objects until the group crosses the size threshold
         MINOR_V1,
-        // major v1: 1. CLEANUP; 2. use composite object logic merge the small object to a large object with max group size maxStreamObjectSize
+        // major v1: 1. CLEANUP; 2. use composite object logic with a hard group size threshold
         MAJOR_V1
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StreamClientTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StreamClientTest.java
@@ -31,10 +31,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.CLEANUP_V1;
+import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.MAJOR_V1;
+import static com.automq.stream.s3.compact.StreamObjectCompactor.CompactionType.MINOR_V1;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -102,6 +106,18 @@ public class S3StreamClientTest {
         assertFalse(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(89, hardThreshold));
         assertTrue(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(90, hardThreshold));
         assertTrue(S3StreamClient.shouldRunMajorV1CompactionByObjectCount(100, hardThreshold));
+    }
+
+    /**
+     * Given object-count pressure, when selecting V1 compactions, then pressure appends MAJOR_V1 after the regular task
+     * without duplicating an already scheduled MAJOR_V1.
+     */
+    @Test
+    public void testObjectCountPressureAppendsMajorV1AfterScheduledCompaction() {
+        assertEquals(List.of(MINOR_V1, MAJOR_V1), S3StreamClient.v1CompactionTypes(false, true, true));
+        assertEquals(List.of(CLEANUP_V1, MAJOR_V1), S3StreamClient.v1CompactionTypes(false, false, true));
+        assertEquals(List.of(MAJOR_V1), S3StreamClient.v1CompactionTypes(true, true, true));
+        assertEquals(List.of(MINOR_V1), S3StreamClient.v1CompactionTypes(false, true, false));
     }
 
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/compact/StreamObjectCompactorTest.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -205,7 +205,7 @@ class StreamObjectCompactorTest {
             System.currentTimeMillis(), System.currentTimeMillis(), 100, 2);
 
         List<List<S3ObjectMetadata>> groups = group0(
-            List.of(bigObject, normalObject), Long.MAX_VALUE, obj -> true);
+            List.of(bigObject, normalObject), Long.MAX_VALUE, MAJOR, (__, ___) -> true);
 
         // No group should be empty
         for (List<S3ObjectMetadata> g : groups) {
@@ -231,7 +231,8 @@ class StreamObjectCompactorTest {
             List.of(new StreamOffsetRange(streamId, 10, 20)),
             System.currentTimeMillis(), System.currentTimeMillis(), 100, 3);
 
-        List<List<S3ObjectMetadata>> groups = group0(List.of(first, duplicate, second), Long.MAX_VALUE, obj -> true);
+        List<List<S3ObjectMetadata>> groups = group0(List.of(first, duplicate, second), Long.MAX_VALUE, MAJOR,
+            (__, ___) -> true);
 
         List<S3ObjectMetadata> deduplicated = groups.stream().flatMap(List::stream).collect(Collectors.toList());
         assertEquals(List.of(duplicate, second), deduplicated);
@@ -250,7 +251,7 @@ class StreamObjectCompactorTest {
         when(stream.confirmOffset()).thenReturn(32L);
 
         StreamObjectCompactor task = builder().objectManager(objectManager).objectStorage(objectStorage)
-            .maxStreamObjectSize(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
+            .groupSizeThreshold(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
         task.compact(MAJOR);
 
         ArgumentCaptor<CompactStreamObjectRequest> ac = ArgumentCaptor.forClass(CompactStreamObjectRequest.class);
@@ -348,7 +349,7 @@ class StreamObjectCompactorTest {
         when(stream.confirmOffset()).thenReturn(32L);
 
         StreamObjectCompactor task = builder().objectManager(objectManager).objectStorage(objectStorage)
-            .maxStreamObjectSize(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
+            .groupSizeThreshold(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
         task.compact(MAJOR);
 
         ArgumentCaptor<CompactStreamObjectRequest> ac = ArgumentCaptor.forClass(CompactStreamObjectRequest.class);
@@ -422,12 +423,117 @@ class StreamObjectCompactorTest {
                 System.currentTimeMillis(), System.currentTimeMillis(), 1, 6)
         );
 
-        Predicate<S3ObjectMetadata> objectFilter = __ -> true;
-        List<List<S3ObjectMetadata>> groups = group0(objects, 512, objectFilter);
+        BiPredicate<List<S3ObjectMetadata>, Integer> objectFilter = (__, ___) -> true;
+        List<List<S3ObjectMetadata>> groups = group0(objects, 512, MAJOR, objectFilter);
         assertEquals(3, groups.size());
         assertEquals(List.of(2L), groups.get(0).stream().map(S3ObjectMetadata::objectId).collect(Collectors.toList()));
         assertEquals(List.of(3L, 4L), groups.get(1).stream().map(S3ObjectMetadata::objectId).collect(Collectors.toList()));
         assertEquals(List.of(5L, 6L), groups.get(2).stream().map(S3ObjectMetadata::objectId).collect(Collectors.toList()));
+    }
+
+    /**
+     * Given a MINOR_V1 group below the threshold, when the next object crosses the threshold, then the object remains
+     * in the current group and the following object starts a new group.
+     */
+    @Test
+    public void testGroupMinorV1CrossesSizeThresholdOnce() {
+        List<S3ObjectMetadata> objects = List.of(
+            s3ObjectMetadata(1, 0, 1, 3, Normal),
+            s3ObjectMetadata(2, 1, 2, 2, Normal),
+            s3ObjectMetadata(3, 2, 3, 2, Normal));
+
+        List<List<S3ObjectMetadata>> groups = group0(objects, 4, MINOR_V1, (__, ___) -> true);
+
+        assertEquals(List.of(1L, 2L), groups.get(0).stream().map(S3ObjectMetadata::objectId).toList());
+        assertEquals(List.of(3L), groups.get(1).stream().map(S3ObjectMetadata::objectId).toList());
+    }
+
+    /**
+     * Given a MINOR_V1 group already above the threshold, when another object follows, then the next object starts a
+     * new group.
+     */
+    @Test
+    public void testGroupMinorV1DoesNotExtendOversizedGroup() {
+        List<S3ObjectMetadata> objects = List.of(
+            s3ObjectMetadata(1, 0, 1, 5, Normal),
+            s3ObjectMetadata(2, 1, 2, 2, Normal));
+
+        List<List<S3ObjectMetadata>> groups = group0(objects, 4, MINOR_V1, (__, ___) -> true);
+
+        assertEquals(List.of(1L), groups.get(0).stream().map(S3ObjectMetadata::objectId).toList());
+        assertEquals(List.of(2L), groups.get(1).stream().map(S3ObjectMetadata::objectId).toList());
+    }
+
+    /**
+     * Given a hard-threshold compaction group, when the next object would cross the threshold, then it starts a new
+     * group.
+     */
+    @Test
+    public void testGroupMajorRetainsHardSizeThreshold() {
+        List<S3ObjectMetadata> objects = List.of(
+            s3ObjectMetadata(1, 0, 1, 3, Normal),
+            s3ObjectMetadata(2, 1, 2, 2, Normal));
+
+        List<List<S3ObjectMetadata>> groups = group0(objects, 4, MAJOR, (__, ___) -> true);
+
+        assertEquals(List.of(1L), groups.get(0).stream().map(S3ObjectMetadata::objectId).toList());
+        assertEquals(List.of(2L), groups.get(1).stream().map(S3ObjectMetadata::objectId).toList());
+    }
+
+    /**
+     * Given a small normal object continuously bridging two composite objects, when MAJOR_V1 filters candidates, then
+     * the bridge remains eligible so filtering does not create an artificial offset gap between the composites.
+     */
+    @Test
+    public void testMajorV1IncludesSmallNormalObjectBridgingCompositeObjects() {
+        List<S3ObjectMetadata> objects = List.of(
+            s3ObjectMetadata(1, 0, 1, 10, Composite),
+            s3ObjectMetadata(2, 1, 2, 3, Normal),
+            s3ObjectMetadata(3, 2, 3, 10, Composite));
+
+        List<List<S3ObjectMetadata>> groups = group0(objects, 100, MAJOR_V1, getObjectFilter(MAJOR_V1, 4));
+
+        assertEquals(1, groups.size());
+        assertEquals(List.of(1L, 2L, 3L),
+            groups.get(0).stream().map(S3ObjectMetadata::objectId).toList());
+    }
+
+    /**
+     * Given a small normal object with a real offset gap on either side, when MAJOR_V1 filters candidates, then the
+     * normal object remains excluded because it does not bridge continuous composite objects.
+     */
+    @Test
+    public void testMajorV1SkipsSmallNormalObjectWhenCompositeBridgeHasGap() {
+        List<S3ObjectMetadata> previousGap = List.of(
+            s3ObjectMetadata(1, 0, 1, 10, Composite),
+            s3ObjectMetadata(2, 2, 3, 3, Normal),
+            s3ObjectMetadata(3, 3, 4, 10, Composite));
+        List<S3ObjectMetadata> nextGap = List.of(
+            s3ObjectMetadata(4, 0, 1, 10, Composite),
+            s3ObjectMetadata(5, 1, 2, 3, Normal),
+            s3ObjectMetadata(6, 3, 4, 10, Composite));
+        BiPredicate<List<S3ObjectMetadata>, Integer> objectFilter = getObjectFilter(MAJOR_V1, 4);
+
+        assertFalse(objectFilter.test(previousGap, 1));
+        assertFalse(objectFilter.test(nextGap, 1));
+    }
+
+    /**
+     * Given a small normal object at either edge of the object list, when MAJOR_V1 filters candidates, then it is
+     * excluded without attempting to read a missing neighbor.
+     */
+    @Test
+    public void testMajorV1SkipsSmallNormalObjectAtListEdge() {
+        List<S3ObjectMetadata> normalFirst = List.of(
+            s3ObjectMetadata(1, 0, 1, 3, Normal),
+            s3ObjectMetadata(2, 1, 2, 10, Composite));
+        List<S3ObjectMetadata> normalLast = List.of(
+            s3ObjectMetadata(3, 0, 1, 10, Composite),
+            s3ObjectMetadata(4, 1, 2, 3, Normal));
+        BiPredicate<List<S3ObjectMetadata>, Integer> objectFilter = getObjectFilter(MAJOR_V1, 4);
+
+        assertFalse(objectFilter.test(normalFirst, 0));
+        assertFalse(objectFilter.test(normalLast, 1));
     }
 
     private List<S3ObjectMetadata> prepareS3ObjectMetadata(int normalObjectNumber, int compositeObjectNumber, int smallObjectNumber,
@@ -488,8 +594,10 @@ class StreamObjectCompactorTest {
         int majorCompactionObjectThreshold = 4 * 1024 * 1024;
         List<S3ObjectMetadata> metadataList = prepareS3ObjectMetadata(20, 20, 20,
             majorCompactionObjectThreshold, majorCompactionObjectThreshold, 64);
-        Predicate<S3ObjectMetadata> objectFilter = getObjectFilter(MAJOR_V1, majorCompactionObjectThreshold);
-        List<List<S3ObjectMetadata>> groups = group0(metadataList, 10 * majorCompactionObjectThreshold, objectFilter);
+        BiPredicate<List<S3ObjectMetadata>, Integer> objectFilter = getObjectFilter(MAJOR_V1,
+            majorCompactionObjectThreshold);
+        List<List<S3ObjectMetadata>> groups = group0(metadataList, 10 * majorCompactionObjectThreshold, MAJOR_V1,
+            objectFilter);
 
         // major_v1 compaction small composite object can still be compacted
         assertTrue(groups.stream().flatMap(List::stream)
@@ -505,7 +613,7 @@ class StreamObjectCompactorTest {
         long disableMajorV1CompactionSkipSmallObject = 0;
 
         objectFilter = getObjectFilter(MAJOR_V1, disableMajorV1CompactionSkipSmallObject);
-        groups = group0(metadataList, 10 * majorCompactionObjectThreshold, objectFilter);
+        groups = group0(metadataList, 10 * majorCompactionObjectThreshold, MAJOR_V1, objectFilter);
 
         assertTrue(groups.stream().flatMap(List::stream)
             .anyMatch(meta -> ObjectAttributes.from(meta.attributes()).type().equals(Composite)));
@@ -517,7 +625,7 @@ class StreamObjectCompactorTest {
 
         // MINOR_V1 should skip composite object
         objectFilter = getObjectFilter(MINOR_V1, majorCompactionObjectThreshold);
-        groups = group0(metadataList, 10 * majorCompactionObjectThreshold, objectFilter);
+        groups = group0(metadataList, 10 * majorCompactionObjectThreshold, MINOR_V1, objectFilter);
 
         assertTrue(groups.stream().flatMap(List::stream).filter(meta -> ObjectAttributes.from(meta.attributes()).type().equals(Composite))
             .findAny().isEmpty());
@@ -565,7 +673,7 @@ class StreamObjectCompactorTest {
         when(stream.confirmOffset()).thenReturn(1500L);
 
         StreamObjectCompactor task = builder().objectManager(objectManager).objectStorage(objectStorage)
-            .maxStreamObjectSize(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
+            .groupSizeThreshold(1024 * 1024 * 1024).stream(stream).dataBlockGroupSizeThreshold(1).build();
         task.compact(CLEANUP);
 
         ArgumentCaptor<CompactStreamObjectRequest> ac = ArgumentCaptor.forClass(CompactStreamObjectRequest.class);


### PR DESCRIPTION
## Summary

Improve V1 Stream Object compaction convergence and prevent small Normal Objects from permanently fragmenting Composite Objects.

## Problem

MINOR_V1 previously treated 4 MiB as a hard upper bound, while MAJOR_V1 excluded Normal Objects smaller than 4 MiB. Objects near this boundary could therefore remain too small for MAJOR_V1 and accumulate over time.

A small Normal Object between two continuous Composite Objects could also prevent the Composite Objects from being merged.

Under cluster object-count pressure, MAJOR_V1 took priority over regular V1 compaction, potentially starving MINOR_V1 while small Normal Objects were still excluded.

## Changes

- Allow MINOR_V1 to merge continuous small Normal Objects until the result reaches or crosses the 4 MiB threshold.
- Allow MAJOR_V1 to include a small Normal Object when it continuously bridges two Composite Objects.
- Keep small Normal Objects excluded from regular MAJOR_V1 compaction unless they are required to preserve continuity.
- Run object-count-pressure MAJOR_V1 after the regularly scheduled V1 compaction instead of replacing it.
- Avoid running MAJOR_V1 twice when it is already the regularly scheduled compaction.