### PR TITLE
fix(s3stream): isolate snapshot read options

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogFileRecords.java
@@ -311,7 +311,7 @@ public class ElasticLogFileRecords implements AutoCloseable {
     }
 
     public Iterable<RecordBatch> batchesFrom(final long startOffset) {
-        return batchesFrom(FetchContext.DEFAULT, startOffset);
+        return () -> batchIterator(new FetchContext(), startOffset, Long.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     public Iterable<RecordBatch> batchesFrom(FetchContext fetchContext, final long startOffset) {
@@ -319,7 +319,7 @@ public class ElasticLogFileRecords implements AutoCloseable {
     }
 
     protected RecordBatchIterator<RecordBatch> batchIterator(long startOffset, long maxOffset, int fetchSize) {
-        return batchIterator(FetchContext.DEFAULT, startOffset, maxOffset, fetchSize);
+        return batchIterator(new FetchContext(), startOffset, maxOffset, fetchSize);
     }
 
     protected RecordBatchIterator<RecordBatch> batchIterator(FetchContext fetchContext, long startOffset, long maxOffset, int fetchSize) {
@@ -539,7 +539,7 @@ public class ElasticLogFileRecords implements AutoCloseable {
             }
             Records records;
             try {
-                records = elasticLogFileRecords.readAll0(FetchContext.DEFAULT, startOffset, maxOffset, fetchSize).get();
+                records = elasticLogFileRecords.readAll0(new FetchContext(), startOffset, maxOffset, fetchSize).get();
             } catch (Throwable t) {
                 throw new IOException(FutureUtil.cause(t));
             }

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticStreamSlice.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticStreamSlice.java
@@ -57,7 +57,7 @@ public interface ElasticStreamSlice {
     CompletableFuture<FetchResult> fetch(FetchContext context, long startOffset, long endOffset, int maxBytesHint);
 
     default CompletableFuture<FetchResult> fetch(long startOffset, long endOffset, int maxBytesHint) {
-        return fetch(FetchContext.DEFAULT, startOffset, endOffset, maxBytesHint);
+        return fetch(new FetchContext(), startOffset, endOffset, maxBytesHint);
     }
 
     default CompletableFuture<FetchResult> fetch(long startOffset, long endOffset) {

--- a/s3stream/src/main/java/com/automq/stream/api/ReadOptions.java
+++ b/s3stream/src/main/java/com/automq/stream/api/ReadOptions.java
@@ -24,10 +24,21 @@ import com.automq.stream.api.exceptions.FastReadFailFastException;
 public class ReadOptions {
     public static final ReadOptions DEFAULT = new ReadOptions();
 
-    private boolean fastRead;
-    private boolean pooledBuf;
-    private boolean prioritizedRead;
-    private boolean snapshotRead;
+    private final boolean fastRead;
+    private final boolean pooledBuf;
+    private final boolean prioritizedRead;
+    private final boolean snapshotRead;
+
+    public ReadOptions() {
+        this(false, false, false, false);
+    }
+
+    private ReadOptions(boolean fastRead, boolean pooledBuf, boolean prioritizedRead, boolean snapshotRead) {
+        this.fastRead = fastRead;
+        this.pooledBuf = pooledBuf;
+        this.prioritizedRead = prioritizedRead;
+        this.snapshotRead = snapshotRead;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -49,19 +60,37 @@ public class ReadOptions {
         return snapshotRead;
     }
 
+    /**
+     * Return read options with the requested snapshot-read mode.
+     *
+     * @deprecated Use {@link #withSnapshotRead(boolean)} to make the copy semantics explicit.
+     */
+    @Deprecated
     public ReadOptions snapshotRead(boolean snapshotRead) {
-        this.snapshotRead = snapshotRead;
-        return this;
+        return withSnapshotRead(snapshotRead);
+    }
+
+    /**
+     * Return read options with the requested snapshot-read mode.
+     */
+    public ReadOptions withSnapshotRead(boolean snapshotRead) {
+        if (this.snapshotRead == snapshotRead) {
+            return this;
+        }
+        return new ReadOptions(fastRead, pooledBuf, prioritizedRead, snapshotRead);
     }
 
     public static class Builder {
-        private final ReadOptions options = new ReadOptions();
+        private boolean fastRead;
+        private boolean pooledBuf;
+        private boolean prioritizedRead;
+        private boolean snapshotRead;
 
         /**
          * Read from cache, if the data is not in cache, then fail fast with {@link FastReadFailFastException}.
          */
         public Builder fastRead(boolean fastRead) {
-            options.fastRead = fastRead;
+            this.fastRead = fastRead;
             return this;
         }
 
@@ -69,22 +98,22 @@ public class ReadOptions {
          * Use pooled buffer for reading. The caller is responsible for releasing the buffer.
          */
         public Builder pooledBuf(boolean pooledBuf) {
-            options.pooledBuf = pooledBuf;
+            this.pooledBuf = pooledBuf;
             return this;
         }
 
         public Builder prioritizedRead(boolean prioritizedRead) {
-            options.prioritizedRead = prioritizedRead;
+            this.prioritizedRead = prioritizedRead;
             return this;
         }
 
         public Builder snapshotRead(boolean snapshotRead) {
-            options.snapshotRead = snapshotRead;
+            this.snapshotRead = snapshotRead;
             return this;
         }
 
         public ReadOptions build() {
-            return options;
+            return new ReadOptions(fastRead, pooledBuf, prioritizedRead, snapshotRead);
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/api/ReadOptions.java
+++ b/s3stream/src/main/java/com/automq/stream/api/ReadOptions.java
@@ -44,6 +44,17 @@ public class ReadOptions {
         return new Builder();
     }
 
+    /**
+     * Return a new builder initialized with this instance's values.
+     */
+    public Builder toBuilder() {
+        return new Builder()
+            .fastRead(fastRead)
+            .pooledBuf(pooledBuf)
+            .prioritizedRead(prioritizedRead)
+            .snapshotRead(snapshotRead);
+    }
+
     public boolean fastRead() {
         return fastRead;
     }
@@ -58,26 +69,6 @@ public class ReadOptions {
 
     public boolean snapshotRead() {
         return snapshotRead;
-    }
-
-    /**
-     * Return read options with the requested snapshot-read mode.
-     *
-     * @deprecated Use {@link #withSnapshotRead(boolean)} to make the copy semantics explicit.
-     */
-    @Deprecated
-    public ReadOptions snapshotRead(boolean snapshotRead) {
-        return withSnapshotRead(snapshotRead);
-    }
-
-    /**
-     * Return read options with the requested snapshot-read mode.
-     */
-    public ReadOptions withSnapshotRead(boolean snapshotRead) {
-        if (this.snapshotRead == snapshotRead) {
-            return this;
-        }
-        return new ReadOptions(fastRead, pooledBuf, prioritizedRead, snapshotRead);
     }
 
     public static class Builder {

--- a/s3stream/src/main/java/com/automq/stream/api/Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/api/Stream.java
@@ -87,7 +87,7 @@ public interface Stream {
     CompletableFuture<FetchResult> fetch(FetchContext context, long startOffset, long endOffset, int maxBytesHint);
 
     default CompletableFuture<FetchResult> fetch(long startOffset, long endOffset, int maxBytesHint) {
-        return fetch(FetchContext.DEFAULT, startOffset, endOffset, maxBytesHint);
+        return fetch(new FetchContext(), startOffset, endOffset, maxBytesHint);
     }
 
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -286,7 +286,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
         @SpanAttribute long endOffset,
         @SpanAttribute int maxBytes) {
         if (snapshotRead()) {
-            context.setReadOptions(context.readOptions().withSnapshotRead(true));
+            context.setReadOptions(context.readOptions().toBuilder().snapshotRead(true).build());
         }
         TimerUtil timerUtil = new TimerUtil();
         readLock.lock();

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -25,6 +25,7 @@ import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.api.AppendResult;
 import com.automq.stream.api.FetchResult;
 import com.automq.stream.api.OpenStreamOptions;
+import com.automq.stream.api.ReadOptions;
 import com.automq.stream.api.RecordBatch;
 import com.automq.stream.api.RecordBatchWithContext;
 import com.automq.stream.api.Stream;
@@ -285,13 +286,15 @@ public class S3Stream implements Stream, StreamMetadataListener {
         @SpanAttribute long startOffset,
         @SpanAttribute long endOffset,
         @SpanAttribute int maxBytes) {
-        if (snapshotRead()) {
-            context.readOptions().snapshotRead(true);
-        }
+        FetchContext effectiveContext = new FetchContext(context);
+        ReadOptions effectiveReadOptions = snapshotRead()
+            ? context.readOptions().withSnapshotRead(true)
+            : context.readOptions();
+        effectiveContext.setReadOptions(effectiveReadOptions);
         TimerUtil timerUtil = new TimerUtil();
         readLock.lock();
         try {
-            CompletableFuture<FetchResult> cf = exec(() -> fetch0(context, startOffset, endOffset, maxBytes), LOGGER, "fetch");
+            CompletableFuture<FetchResult> cf = exec(() -> fetch0(effectiveContext, startOffset, endOffset, maxBytes), LOGGER, "fetch");
             CompletableFuture<FetchResult> retCf = cf.thenApply(rs -> {
                 // TODO: move the fast / slow read metrics to kafka module.
                 long totalSize = 0L;
@@ -299,7 +302,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
                     totalSize += recordBatch.rawPayload().remaining();
                 }
                 final long finalSize = totalSize;
-                if (context.readOptions().fastRead()) {
+                if (effectiveContext.readOptions().fastRead()) {
                     NetworkStats.getInstance().fastReadBytesStats(streamId).ifPresent(counter -> counter.inc(finalSize));
                 } else {
                     NetworkStats.getInstance().slowReadBytesStats(streamId).ifPresent(counter -> counter.inc(finalSize));

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -25,7 +25,6 @@ import com.automq.stream.RecyclingByteBufSeqAlloc;
 import com.automq.stream.api.AppendResult;
 import com.automq.stream.api.FetchResult;
 import com.automq.stream.api.OpenStreamOptions;
-import com.automq.stream.api.ReadOptions;
 import com.automq.stream.api.RecordBatch;
 import com.automq.stream.api.RecordBatchWithContext;
 import com.automq.stream.api.Stream;
@@ -286,15 +285,13 @@ public class S3Stream implements Stream, StreamMetadataListener {
         @SpanAttribute long startOffset,
         @SpanAttribute long endOffset,
         @SpanAttribute int maxBytes) {
-        FetchContext effectiveContext = new FetchContext(context);
-        ReadOptions effectiveReadOptions = snapshotRead()
-            ? context.readOptions().withSnapshotRead(true)
-            : context.readOptions();
-        effectiveContext.setReadOptions(effectiveReadOptions);
+        if (snapshotRead()) {
+            context.setReadOptions(context.readOptions().withSnapshotRead(true));
+        }
         TimerUtil timerUtil = new TimerUtil();
         readLock.lock();
         try {
-            CompletableFuture<FetchResult> cf = exec(() -> fetch0(effectiveContext, startOffset, endOffset, maxBytes), LOGGER, "fetch");
+            CompletableFuture<FetchResult> cf = exec(() -> fetch0(context, startOffset, endOffset, maxBytes), LOGGER, "fetch");
             CompletableFuture<FetchResult> retCf = cf.thenApply(rs -> {
                 // TODO: move the fast / slow read metrics to kafka module.
                 long totalSize = 0L;
@@ -302,7 +299,7 @@ public class S3Stream implements Stream, StreamMetadataListener {
                     totalSize += recordBatch.rawPayload().remaining();
                 }
                 final long finalSize = totalSize;
-                if (effectiveContext.readOptions().fastRead()) {
+                if (context.readOptions().fastRead()) {
                     NetworkStats.getInstance().fastReadBytesStats(streamId).ifPresent(counter -> counter.inc(finalSize));
                 } else {
                     NetworkStats.getInstance().slowReadBytesStats(streamId).ifPresent(counter -> counter.inc(finalSize));

--- a/s3stream/src/main/java/com/automq/stream/s3/Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Storage.java
@@ -50,7 +50,7 @@ public interface Storage {
         int maxBytes);
 
     default CompletableFuture<ReadDataBlock> read(long streamId, long startOffset, long endOffset, int maxBytes) {
-        return read(FetchContext.DEFAULT, streamId, startOffset, endOffset, maxBytes);
+        return read(new FetchContext(), streamId, startOffset, endOffset, maxBytes);
     }
 
     /**

--- a/s3stream/src/main/java/com/automq/stream/s3/context/FetchContext.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/context/FetchContext.java
@@ -25,8 +25,10 @@ import com.automq.stream.s3.trace.context.TraceContext;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 
+/**
+ * Context for a single fetch operation.
+ */
 public class FetchContext extends TraceContext {
-    public static final FetchContext DEFAULT = new FetchContext();
     private ReadOptions readOptions = ReadOptions.DEFAULT;
 
     public FetchContext() {

--- a/s3stream/src/test/java/com/automq/stream/api/ReadOptionsTest.java
+++ b/s3stream/src/test/java/com/automq/stream/api/ReadOptionsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.api;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("S3Unit")
+class ReadOptionsTest {
+
+    /**
+     * Given a reused builder, when options are built before and after a builder update, then the first value remains unchanged.
+     */
+    @Test
+    void testBuilderCreatesImmutableValues() {
+        ReadOptions.Builder builder = ReadOptions.builder().fastRead(true);
+
+        ReadOptions first = builder.build();
+        ReadOptions second = builder.pooledBuf(true).build();
+
+        assertTrue(first.fastRead());
+        assertFalse(first.pooledBuf());
+        assertTrue(second.fastRead());
+        assertTrue(second.pooledBuf());
+        assertNotSame(first, second);
+    }
+
+    /**
+     * Given default read options, when snapshot-read mode is derived, then the shared default remains unchanged.
+     */
+    @Test
+    void testWithSnapshotReadCopiesOptions() {
+        ReadOptions original = ReadOptions.builder()
+            .fastRead(true)
+            .pooledBuf(true)
+            .prioritizedRead(true)
+            .build();
+
+        ReadOptions derived = original.withSnapshotRead(true);
+
+        assertFalse(original.snapshotRead());
+        assertFalse(ReadOptions.DEFAULT.snapshotRead());
+        assertTrue(derived.fastRead());
+        assertTrue(derived.pooledBuf());
+        assertTrue(derived.prioritizedRead());
+        assertTrue(derived.snapshotRead());
+        assertNotSame(original, derived);
+        assertSame(derived, derived.withSnapshotRead(true));
+    }
+
+    /**
+     * Given the legacy fluent API, when snapshot-read mode is requested, then it returns a copy instead of mutating.
+     */
+    @SuppressWarnings("deprecation")
+    @Test
+    void testLegacySnapshotReadMethodCopiesOptions() {
+        ReadOptions original = ReadOptions.DEFAULT;
+
+        ReadOptions derived = original.snapshotRead(true);
+
+        assertFalse(original.snapshotRead());
+        assertTrue(derived.snapshotRead());
+        assertNotSame(original, derived);
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/api/ReadOptionsTest.java
+++ b/s3stream/src/test/java/com/automq/stream/api/ReadOptionsTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("S3Unit")
@@ -51,14 +50,14 @@ class ReadOptionsTest {
      * Given default read options, when snapshot-read mode is derived, then the shared default remains unchanged.
      */
     @Test
-    void testWithSnapshotReadCopiesOptions() {
+    void testToBuilderCopiesOptions() {
         ReadOptions original = ReadOptions.builder()
             .fastRead(true)
             .pooledBuf(true)
             .prioritizedRead(true)
             .build();
 
-        ReadOptions derived = original.withSnapshotRead(true);
+        ReadOptions derived = original.toBuilder().snapshotRead(true).build();
 
         assertFalse(original.snapshotRead());
         assertFalse(ReadOptions.DEFAULT.snapshotRead());
@@ -67,21 +66,6 @@ class ReadOptionsTest {
         assertTrue(derived.prioritizedRead());
         assertTrue(derived.snapshotRead());
         assertNotSame(original, derived);
-        assertSame(derived, derived.withSnapshotRead(true));
     }
 
-    /**
-     * Given the legacy fluent API, when snapshot-read mode is requested, then it returns a copy instead of mutating.
-     */
-    @SuppressWarnings("deprecation")
-    @Test
-    void testLegacySnapshotReadMethodCopiesOptions() {
-        ReadOptions original = ReadOptions.DEFAULT;
-
-        ReadOptions derived = original.snapshotRead(true);
-
-        assertFalse(original.snapshotRead());
-        assertTrue(derived.snapshotRead());
-        assertNotSame(original, derived);
-    }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
@@ -88,10 +88,10 @@ public class S3StreamTest {
     }
 
     /**
-     * Given a pending snapshot fetch, when a local fetch uses the shared default context, then their read modes remain isolated.
+     * Given a pending snapshot fetch, when a local fetch starts, then the default overload creates isolated contexts.
      */
     @Test
-    public void testSnapshotFetchDoesNotPolluteDefaultContext() throws Exception {
+    public void testDefaultFetchContextsAreIsolated() throws Exception {
         S3Stream snapshotStream = S3Stream.create(234L, 1L, 100L, 120L, storage, streamManager,
             OpenStreamOptions.builder().readWriteMode(OpenStreamOptions.ReadWriteMode.SNAPSHOT_READ).build());
         CompletableFuture<ReadDataBlock> snapshotRead = new CompletableFuture<>();
@@ -99,8 +99,8 @@ public class S3StreamTest {
         Mockito.when(storage.read(any(), eq(233L), eq(110L), eq(120L), eq(100)))
             .thenReturn(CompletableFuture.completedFuture(newReadDataBlock(110, 115, 110)));
 
-        CompletableFuture<FetchResult> snapshotFetch = snapshotStream.fetch(FetchContext.DEFAULT, 110L, 120L, 100);
-        FetchResult localFetch = stream.fetch(FetchContext.DEFAULT, 110L, 120L, 100).get(1, TimeUnit.SECONDS);
+        CompletableFuture<FetchResult> snapshotFetch = snapshotStream.fetch(110L, 120L, 100);
+        FetchResult localFetch = stream.fetch(110L, 120L, 100).get(1, TimeUnit.SECONDS);
 
         ArgumentCaptor<FetchContext> snapshotContext = ArgumentCaptor.forClass(FetchContext.class);
         ArgumentCaptor<FetchContext> localContext = ArgumentCaptor.forClass(FetchContext.class);
@@ -108,9 +108,8 @@ public class S3StreamTest {
         verify(storage).read(localContext.capture(), eq(233L), eq(110L), eq(120L), eq(100));
         assertFalse(ReadOptions.DEFAULT.snapshotRead());
         assertTrue(snapshotContext.getValue().readOptions().snapshotRead());
-        assertNotSame(FetchContext.DEFAULT, snapshotContext.getValue());
         assertFalse(localContext.getValue().readOptions().snapshotRead());
-        assertNotSame(FetchContext.DEFAULT, localContext.getValue());
+        assertNotSame(snapshotContext.getValue(), localContext.getValue());
 
         snapshotRead.complete(newReadDataBlock(110, 115, 110));
         snapshotFetch.get(1, TimeUnit.SECONDS);

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StreamTest.java
@@ -20,9 +20,12 @@
 package com.automq.stream.s3;
 
 import com.automq.stream.api.FetchResult;
+import com.automq.stream.api.OpenStreamOptions;
+import com.automq.stream.api.ReadOptions;
 import com.automq.stream.api.exceptions.StreamClientException;
 import com.automq.stream.s3.cache.CacheAccessType;
 import com.automq.stream.s3.cache.ReadDataBlock;
+import com.automq.stream.s3.context.FetchContext;
 import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.streams.StreamManager;
 
@@ -30,6 +33,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -38,9 +42,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @Tag("S3Unit")
 public class S3StreamTest {
@@ -77,6 +85,36 @@ public class S3StreamTest {
             }
         }
         Assertions.assertTrue(isException);
+    }
+
+    /**
+     * Given a pending snapshot fetch, when a local fetch uses the shared default context, then their read modes remain isolated.
+     */
+    @Test
+    public void testSnapshotFetchDoesNotPolluteDefaultContext() throws Exception {
+        S3Stream snapshotStream = S3Stream.create(234L, 1L, 100L, 120L, storage, streamManager,
+            OpenStreamOptions.builder().readWriteMode(OpenStreamOptions.ReadWriteMode.SNAPSHOT_READ).build());
+        CompletableFuture<ReadDataBlock> snapshotRead = new CompletableFuture<>();
+        Mockito.when(storage.read(any(), eq(234L), eq(110L), eq(120L), eq(100))).thenReturn(snapshotRead);
+        Mockito.when(storage.read(any(), eq(233L), eq(110L), eq(120L), eq(100)))
+            .thenReturn(CompletableFuture.completedFuture(newReadDataBlock(110, 115, 110)));
+
+        CompletableFuture<FetchResult> snapshotFetch = snapshotStream.fetch(FetchContext.DEFAULT, 110L, 120L, 100);
+        FetchResult localFetch = stream.fetch(FetchContext.DEFAULT, 110L, 120L, 100).get(1, TimeUnit.SECONDS);
+
+        ArgumentCaptor<FetchContext> snapshotContext = ArgumentCaptor.forClass(FetchContext.class);
+        ArgumentCaptor<FetchContext> localContext = ArgumentCaptor.forClass(FetchContext.class);
+        verify(storage).read(snapshotContext.capture(), eq(234L), eq(110L), eq(120L), eq(100));
+        verify(storage).read(localContext.capture(), eq(233L), eq(110L), eq(120L), eq(100));
+        assertFalse(ReadOptions.DEFAULT.snapshotRead());
+        assertTrue(snapshotContext.getValue().readOptions().snapshotRead());
+        assertNotSame(FetchContext.DEFAULT, snapshotContext.getValue());
+        assertFalse(localContext.getValue().readOptions().snapshotRead());
+        assertNotSame(FetchContext.DEFAULT, localContext.getValue());
+
+        snapshotRead.complete(newReadDataBlock(110, 115, 110));
+        snapshotFetch.get(1, TimeUnit.SECONDS);
+        assertEquals(1, localFetch.recordBatchList().size());
     }
 
     @Test


### PR DESCRIPTION
Backport #3480 to `1.7`.

## Summary

- make `ReadOptions` immutable and derive modified values through `toBuilder()`
- remove the mutable-looking `ReadOptions.snapshotRead(boolean)` API
- remove `FetchContext.DEFAULT` and scope fetch contexts per operation or iterator
- preserve snapshot/local read isolation across pending and concurrent fetches
- include the main-branch regression tests for immutable options and context isolation

## 1.7 adjustment

- preserve the branch's static `LOGGER` / `logIdent` logging form in `S3Stream`; fetch-context behavior is identical to #3480

## Compatibility and allocation

Removing `ReadOptions.snapshotRead(boolean)` and `FetchContext.DEFAULT` is a source and binary compatibility break for external callers that reference them. All `1.7` in-repository callers are migrated.

Default fetch/read calls allocate one context per operation. `ElasticLogFileRecords` allocates one context per iterator, not per record batch.

## Verification

- `./gradlew :s3stream:test --tests com.automq.stream.api.ReadOptionsTest --tests com.automq.stream.s3.S3StreamTest`
- `./gradlew :core:S3UnitTest --tests kafka.log.streamaspect.ElasticLogFileRecordsTest`
- `./gradlew --build-cache metadata:S3UnitTest core:S3UnitTest s3stream:test`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`
- existing ZeroZone DevKit evidence from #3479 was reused; the costly E2E was not rerun

Related issue: #3479
