### PR TITLE
chore: modernize Python test config and setup

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -295,12 +295,12 @@ The system tests have unit tests! The various services in the python `kafkatest`
 for the system service classes.
 
 Where are the unit tests?
-* The kafkatest unit tests are located under kafka/tests/unit
+* The kafkatest unit tests are located under tests/unit
 
 How do I run the unit tests?
 ```bash
-$ cd kafka/tests # The base system test directory
-$ python3 setup.py test
+$ cd tests # The base system test directory
+$ pytest
 ```
 
 How can I add a unit test?

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -20,11 +20,13 @@
 #
 # To ease possible confusion, 'check' instead of 'test' as a prefix for unit tests, since
 # many system test files, classes, and methods have 'test' somewhere in the name
-[pytest]
+[tool:pytest]
 testpaths=unit
 python_files=check_*.py
 python_classes=Check
 python_functions=check_*
+filterwarnings =
+    ignore::DeprecationWarning
 
 # don't search inside any resources directory for unit tests
 norecursedirs = resources

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,31 +16,10 @@
 import re
 import sys
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 version = ''
 with open('kafkatest/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
-
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        print(self.pytest_args)
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 # Note: when changing the version of ducktape, also revise tests/docker/Dockerfile
 setup(name="kafkatest",
@@ -52,7 +31,5 @@ setup(name="kafkatest",
       packages=find_packages(),
       include_package_data=True,
       install_requires=["ducktape<0.9", "requests==2.31.0"],
-      tests_require=["pytest", "mock"],
-      cmdclass={'test': PyTest},
       zip_safe=False
       )

--- a/tests/unit/setup.cfg
+++ b/tests/unit/setup.cfg
@@ -17,7 +17,9 @@
 #
 # To ease possible confusion, prefix muckrake *unit* tests with 'check' instead of 'test', since
 # many muckrake files, classes, and methods have 'test' somewhere in the name
-[pytest]
+[tool:pytest]
 python_files=check_*.py
 python_classes=Check
 python_functions=check_*
+filterwarnings =
+    ignore::DeprecationWarning


### PR DESCRIPTION
### Description
This PR resolves configuration issues and runtime errors encountered when executing Python-based integration/unit tests on newer Python (3.12/3.13) and Setuptools (>= 72) environments.
### Changes
1. **Migrate `pytest` Config**: Renamed the deprecated `[pytest]` section header to `[tool:pytest]` in both `tests/setup.cfg` and `tests/unit/setup.cfg` to align with modern `pytest` standards.
2. **Ignore Legacy Warnings**: Added `filterwarnings = ignore::DeprecationWarning` to ignore `distutils.version.LooseVersion` deprecation warnings caused by non-PEP440 versions (e.g., `3.9.0-SNAPSHOT`).
3. **Remove Deprecated Test Command**: Cleaned up the custom `PyTest` wrapper class in `tests/setup.py` that inherited from the deprecated/removed `setuptools.command.test` class (avoiding runtime `RuntimeError` on Setuptools 72+).
4. **Update Documentation**: Updated the `tests/README.md` to guide developers to run `pytest` directly and corrected folder reference paths (`kafka/tests/` -> `tests/`).
### Verification
- Checked unit tests locally: `pytest` executed inside the `tests/` directory with 6/6 tests passing successfully.
- Ran project checkstyle/formatting/licensing checks: `./gradlew rat checkstyleMain checkstyleTest spotlessJavaCheck` completed successfully.
