### PR TITLE
fix(autobalancer): skip metrics reporter on controller-only nodes

### DIFF
--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -39,6 +39,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.internals.Topic;
@@ -96,6 +97,18 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
     private volatile boolean shutdown = false;
     private int metricsReporterCreateRetries;
     private long lastErrorReportTime = 0;
+    private boolean enabled = true;
+
+    static boolean isControllerOnly(Object processRoles) {
+        if (processRoles == null) {
+            return false;
+        }
+        List<?> roles = (List<?>) ConfigDef.parseType(
+            KRaftConfigs.PROCESS_ROLES_CONFIG,
+            processRoles,
+            ConfigDef.Type.LIST);
+        return roles.equals(List.of("controller"));
+    }
 
     String getBootstrapServers(Map<String, ?> configs, String expectedListenerName) {
         String listenerStr = String.valueOf(configs.get(SocketServerConfigs.LISTENERS_CONFIG));
@@ -128,6 +141,9 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
 
     @Override
     public void init(List<KafkaMetric> metrics) {
+        if (!enabled) {
+            return;
+        }
         metricsReporterRunner = new KafkaThread("AutoBalancerMetricsReporterRunner", this, true);
         yammerMetricProcessor = new YammerMetricProcessor();
         metricsReporterRunner.start();
@@ -221,6 +237,12 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
     public void configure(Map<String, ?> rawConfigs) {
 
         Map<String, Object> configs = new HashMap<>(rawConfigs);
+
+        if (isControllerOnly(configs.get(KRaftConfigs.PROCESS_ROLES_CONFIG))) {
+            enabled = false;
+            LOGGER.info("Skipping AutoBalancerMetricsReporter on controller-only node");
+            return;
+        }
 
         StaticAutoBalancerConfig staticAutoBalancerConfig = new StaticAutoBalancerConfig(configs, false);
         Properties producerProps = AutoBalancerMetricsReporterConfig.parseProducerConfigs(configs);

--- a/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
+++ b/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
@@ -21,15 +21,21 @@ import kafka.autobalancer.config.StaticAutoBalancerConfig;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.network.SocketServerConfigs;
+import org.apache.kafka.server.config.KRaftConfigs;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Timeout(60)
 @Tag("S3Unit")
@@ -87,4 +93,38 @@ public class AutoBalancerMetricsReporterTest {
         ), staticConfig4.getString(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG)));
 
     }
+
+    @Test
+    public void testControllerOnlyNodeDisablesMetricsReporter() {
+        AutoBalancerMetricsReporter reporter = Mockito.spy(new AutoBalancerMetricsReporter());
+
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(KRaftConfigs.PROCESS_ROLES_CONFIG, "controller");
+        configs.put(SocketServerConfigs.LISTENERS_CONFIG, "CONTROLLER://:9093");
+
+        Assertions.assertDoesNotThrow(() -> reporter.configure(configs));
+        Mockito.verify(reporter, Mockito.never()).getBootstrapServers(Mockito.anyMap(), Mockito.anyString());
+        Mockito.verify(reporter, Mockito.never()).createAutoBalancerMetricsProducer(Mockito.any());
+
+        reporter.init(List.of());
+        Assertions.assertNull(reporter.yammerMetricProcessor);
+    }
+
+    @ParameterizedTest
+    @MethodSource("processRoles")
+    public void testIsControllerOnly(Object processRoles, boolean expected) {
+        Assertions.assertEquals(expected, AutoBalancerMetricsReporter.isControllerOnly(processRoles));
+    }
+
+    private static Stream<Arguments> processRoles() {
+        return Stream.of(
+            Arguments.of("controller", true),
+            Arguments.of("broker", false),
+            Arguments.of("broker,controller", false),
+            Arguments.of(List.of("controller"), true),
+            Arguments.of(List.of("broker", "controller"), false),
+            Arguments.of(null, false)
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes AutoBalancerMetricsReporter startup on controller-only nodes.

- Skips reporter configuration when the broker role is absent
- Avoids broker listener resolution and producer creation on controller-only nodes
- Prevents the reporter thread from starting on controller-only nodes
- Preserves existing behavior for broker, combined-role, and missing-role configurations
- Adds regression coverage for all role scenarios

Closes #3492