### PR TITLE
fix(s3stream): handle WAL prepare failures

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -773,6 +773,8 @@ public class S3Storage implements Storage {
             }
         }, backgroundExecutor).exceptionally(ex -> {
             LOGGER.error("Unexpected exception when prepare commit stream set object", ex);
+            context.cf.completeExceptionally(ex);
+            storageFailureHandler.handle(ex);
             return null;
         });
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -773,7 +773,13 @@ public class S3Storage implements Storage {
             }
         }, backgroundExecutor).exceptionally(ex -> {
             LOGGER.error("Unexpected exception when prepare commit stream set object", ex);
-            context.cf.completeExceptionally(ex);
+            // poll out current task so the prepare pipeline isn't wedged, and fail the remaining queued tasks.
+            DeltaWALUploadTaskContext peek = walPrepareQueue.poll();
+            Objects.requireNonNull(peek).cf.completeExceptionally(ex);
+            for (DeltaWALUploadTaskContext remaining : walPrepareQueue) {
+                remaining.cf.completeExceptionally(ex);
+            }
+            walPrepareQueue.clear();
             storageFailureHandler.handle(ex);
             return null;
         });

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -58,6 +58,7 @@ import static com.automq.stream.s3.TestUtils.random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -183,7 +184,7 @@ public class S3StorageTest {
     @Test
     public void testUploadWALObject_prepareFailureTriggersStorageFailover() {
         RuntimeException prepareFailure = new RuntimeException("prepare failure");
-        Mockito.when(objectManager.prepareObject(any(), anyLong()))
+        Mockito.when(objectManager.prepareObject(anyInt(), anyLong()))
             .thenReturn(CompletableFuture.failedFuture(prepareFailure));
 
         LogCache.LogCacheBlock logCacheBlock = new LogCache.LogCacheBlock(1024);

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.automq.stream.s3.TestUtils.random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,6 +74,7 @@ public class S3StorageTest {
     ObjectManager objectManager;
     WriteAheadLog wal;
     ObjectStorage objectStorage;
+    StorageFailureHandler storageFailureHandler;
     S3Storage storage;
     Config config;
 
@@ -88,9 +90,10 @@ public class S3StorageTest {
         streamManager = mock(StreamManager.class);
         wal = spy(new MemoryWriteAheadLog());
         objectStorage = new MemoryObjectStorage();
+        storageFailureHandler = mock(StorageFailureHandler.class);
         storage = new S3Storage(config, wal,
             streamManager, objectManager, new StreamReaders(config.blockCacheSize(), objectManager, objectStorage,
-            new DefaultObjectReaderFactory(objectStorage)), objectStorage, mock(StorageFailureHandler.class));
+            new DefaultObjectReaderFactory(objectStorage)), objectStorage, storageFailureHandler);
     }
 
     @Test
@@ -172,6 +175,25 @@ public class S3StorageTest {
         commitCfList.get(1).complete(new CommitStreamSetObjectResponse());
         cf1.get(1, TimeUnit.SECONDS);
         cf2.get(1, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Given object preparation fails, when a WAL upload starts, then the upload future fails and storage failover runs.
+     */
+    @Test
+    public void testUploadWALObject_prepareFailureTriggersStorageFailover() {
+        RuntimeException prepareFailure = new RuntimeException("prepare failure");
+        Mockito.when(objectManager.prepareObject(any(), anyLong()))
+            .thenReturn(CompletableFuture.failedFuture(prepareFailure));
+
+        LogCache.LogCacheBlock logCacheBlock = new LogCache.LogCacheBlock(1024);
+        logCacheBlock.put(newRecord(233L, 10L));
+        logCacheBlock.lastRecordOffset(DefaultRecordOffset.of(0, 10L, 0));
+
+        CompletableFuture<Void> uploadCf = storage.uploadDeltaWAL(logCacheBlock);
+
+        assertThrows(ExecutionException.class, () -> uploadCf.get(1, TimeUnit.SECONDS));
+        verify(storageFailureHandler, timeout(1000)).handle(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- On WAL object prepare failure, fail the upload future and invoke the storage failure handler instead of silently swallowing the exception.
- Fix a resulting deadlock: the failed context was never polled off `walPrepareQueue`, so the prepare pipeline stayed permanently non-empty and never accepted new prepare cycles once a failure occurred (only masked when the handler halts the JVM; `ForceCloseStorageFailureHandler` just sets a flag and doesn't drain the queue).
- Fix a test bug: `prepareObject(int count, long ttl)` was stubbed with `any()` against its primitive `int` param, which corrupted Mockito's matcher stack and broke an unrelated test (`testAppend`) in the same class. Switched to `anyInt()`.

## Test plan
- [x] `./gradlew :s3stream:test --tests "com.automq.stream.s3.S3StorageTest"` — all 4 tests pass
- [x] Verified `prepareDeltaWALUpload`'s exceptional path now drains `walPrepareQueue` and fails all queued contexts