### PR TITLE
fix(s3stream): distinguish capacity vs TTL-expiry evictions in block cache warning

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
@@ -82,7 +82,7 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
      */
     public void completeExceptionally(Throwable ex) {
         loadCf.completeExceptionally(ex);
-        free0();
+        free0(EvictReason.NONE);
     }
 
     public CompletableFuture<DataBlock> dataFuture() {
@@ -90,15 +90,19 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
     }
 
     public void free() {
-        release();
-        free0();
+        free(EvictReason.NONE);
     }
 
-    private void free0() {
+    public void free(EvictReason evictReason) {
+        release();
+        free0(evictReason);
+    }
+
+    private void free0(EvictReason evictReason) {
         freeCf.complete(this);
         for (FreeListener listener : freeListeners) {
             try {
-                listener.onFree(this);
+                listener.onFree(this, evictReason);
             } catch (Throwable e) {
                 LOGGER.error("invoke onFree fail", e);
             }
@@ -112,7 +116,7 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
 
     public FreeListenerHandle registerFreeListener(FreeListener listener) {
         if (freeCf.isDone()) {
-            listener.onFree(this);
+            listener.onFree(this, EvictReason.NONE);
             return () -> {
             };
         } else {
@@ -207,11 +211,24 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
     }
 
     public interface FreeListener {
-        void onFree(DataBlock dataBlock);
+        void onFree(DataBlock dataBlock, EvictReason evictReason);
     }
 
     public interface FreeListenerHandle {
         void close();
+    }
+
+    /**
+     * Why a cached {@link DataBlock} was freed, so listeners can tell a benign read-completion
+     * free apart from an eviction caused by cache pressure vs. one caused by TTL expiration.
+     */
+    public enum EvictReason {
+        /** Freed because it was fully read, or the load failed; not an eviction. */
+        NONE,
+        /** Evicted because the cache is full and needs space. */
+        CAPACITY,
+        /** Evicted because the block's TTL elapsed before it was fully read. */
+        EXPIRED
     }
 
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlock.java
@@ -57,6 +57,9 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
 
     private final CompletableFuture<DataBlock> freeCf = new CompletableFuture<>();
     final List<FreeListener> freeListeners = new ArrayList<>();
+    // Reason recorded when this block is freed, so listeners registered after the fact (see
+    // registerFreeListener) can be told the real cause instead of defaulting to NONE.
+    private volatile EvictReason evictReason = EvictReason.NONE;
 
     private final Time time;
 
@@ -99,6 +102,7 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
     }
 
     private void free0(EvictReason evictReason) {
+        this.evictReason = evictReason;
         freeCf.complete(this);
         for (FreeListener listener : freeListeners) {
             try {
@@ -116,7 +120,10 @@ import static com.automq.stream.s3.ByteBufAlloc.BLOCK_CACHE;
 
     public FreeListenerHandle registerFreeListener(FreeListener listener) {
         if (freeCf.isDone()) {
-            listener.onFree(this, EvictReason.NONE);
+            // Block was already freed (e.g. tryEvictExpired() ran before this listener got registered).
+            // Replay the actual eviction reason instead of NONE, otherwise a late registrant like
+            // StreamReader would misclassify an EXPIRED eviction as a capacity one.
+            listener.onFree(this, evictReason);
             return () -> {
             };
         } else {

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlockCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/DataBlockCache.java
@@ -253,12 +253,13 @@ public class DataBlockCache {
                 }
                 DataBlockGroupKey key = entry.getKey();
                 DataBlock dataBlock = entry.getValue();
-                if (!dataBlock.isExpired(expiredTimestamp) && !sizeLimiter.requiredRelease()) {
+                boolean expired = dataBlock.isExpired(expiredTimestamp);
+                if (!expired && !sizeLimiter.requiredRelease()) {
                     break;
                 }
                 lru.pop();
                 if (blocks.remove(key, dataBlock)) {
-                    dataBlock.free();
+                    dataBlock.free(expired ? DataBlock.EvictReason.EXPIRED : DataBlock.EvictReason.CAPACITY);
                     BlockCacheMetrics.BLOCK_EVICT_THROUGHPUT.add(dataBlock.dataBlockIndex().size());
                 } else {
                     LOGGER.error("[BUG] duplicated free data block {}", dataBlock);

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
@@ -491,15 +491,22 @@ import static com.automq.stream.utils.FutureUtil.exec;
         return nextReadOffset;
     }
 
-    private void handleBlockFree(Block block) {
+    private void handleBlockFree(Block block, DataBlock.EvictReason evictReason) {
         if (closed) {
             return;
         }
         Block blockInMap = blocksMap.get(block.index.startOffset());
         if (block == blockInMap) {
-            // The unread block is evicted; It means the cache is full, we need to reset the readahead.
+            // The unread block is evicted; we need to reset the readahead.
             readahead.reset();
-            READAHEAD_RESET_LOG_SUPPRESSOR.warn("The unread block is evicted, please increase the block cache size");
+            if (evictReason == DataBlock.EvictReason.EXPIRED) {
+                // The block sat unread past its TTL; usually the consumer is reading slower than the readahead pace,
+                // not that the cache is undersized.
+                READAHEAD_RESET_LOG_SUPPRESSOR.warn("The unread block is evicted because it exceeded the cache TTL, "
+                    + "the consumer may be reading too slowly");
+            } else {
+                READAHEAD_RESET_LOG_SUPPRESSOR.warn("The unread block is evicted, please increase the block cache size");
+            }
         }
     }
 
@@ -595,7 +602,7 @@ import static com.automq.stream.utils.FutureUtil.exec;
                     }
                     data = newData;
                     newData.markUnread();
-                    freeListenerHandle = data.registerFreeListener(b -> handleBlockFree(this));
+                    freeListenerHandle = data.registerFreeListener((b, evictReason) -> handleBlockFree(this, evictReason));
                 }
             }).exceptionally(ex -> {
                 exception = ex;

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/DataBlockTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/DataBlockTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.cache.blockcache;
+
+import com.automq.stream.s3.DataBlockIndex;
+import com.automq.stream.utils.Time;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@Tag("S3Unit")
+public class DataBlockTest {
+
+    /**
+     * Regression test for the race in registerFreeListener: a block can be freed with EXPIRED
+     * before a listener (e.g. StreamReader) has a chance to register, e.g. when
+     * DataBlockCache.Cache#getBlock0 calls tryEvictExpired() right after completing the load
+     * future but before the caller registers its free listener. The already-freed branch used to
+     * hardcode EvictReason.NONE, which made handleBlockFree fall back to the misleading capacity
+     * warning even though the real cause was TTL expiry.
+     */
+    @Test
+    public void testRegisterFreeListenerAfterFree_repliesActualEvictReason() {
+        DataBlock block = new DataBlock(1L, new DataBlockIndex(1L, 0L, 100, 1, 0L, 100),
+            mock(ReadStatusChangeListener.class), Time.SYSTEM);
+
+        // Simulate the block already being evicted for TTL expiry before any listener registers.
+        block.free(DataBlock.EvictReason.EXPIRED);
+
+        AtomicReference<DataBlock.EvictReason> observed = new AtomicReference<>();
+        block.registerFreeListener((db, evictReason) -> observed.set(evictReason));
+
+        assertEquals(DataBlock.EvictReason.EXPIRED, observed.get());
+    }
+
+    @Test
+    public void testRegisterFreeListenerAfterFree_capacityReasonPreserved() {
+        DataBlock block = new DataBlock(1L, new DataBlockIndex(1L, 0L, 100, 1, 0L, 100),
+            mock(ReadStatusChangeListener.class), Time.SYSTEM);
+
+        block.free(DataBlock.EvictReason.CAPACITY);
+
+        AtomicReference<DataBlock.EvictReason> observed = new AtomicReference<>();
+        block.registerFreeListener((db, evictReason) -> observed.set(evictReason));
+
+        assertEquals(DataBlock.EvictReason.CAPACITY, observed.get());
+    }
+}


### PR DESCRIPTION
## Summary
- `StreamReader` logged `"The unread block is evicted, please increase the block cache size"` for **every** unread-block eviction, regardless of cause.
- `DataBlockCache#evict0()` evicts a block for two different reasons: the cache is full (`sizeLimiter.requiredRelease()`) or the block simply sat past its TTL (`DATA_TTL`, 1 min) because the consumer is reading slower than the readahead pace. The old log message conflated both, so users chasing the warning kept bumping `s3.block.cache.size` (as reported in #2662) without effect, because the real cause was consumer lag.
- `DataBlock#free()` now takes a `DataBlock.EvictReason` (`NONE` / `CAPACITY` / `EXPIRED`). `evict0()` derives the reason from `isExpired(expiredTimestamp)` before freeing. Normal read-completion frees (`DataBlockCache#markRead`) still pass `NONE`.
- `StreamReader#handleBlockFree` now logs a distinct message for TTL-expiry evictions ("...evicted because it exceeded the cache TTL, the consumer may be reading too slowly") instead of always pointing at cache size.

Fixes #2662 (maintainer confirmed this is the right fix location: https://github.com/AutoMQ/automq/issues/2662#issuecomment-3072671443).

## Test plan
- [x] `./gradlew :s3stream:compileJava :s3stream:compileTestJava` — clean
- [x] `./gradlew :s3stream:test --tests "com.automq.stream.s3.cache.blockcache.DataBlockCacheTest" --tests "com.automq.stream.s3.cache.blockcache.StreamReaderTest"` — all pass