### PR TITLE
fix(cli): negotiate broker API versions for backward compatibility

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/util/CLIUtils.java
+++ b/automq-shell/src/main/java/com/automq/shell/util/CLIUtils.java
@@ -72,7 +72,7 @@ public class CLIUtils {
             config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
             config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
             time,
-            false,
+            true,
             new ApiVersions(),
             logContext,
             MetadataRecoveryStrategy.NONE

--- a/chart/bitnami/demo-values.yaml
+++ b/chart/bitnami/demo-values.yaml
@@ -4,7 +4,7 @@ global:
 image:
   registry: automqinc
   repository: automq
-  tag: 1.7.2-bitnami
+  tag: 1.7.3-rc0-bitnami
   pullPolicy: Always
 extraEnvVars:
   - name: AWS_ACCESS_KEY_ID

--- a/docker/docker-compose-cluster.yaml
+++ b/docker/docker-compose-cluster.yaml
@@ -68,7 +68,7 @@ services:
   # Three nodes for AutoMQ cluster
   server1:
     container_name: "automq-server1"
-    image: automqinc/automq:1.7.2
+    image: automqinc/automq:1.7.3-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env
@@ -94,7 +94,7 @@ services:
 
   server2:
     container_name: "automq-server2"
-    image: automqinc/automq:1.7.2
+    image: automqinc/automq:1.7.3-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env
@@ -120,7 +120,7 @@ services:
 
   server3:
     container_name: "automq-server3"
-    image: automqinc/automq:1.7.2
+    image: automqinc/automq:1.7.3-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
   # Single node with combined controller and broker roles
   server1:
     container_name: "automq-single-server"
-    image: automqinc/automq:1.7.2
+    image: automqinc/automq:1.7.3-rc0
     stop_grace_period: 1m
     environment:
       - KAFKA_S3_ACCESS_KEY=minioadmin

--- a/docker/table_topic/docker-compose.yml
+++ b/docker/table_topic/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       "
   automq:
     container_name: "automq"
-    image: automqinc/automq:1.7.2
+    image: automqinc/automq:1.7.3-rc0
     stop_grace_period: 1m
     networks:
       iceberg_net:


### PR DESCRIPTION
## Summary
- enable broker API version discovery in `CLIUtils`
- negotiate request versions before sending AutoMQ-specific requests
- allow the 1.7 client to downgrade `GET_KVS` to v0 for older data planes
- prepare release metadata for `1.7.3-rc0` in the standard Docker Compose and Bitnami examples

## Versioning
- keep Kafka source/build version at `3.9.1`
- keep workflow `KAFKA_VERSION` at `3.9.1`; release workflows derive the AutoMQ version from the tag or `-Pversion`

## Tests
- `./gradlew :automq-shell:compileJava`
- `./gradlew :clients:test --tests org.apache.kafka.clients.NetworkClientTest`
- `yq` YAML parsing for all four release metadata files