### PR TITLE
docs: define PR description conventions

### DIFF
--- a/.agents/pull-request-description.md
+++ b/.agents/pull-request-description.md
@@ -1,0 +1,51 @@
+---
+last_updated: 2026-08-07
+---
+
+# Pull Request Description Conventions
+
+The PR title and description form the squashed commit message. Write them in
+English as durable engineering history for future readers, without relying on
+the review conversation. Put transient information such as reviewer pings,
+current CI status, and coordination notes in PR comments.
+
+Use the following template for non-trivial changes. Subsections are optional;
+add them only when they improve clarity. Small or mechanical changes may use a
+shorter form. Do not leave the guidance comments in the final description.
+
+```markdown
+## Why
+
+<!--
+Describe the background and current behavior, then identify the concrete problem
+and requirement or goal. Include material evidence, constraints, or non-goals
+when they clarify the scope.
+-->
+
+## What
+
+<!--
+Describe the chosen solution and resulting system behavior at a high level.
+State the scope and any important behavior that remains unchanged. Leave
+implementation mechanics to How.
+-->
+
+## How
+
+<!--
+Describe the abstract control flow, data flow, state transitions, and ownership;
+do not translate the diff file by file. When relevant, cover correctness
+invariants and fallback behavior, compatibility and version gating,
+configuration changes, observability changes, and rollout or rollback
+considerations. Add subsections only when they improve clarity.
+-->
+
+## Reviewer notes
+
+<!--
+Give a suggested reading order through the core flow using stable file paths or
+class names. Explain the responsibility, contract, or invariant implemented by
+each group, and call out cross-cutting changes that need special attention.
+Avoid line numbers and temporary review status.
+-->
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+---
+last_updated: 2026-08-07
+---
+
 # AutoMQ Agent Instructions
 
 This repository is the open-source AutoMQ Kafka fork.
@@ -10,6 +14,8 @@ progressively loaded rules live in `.agents/`.
 - Before changing production code, read `.agents/coding-conventions.md`.
 - Before adding or changing tests, read `.agents/testing.md`.
 - Before reviewing or handing off a PR, read `.agents/review.md`.
+- Before preparing or updating a PR description, read
+  `.agents/pull-request-description.md`.
 
 ## Core Rules
 
@@ -21,6 +27,8 @@ progressively loaded rules live in `.agents/`.
   completion gates, SpotBugs, E2E suite registration, and suppression rules.
 - Follow `.agents/review.md` for PR review range, repository rule checks, and
   CI failure handling.
+- Follow `.agents/pull-request-description.md` when writing a PR description
+  that will become the squash commit body.
 
 ## Verification
 


### PR DESCRIPTION
## Why

AGENTS.md routes agents to the repository coding, testing, and review rules, but it does not define how to write a PR description that will become the squash commit body.

Without a shared structure, descriptions may omit the reason for a change, mix the solution contract with implementation details, or leave reviewers without a useful reading path.

## What

Add a focused PR description convention for non-trivial changes:

- Why explains the background, current behavior, problem, and goal.
- What explains the chosen solution and resulting behavior at a high level.
- How explains the abstract flow, correctness, compatibility, and relevant operational changes.
- Reviewer notes guide reviewers through the files and classes in core-flow order.

Subsections remain optional, and small or mechanical changes may use a shorter form.

## How

AGENTS.md loads the new .agents/pull-request-description.md guidance when an agent prepares or updates a PR description.

The guidance provides a concise HTML-comment template, keeps transient review coordination in PR comments, and asks authors to remove guidance comments from the final description. It does not change runtime code or PULL_REQUEST_TEMPLATE.md.

## Reviewer notes

1. Review .agents/pull-request-description.md for the writing contract and template.
2. Review AGENTS.md for the context-loading and core-rule references.
