### PR TITLE
fix(clients): replace deprecated X509Certificate DN accessors with X500Principal

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
@@ -321,8 +321,9 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
         }
 
         @Override
+        @SuppressWarnings("deprecation") // must override the deprecated X509Certificate#getIssuerDN
         public Principal getIssuerDN() {
-            return this.origCertificate.getIssuerDN();
+            return this.origCertificate.getIssuerX500Principal();
         }
 
         @Override
@@ -371,8 +372,9 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
         }
 
         @Override
+        @SuppressWarnings("deprecation") // must override the deprecated X509Certificate#getSubjectDN
         public Principal getSubjectDN() {
-            return this.origCertificate.getSubjectDN();
+            return this.origCertificate.getSubjectX500Principal();
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
@@ -122,7 +122,7 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
                     wrappedCert.hasUnsupportedCriticalExtension());
             // We have just generated a valid test certificate, it should still be valid now
             assertEquals(cert.getBasicConstraints(), wrappedCert.getBasicConstraints());
-            assertEquals(cert.getIssuerDN(), wrappedCert.getIssuerDN());
+            assertEquals(cert.getIssuerX500Principal(), wrappedCert.getIssuerDN());
             assertEquals(cert.getIssuerUniqueID(), wrappedCert.getIssuerUniqueID());
             assertEquals(cert.getKeyUsage(), wrappedCert.getKeyUsage());
             assertEquals(cert.getNotAfter(), wrappedCert.getNotAfter());
@@ -132,7 +132,7 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
             assertEquals(cert.getSigAlgOID(), wrappedCert.getSigAlgOID());
             assertArrayEquals(cert.getSigAlgParams(), wrappedCert.getSigAlgParams());
             assertArrayEquals(cert.getSignature(), wrappedCert.getSignature());
-            assertEquals(cert.getSubjectDN(), wrappedCert.getSubjectDN());
+            assertEquals(cert.getSubjectX500Principal(), wrappedCert.getSubjectDN());
             assertEquals(cert.getSubjectUniqueID(), wrappedCert.getSubjectUniqueID());
             assertArrayEquals(cert.getTBSCertificate(), wrappedCert.getTBSCertificate());
             assertEquals(cert.getVersion(), wrappedCert.getVersion());


### PR DESCRIPTION
## Summary
- `CommonNameLoggingTrustManagerFactoryWrapper` calls `X509Certificate#getSubjectDN()`/`getIssuerDN()`, deprecated since JDK 16 (JDK-4959744), producing build warnings.
- The wrapper must still *override* `getSubjectDN()`/`getIssuerDN()` since they're abstract on `X509Certificate`, but the bodies now delegate to `getSubjectX500Principal()`/`getIssuerX500Principal()`, which return a well-defined `X500Principal` with RFC 2253 canonical output instead of an implementation-dependent `Principal`.
- Added `@SuppressWarnings("deprecation")` on the two overrides since the override itself is unavoidable but the internal deprecated call is now gone.
- Updated `CommonNameLoggingTrustManagerFactoryWrapperTest` to compare against `getSubjectX500Principal()`/`getIssuerX500Principal()` on both sides — the old assertions compared the deprecated `Principal` (e.g. `X500Name`) against the new `X500Principal`, which aren't `.equals()` to each other despite representing the same DN.

Fixes #3282.

## Test plan
- [x] `./gradlew :clients:compileJava :clients:compileTestJava` — zero deprecation warnings for `getSubjectDN`/`getIssuerDN` (previously 4)
- [x] `./gradlew :clients:test --tests "org.apache.kafka.common.security.ssl.CommonNameLoggingTrustManagerFactoryWrapperTest"` — all 11 tests pass