### PR TITLE
fix: await append callbacks before closing elastic log

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLog.scala
@@ -120,7 +120,7 @@ class ElasticLog(val metaStream: MetaStream,
 
     private val appendAckQueue = new LinkedBlockingQueue[Long]()
     val appendAckThread = APPEND_CALLBACK_EXECUTOR(math.abs(logIdent.hashCode % APPEND_CALLBACK_EXECUTOR.length))
-    @volatile private[log] var lastAppendAckFuture: Future[?] = CompletableFuture.completedFuture(null)
+    @volatile private[log] var lastAppendAckFuture: CompletableFuture[Void] = CompletableFuture.completedFuture(null)
 
     private val readAsyncThread = READ_ASYNC_EXECUTOR(math.abs(logIdent.hashCode % READ_ASYNC_EXECUTOR.length))
     var logStartOffset = _initStartOffset
@@ -238,7 +238,7 @@ class ElasticLog(val metaStream: MetaStream,
                 recordLogWriteFailedIfUnexpected(FutureUtil.cause(throwable))
             }
         })
-        cf.thenAccept(_ => {
+        lastAppendAckFuture = cf.thenCompose[Void](_ => {
             APPEND_CALLBACK_TIME_HIST.update(System.nanoTime() - startTimestamp)
             // run callback async by executors to avoid deadlock when asyncLogFlush is called by append thread.
             // append callback executor is single thread executor, so the callback will be executed in order.
@@ -257,7 +257,7 @@ class ElasticLog(val metaStream: MetaStream,
             }
             if (notify) {
                 appendAckQueue.offer(endOffset)
-                lastAppendAckFuture = appendAckThread.submit(new Runnable {
+                CompletableFuture.runAsync(new Runnable {
                     override def run(): Unit = {
                         try {
                             appendCallback(startNanos)
@@ -266,7 +266,9 @@ class ElasticLog(val metaStream: MetaStream,
                                 error(s"append callback error", e)
                         }
                     }
-                })
+                }, appendAckThread)
+            } else {
+                CompletableFuture.completedFuture(null)
             }
         })
     }

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticUnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticUnifiedLog.scala
@@ -218,6 +218,8 @@ class ElasticUnifiedLog(_logStartOffset: Long,
             }
             elasticLog.close()
         }
+        // Await the callback outside the UnifiedLog lock because it may advance the high watermark under the same lock.
+        elasticLog.lastAppendAckFuture.handle[Void]((_, _) => null).join()
         elasticLog.isMemoryMappedBufferClosed = true
         // Since https://github.com/AutoMQ/automq/pull/2837 , AutoMQ won't create the partition directory when the partition opens
         // The deletion here aims to clean the old directory.

--- a/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
+++ b/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
@@ -20,8 +20,8 @@
 package kafka.log.streamaspect
 
 import com.automq.stream.DefaultRecordBatch
-import com.automq.stream.api.{CreateStreamOptions, FetchResult, OpenStreamOptions, Stream, StreamClient}
-import com.automq.stream.s3.context.FetchContext
+import com.automq.stream.api.{AppendResult, CreateStreamOptions, FetchResult, OpenStreamOptions, RecordBatch, Stream, StreamClient}
+import com.automq.stream.s3.context.{AppendContext, FetchContext}
 import kafka.log._
 import kafka.log.streamaspect.reassignment._
 import kafka.server.KafkaConfig
@@ -210,6 +210,32 @@ class ElasticLogTest {
         val fetchDataInfo = readRecords()
         assertEquals(2L, fetchDataInfo.records.records.asScala.size)
         assertEquals(keyValues, recordsToKvs(fetchDataInfo.records.records.asScala))
+    }
+
+    /** An admitted append publishes its callback completion before the underlying stream append completes. */
+    @Test
+    def testAppendPublishesAckFutureBeforeStreamCompletion(): Unit = {
+        val client = new DelayedDataAppendClient()
+        val dir = TestUtils.randomPartitionLogDir(tmpDir)
+        val delayedLog = createElasticLogWithActiveSegment(
+            dir = dir,
+            config = LogTestUtils.createLogConfig(),
+            topicPartition = LocalLog.parseTopicPartitionName(dir),
+            client = client)
+        val callbackCount = new AtomicInteger()
+        delayedLog.confirmOffsetChangeListener = Some(() => callbackCount.incrementAndGet())
+
+        try {
+            appendRecords(Seq(new SimpleRecord(mockTime.milliseconds(), "value".getBytes)), delayedLog)
+
+            assertFalse(delayedLog.lastAppendAckFuture.isDone)
+            client.completeDataAppend()
+            delayedLog.lastAppendAckFuture.get(10, TimeUnit.SECONDS)
+            assertEquals(1, callbackCount.get())
+        } finally {
+            client.completeDataAppend()
+            delayedLog.close()
+        }
     }
 
     @Test
@@ -1265,6 +1291,38 @@ class ElasticLogTest {
                 super.fetch(context, startOffset, endOffset, maxSizeHint)
             }
         }
+    }
+
+    private class DelayedDataAppendClient extends MemoryClient {
+        private val streamId = new AtomicLong()
+        private val dataAppendCompletion = new CompletableFuture[Void]()
+        private val delayedStreamClient = new StreamClient {
+            override def createAndOpenStream(options: CreateStreamOptions): CompletableFuture[Stream] = {
+                val id = streamId.incrementAndGet()
+                val stream = if (id == 1) {
+                    new MemoryClient.StreamImpl(id)
+                } else {
+                    new MemoryClient.StreamImpl(id) {
+                        override def append(context: AppendContext, recordBatch: RecordBatch): CompletableFuture[AppendResult] = {
+                            val result = super.append(context, recordBatch).join()
+                            dataAppendCompletion.thenApply(_ => result)
+                        }
+                    }
+                }
+                CompletableFuture.completedFuture(stream)
+            }
+
+            override def openStream(id: Long, options: OpenStreamOptions): CompletableFuture[Stream] =
+                CompletableFuture.completedFuture(new MemoryClient.StreamImpl(id))
+
+            override def getStream(id: Long): Optional[Stream] = Optional.empty()
+
+            override def shutdown(): Unit = {}
+        }
+
+        override def streamClient(): StreamClient = delayedStreamClient
+
+        def completeDataAppend(): Unit = dataAppendCompletion.complete(null)
     }
 
     private class CloseTrackingStream(streamId: Long, failCloseOnce: AtomicBoolean, failAppendOnce: AtomicBoolean,


### PR DESCRIPTION
## Why

Fast partition reassignment can close an ElasticLog shortly after its stream append completes. However, `asyncLogFlush()` only covers the stream append future; confirm-offset updates and the append callback may still be pending on the callback executor.

The close path could therefore mark the memory-mapped buffer as closed before a pending append callback advances the high watermark. The callback would then access the closed buffer and report an append callback error. Clients could retry successfully, but the race exposes an invalid append/close ordering.

## What

Make the last append acknowledgement future represent the complete append callback chain, and wait for it before publishing the memory-mapped buffer as closed.

Append failure logging and the existing close/fallback behavior remain unchanged.

## How

Each admitted append synchronously publishes a `CompletableFuture` that covers stream append completion, confirm-offset advancement, and callback execution on the ordered append callback executor.

The close path first prevents further append work and closes the ElasticLog under the existing `UnifiedLog` lock. It then waits for the published callback future outside that lock before setting `isMemoryMappedBufferClosed`. Waiting outside the lock is required because the callback may acquire the same lock while advancing the high watermark.

A deterministic test delays the data stream append and verifies that the incomplete callback future is already visible before stream completion, then verifies that completing it runs the callback.

## Reviewer notes

Start with `ElasticLog.append` to review the future publication and callback-chain ownership, then review `ElasticUnifiedLog.close` for the lock boundary and closed-buffer publication order. `ElasticLogTest` covers the publication contract without timing-based sleeps.