### PR TITLE
fix(s3wal): release failover WAL resources

### DIFF
--- a/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
+++ b/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
@@ -24,7 +24,6 @@ import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorageFactory;
-import com.automq.stream.s3.wal.OpenMode;
 import com.automq.stream.s3.wal.ReservationService;
 import com.automq.stream.s3.wal.WalFactory;
 import com.automq.stream.s3.wal.WriteAheadLog;
@@ -71,7 +70,8 @@ public class DefaultWalFactory implements WalFactory {
                     .withOpenMode(options.openMode());
                 ReservationService reservationService = new ObjectReservationService(AutoMQApplication.getClusterId(), walObjectStorage, walObjectStorage.bucketId());
                 configBuilder.withReservationService(reservationService);
-                return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build(), options.openMode() == OpenMode.FAILOVER);
+                // This factory creates a dedicated ObjectStorage, so the WAL owns its lifecycle.
+                return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build(), true);
             default:
                 throw new IllegalArgumentException("Unsupported WAL protocol: " + uri.protocol());
         }

--- a/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
+++ b/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
@@ -24,6 +24,7 @@ import com.automq.stream.s3.network.NetworkBandwidthLimiter;
 import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorageFactory;
+import com.automq.stream.s3.wal.OpenMode;
 import com.automq.stream.s3.wal.ReservationService;
 import com.automq.stream.s3.wal.WalFactory;
 import com.automq.stream.s3.wal.WriteAheadLog;
@@ -63,14 +64,23 @@ public class DefaultWalFactory implements WalFactory {
                     .outboundLimiter(networkOutboundLimiter)
                     .build();
 
-                ObjectWALConfig.Builder configBuilder = ObjectWALConfig.builder().withURI(uri)
-                    .withClusterId(AutoMQApplication.getClusterId())
-                    .withNodeId(nodeId)
-                    .withEpoch(options.nodeEpoch())
-                    .withOpenMode(options.openMode());
-                ReservationService reservationService = new ObjectReservationService(AutoMQApplication.getClusterId(), walObjectStorage, walObjectStorage.bucketId());
-                configBuilder.withReservationService(reservationService);
-                return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build());
+                try {
+                    ObjectWALConfig.Builder configBuilder = ObjectWALConfig.builder().withURI(uri)
+                        .withClusterId(AutoMQApplication.getClusterId())
+                        .withNodeId(nodeId)
+                        .withEpoch(options.nodeEpoch())
+                        .withOpenMode(options.openMode());
+                    ReservationService reservationService = new ObjectReservationService(AutoMQApplication.getClusterId(), walObjectStorage, walObjectStorage.bucketId());
+                    configBuilder.withReservationService(reservationService);
+                    return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build(), options.openMode() == OpenMode.FAILOVER);
+                } catch (RuntimeException | Error e) {
+                    try {
+                        walObjectStorage.close();
+                    } catch (Throwable closeException) {
+                        e.addSuppressed(closeException);
+                    }
+                    throw e;
+                }
             default:
                 throw new IllegalArgumentException("Unsupported WAL protocol: " + uri.protocol());
         }

--- a/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
+++ b/core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java
@@ -64,23 +64,14 @@ public class DefaultWalFactory implements WalFactory {
                     .outboundLimiter(networkOutboundLimiter)
                     .build();
 
-                try {
-                    ObjectWALConfig.Builder configBuilder = ObjectWALConfig.builder().withURI(uri)
-                        .withClusterId(AutoMQApplication.getClusterId())
-                        .withNodeId(nodeId)
-                        .withEpoch(options.nodeEpoch())
-                        .withOpenMode(options.openMode());
-                    ReservationService reservationService = new ObjectReservationService(AutoMQApplication.getClusterId(), walObjectStorage, walObjectStorage.bucketId());
-                    configBuilder.withReservationService(reservationService);
-                    return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build(), options.openMode() == OpenMode.FAILOVER);
-                } catch (RuntimeException | Error e) {
-                    try {
-                        walObjectStorage.close();
-                    } catch (Throwable closeException) {
-                        e.addSuppressed(closeException);
-                    }
-                    throw e;
-                }
+                ObjectWALConfig.Builder configBuilder = ObjectWALConfig.builder().withURI(uri)
+                    .withClusterId(AutoMQApplication.getClusterId())
+                    .withNodeId(nodeId)
+                    .withEpoch(options.nodeEpoch())
+                    .withOpenMode(options.openMode());
+                ReservationService reservationService = new ObjectReservationService(AutoMQApplication.getClusterId(), walObjectStorage, walObjectStorage.bucketId());
+                configBuilder.withReservationService(reservationService);
+                return new ObjectWALService(Time.SYSTEM, walObjectStorage, configBuilder.build(), options.openMode() == OpenMode.FAILOVER);
             default:
                 throw new IllegalArgumentException("Unsupported WAL protocol: " + uri.protocol());
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
@@ -86,13 +86,12 @@ public class Failover {
             // recover WAL data and upload to S3
             WriteAheadLog wal = factory.getWal(request);
             try {
-                wal.start();
-            } catch (WALNotInitializedException ex) {
-                LOGGER.info("fail over empty wal {}", request);
-                return resp;
-            }
-
-            try {
+                try {
+                    wal.start();
+                } catch (WALNotInitializedException ex) {
+                    LOGGER.info("fail over empty wal {}", request);
+                    return resp;
+                }
                 WALMetadata metadata = wal.metadata();
                 if (nodeId != metadata.nodeId()) {
                     throw new IllegalArgumentException(String.format("nodeId mismatch, request=%s, wal=%s", request, metadata));

--- a/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
@@ -106,7 +106,7 @@ public class Failover {
                 LOGGER.info("failover recover {}", request);
                 walRecover.recover(wal, streamManager, objectManager, taskLogger);
             } finally {
-                wal.shutdownGracefully();
+                FutureUtil.suppress(wal::shutdownGracefully, LOGGER);
             }
             LOGGER.info("failover done {}", request);
             return resp;

--- a/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
@@ -86,12 +86,7 @@ public class Failover {
             // recover WAL data and upload to S3
             WriteAheadLog wal = factory.getWal(request);
             try {
-                try {
-                    wal.start();
-                } catch (WALNotInitializedException ex) {
-                    LOGGER.info("fail over empty wal {}", request);
-                    return resp;
-                }
+                wal.start();
                 WALMetadata metadata = wal.metadata();
                 if (nodeId != metadata.nodeId()) {
                     throw new IllegalArgumentException(String.format("nodeId mismatch, request=%s, wal=%s", request, metadata));
@@ -105,6 +100,9 @@ public class Failover {
                 ObjectManager objectManager = factory.getObjectManager(nodeId, nodeEpoch);
                 LOGGER.info("failover recover {}", request);
                 walRecover.recover(wal, streamManager, objectManager, taskLogger);
+            } catch (WALNotInitializedException ex) {
+                LOGGER.info("fail over empty wal {}", request);
+                return resp;
             } finally {
                 FutureUtil.suppress(wal::shutdownGracefully, LOGGER);
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
@@ -70,14 +70,9 @@ public class DefaultWalHandle implements WalHandle {
     private CompletableFuture<Void> acquireObjectWALPermission(int nodeId, long nodeEpoch, IdURI walConfig,
         AcquirePermissionOptions options) {
         ObjectStorage objectStorage = ObjectStorageFactory.instance().builder(BucketURI.parse(walConfig)).build();
-        try {
-            ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
-            return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode())
-                .whenComplete((result, exception) -> closeObjectStorage(objectStorage));
-        } catch (RuntimeException | Error e) {
-            closeObjectStorage(objectStorage);
-            throw e;
-        }
+        ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
+        return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode())
+            .whenComplete((result, exception) -> closeObjectStorage(objectStorage));
     }
 
     private void closeObjectStorage(ObjectStorage objectStorage) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
@@ -70,8 +70,8 @@ public class DefaultWalHandle implements WalHandle {
     private CompletableFuture<Void> acquireObjectWALPermission(int nodeId, long nodeEpoch, IdURI walConfig,
         AcquirePermissionOptions options) {
         ObjectStorage objectStorage = ObjectStorageFactory.instance().builder(BucketURI.parse(walConfig)).build();
-        ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
         try {
+            ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
             return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode())
                 .whenComplete((result, exception) -> closeObjectStorage(objectStorage));
         } catch (RuntimeException | Error e) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
@@ -25,10 +25,14 @@ import com.automq.stream.s3.operator.ObjectStorageFactory;
 import com.automq.stream.s3.wal.impl.object.ObjectReservationService;
 import com.automq.stream.utils.IdURI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 public class DefaultWalHandle implements WalHandle {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWalHandle.class);
 
     private final String clusterId;
 
@@ -67,6 +71,20 @@ public class DefaultWalHandle implements WalHandle {
         AcquirePermissionOptions options) {
         ObjectStorage objectStorage = ObjectStorageFactory.instance().builder(BucketURI.parse(walConfig)).build();
         ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
-        return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode());
+        try {
+            return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode())
+                .whenComplete((result, exception) -> closeObjectStorage(objectStorage));
+        } catch (RuntimeException | Error e) {
+            closeObjectStorage(objectStorage);
+            throw e;
+        }
+    }
+
+    private void closeObjectStorage(ObjectStorage objectStorage) {
+        try {
+            objectStorage.close();
+        } catch (Throwable e) {
+            LOGGER.error("Failed to close reservation object storage", e);
+        }
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
@@ -73,10 +73,6 @@ public class DefaultWalHandle implements WalHandle {
         ObjectStorage objectStorage = ObjectStorageFactory.instance().builder(BucketURI.parse(walConfig)).build();
         ObjectReservationService reservationService = new ObjectReservationService(clusterId, objectStorage, walConfig.id());
         return reservationService.acquire(nodeId, nodeEpoch, options.failoverMode())
-            .whenComplete((result, exception) -> closeObjectStorage(objectStorage));
-    }
-
-    private void closeObjectStorage(ObjectStorage objectStorage) {
-        FutureUtil.suppress(objectStorage::close, LOGGER);
+            .whenComplete((result, exception) -> FutureUtil.suppress(objectStorage::close, LOGGER));
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java
@@ -23,6 +23,7 @@ import com.automq.stream.s3.operator.BucketURI;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.operator.ObjectStorageFactory;
 import com.automq.stream.s3.wal.impl.object.ObjectReservationService;
+import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.IdURI;
 
 import org.slf4j.Logger;
@@ -76,10 +77,6 @@ public class DefaultWalHandle implements WalHandle {
     }
 
     private void closeObjectStorage(ObjectStorage objectStorage) {
-        try {
-            objectStorage.close();
-        } catch (Throwable e) {
-            LOGGER.error("Failed to close reservation object storage", e);
-        }
+        FutureUtil.suppress(objectStorage::close, LOGGER);
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/State.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/State.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.wal;
+
+/**
+ * Lifecycle states shared by WAL implementations.
+ *
+ * <p>A WAL can be closed before it is started so that resources created during
+ * construction are released. Once closing begins, the WAL cannot be started or
+ * used again.
+ */
+public enum State {
+    NOT_STARTED,
+    STARTED,
+    CLOSING,
+    CLOSED
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -189,7 +189,7 @@ public class DefaultWriter implements Writer {
         uploadActiveBulk();
         if (lastInActiveBulk != null) {
             try {
-                lastInActiveBulk.completeCf.get(5, TimeUnit.SECONDS);
+                lastInActiveBulk.completeCf.get();
             } catch (Throwable ex) {
                 LOGGER.error("Failed to flush records when close.", ex);
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -30,6 +30,7 @@ import com.automq.stream.s3.wal.OpenMode;
 import com.automq.stream.s3.wal.RecordOffset;
 import com.automq.stream.s3.wal.RecoverResult;
 import com.automq.stream.s3.wal.ReservationService;
+import com.automq.stream.s3.wal.State;
 import com.automq.stream.s3.wal.common.RecordHeader;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
 import com.automq.stream.s3.wal.exception.RuntimeIOException;
@@ -60,7 +61,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -99,8 +99,8 @@ public class DefaultWriter implements Writer {
     private final AtomicLong objectDataBytes = new AtomicLong();
     private final AtomicLong bufferedDataBytes = new AtomicLong();
 
-    protected volatile boolean closed = true;
     protected volatile boolean fenced;
+    private volatile State state = State.NOT_STARTED;
 
     private Bulk activeBulk = null;
     private Bulk lastInActiveBulk = null;
@@ -113,7 +113,6 @@ public class DefaultWriter implements Writer {
 
     private CompletableFuture<Void> callbackCf = CompletableFuture.completedFuture(null);
     private final EventLoop callbackExecutor = new EventLoop("S3_WAL_CALLBACK");
-    private final AtomicBoolean resourcesClosed = new AtomicBoolean();
     private volatile ScheduledFuture<?> monitorTask;
 
     private final AtomicLong nextOffset = new AtomicLong();
@@ -136,7 +135,11 @@ public class DefaultWriter implements Writer {
         }
     }
 
-    public void start() {
+    public synchronized void start() {
+        if (state != State.NOT_STARTED) {
+            LOGGER.warn("Skip starting the WAL because its state is {}.", state);
+            return;
+        }
         // Verify the permission.
         reservationService.verify(config.nodeId(), config.epoch(), config.openMode() == OpenMode.FAILOVER)
             .thenAccept(result -> {
@@ -173,15 +176,15 @@ public class DefaultWriter implements Writer {
 
         startMonitor();
 
-        closed = false;
+        state = State.STARTED;
     }
 
     @Override
-    public void close() {
-        if (!resourcesClosed.compareAndSet(false, true)) {
+    public synchronized void close() {
+        if (state != State.NOT_STARTED && state != State.STARTED) {
             return;
         }
-        closed = true;
+        state = State.CLOSING;
         ScheduledFuture<?> monitorTask = this.monitorTask;
         if (monitorTask != null) {
             monitorTask.cancel(false);
@@ -195,6 +198,7 @@ public class DefaultWriter implements Writer {
             }
         }
         FutureUtil.suppress(() -> callbackExecutor.shutdownGracefully().join(), LOGGER);
+        state = State.CLOSED;
 
         LOGGER.info("S3WAL Writer is closed.");
     }
@@ -208,7 +212,7 @@ public class DefaultWriter implements Writer {
     }
 
     protected void checkStatus() throws WALFencedException {
-        if (closed) {
+        if (state != State.STARTED) {
             throw new IllegalStateException("WAL is closed.");
         }
 
@@ -255,6 +259,7 @@ public class DefaultWriter implements Writer {
         Record record = new Record(streamRecordBatch, new CompletableFuture<>());
         lock.writeLock().lock();
         try {
+            checkWriteStatus();
             if (activeBulk == null) {
                 activeBulk = new Bulk(nextOffset.get());
             }
@@ -547,7 +552,7 @@ public class DefaultWriter implements Writer {
     }
 
     private void retryDelete(List<ObjectStorage.ObjectPath> objectPaths) {
-        if (!closed) {
+        if (state == State.STARTED) {
             // Try to delete the objects again to avoid an object leak after a fast retry failure.
             objectStorage.delete(objectPaths);
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -58,7 +58,9 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -111,6 +113,8 @@ public class DefaultWriter implements Writer {
 
     private CompletableFuture<Void> callbackCf = CompletableFuture.completedFuture(null);
     private final EventLoop callbackExecutor = new EventLoop("S3_WAL_CALLBACK");
+    private final AtomicBoolean resourcesClosed = new AtomicBoolean();
+    private volatile ScheduledFuture<?> monitorTask;
 
     private final AtomicLong nextOffset = new AtomicLong();
     private final AtomicLong flushedOffset = new AtomicLong();
@@ -174,14 +178,25 @@ public class DefaultWriter implements Writer {
 
     @Override
     public void close() {
+        if (!resourcesClosed.compareAndSet(false, true)) {
+            return;
+        }
         closed = true;
-        uploadActiveBulk();
-        if (lastInActiveBulk != null) {
-            try {
-                lastInActiveBulk.completeCf.get();
-            } catch (Throwable ex) {
-                LOGGER.error("Failed to flush records when close.", ex);
+        ScheduledFuture<?> monitorTask = this.monitorTask;
+        if (monitorTask != null) {
+            monitorTask.cancel(false);
+        }
+        try {
+            uploadActiveBulk();
+            if (lastInActiveBulk != null) {
+                try {
+                    lastInActiveBulk.completeCf.get();
+                } catch (Throwable ex) {
+                    LOGGER.error("Failed to flush records when close.", ex);
+                }
             }
+        } finally {
+            FutureUtil.suppress(() -> callbackExecutor.shutdownGracefully().join(), LOGGER);
         }
 
         LOGGER.info("S3WAL Writer is closed.");
@@ -538,7 +553,7 @@ public class DefaultWriter implements Writer {
     }
 
     private void startMonitor() {
-        SCHEDULE.scheduleWithFixedDelay(() -> {
+        monitorTask = SCHEDULE.scheduleWithFixedDelay(() -> {
             try {
                 long count = uploadingBulks.stream()
                     .filter(bulk -> time.nanoseconds() - bulk.startNanos > DEFAULT_UPLOAD_WARNING_TIMEOUT)

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java
@@ -186,18 +186,15 @@ public class DefaultWriter implements Writer {
         if (monitorTask != null) {
             monitorTask.cancel(false);
         }
-        try {
-            uploadActiveBulk();
-            if (lastInActiveBulk != null) {
-                try {
-                    lastInActiveBulk.completeCf.get();
-                } catch (Throwable ex) {
-                    LOGGER.error("Failed to flush records when close.", ex);
-                }
+        uploadActiveBulk();
+        if (lastInActiveBulk != null) {
+            try {
+                lastInActiveBulk.completeCf.get(5, TimeUnit.SECONDS);
+            } catch (Throwable ex) {
+                LOGGER.error("Failed to flush records when close.", ex);
             }
-        } finally {
-            FutureUtil.suppress(() -> callbackExecutor.shutdownGracefully().join(), LOGGER);
         }
+        FutureUtil.suppress(() -> callbackExecutor.shutdownGracefully().join(), LOGGER);
 
         LOGGER.info("S3WAL Writer is closed.");
     }
@@ -538,10 +535,7 @@ public class DefaultWriter implements Writer {
                     if (throwable != null) {
                         LOGGER.error("Failed to delete objects when trim S3 WAL: {}", deleteObjectList, throwable);
                     }
-                    SCHEDULE.schedule(() -> {
-                        // - Try to Delete the objects again after 30 seconds to avoid object leak because of underlying fast retry
-                        objectStorage.delete(deleteObjectList);
-                    }, 10, TimeUnit.SECONDS);
+                    SCHEDULE.schedule(() -> retryDelete(deleteObjectList), 10, TimeUnit.SECONDS);
                 });
             });
             return lastTrimCf;
@@ -549,6 +543,13 @@ public class DefaultWriter implements Writer {
             return CompletableFuture.failedFuture(e);
         } finally {
             lock.writeLock().unlock();
+        }
+    }
+
+    private void retryDelete(List<ObjectStorage.ObjectPath> objectPaths) {
+        if (!closed) {
+            // Try to delete the objects again to avoid an object leak after a fast retry failure.
+            objectStorage.delete(objectPaths);
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -91,10 +91,6 @@ public class ObjectWALService implements WriteAheadLog {
         }
         log.info("Shutdown S3 WAL.");
         writer.close();
-        closeObjectStorage();
-    }
-
-    private void closeObjectStorage() {
         if (closeObjectStorageOnShutdown) {
             FutureUtil.suppress(objectStorage::close, log);
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -56,6 +56,14 @@ public class ObjectWALService implements WriteAheadLog {
         this(time, objectStorage, config, false);
     }
 
+    /**
+     * Creates a WAL with an optional shutdown-owned object storage.
+     *
+     * @param time the time source
+     * @param objectStorage the storage used by this WAL
+     * @param config the WAL configuration
+     * @param closeObjectStorageOnShutdown whether this WAL owns storage shutdown
+     */
     public ObjectWALService(Time time, ObjectStorage objectStorage, ObjectWALConfig config,
         boolean closeObjectStorageOnShutdown) {
         this.objectStorage = objectStorage;
@@ -84,10 +92,16 @@ public class ObjectWALService implements WriteAheadLog {
         log.info("Shutdown S3 WAL.");
         try {
             writer.close();
-        } finally {
-            if (closeObjectStorageOnShutdown) {
-                FutureUtil.suppress(objectStorage::close, log);
-            }
+        } catch (RuntimeException | Error e) {
+            closeObjectStorage();
+            throw e;
+        }
+        closeObjectStorage();
+    }
+
+    private void closeObjectStorage() {
+        if (closeObjectStorageOnShutdown) {
+            FutureUtil.suppress(objectStorage::close, log);
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -29,6 +29,7 @@ import com.automq.stream.s3.wal.RecoverResult;
 import com.automq.stream.s3.wal.WriteAheadLog;
 import com.automq.stream.s3.wal.common.WALMetadata;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
+import com.automq.stream.utils.FutureUtil;
 import com.automq.stream.utils.Time;
 
 import org.slf4j.Logger;
@@ -38,19 +39,28 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ObjectWALService implements WriteAheadLog {
     private static final Logger log = LoggerFactory.getLogger(ObjectWALService.class);
 
     protected ObjectStorage objectStorage;
     protected ObjectWALConfig config;
+    private final boolean closeObjectStorageOnShutdown;
+    private final AtomicBoolean shutdown = new AtomicBoolean();
 
     protected final Writer writer;
     protected final DefaultReader reader;
 
     public ObjectWALService(Time time, ObjectStorage objectStorage, ObjectWALConfig config) {
+        this(time, objectStorage, config, false);
+    }
+
+    public ObjectWALService(Time time, ObjectStorage objectStorage, ObjectWALConfig config,
+        boolean closeObjectStorageOnShutdown) {
         this.objectStorage = objectStorage;
         this.config = config;
+        this.closeObjectStorageOnShutdown = closeObjectStorageOnShutdown;
         if (config.openMode() == OpenMode.READ_WRITE || config.openMode() == OpenMode.FAILOVER) {
             this.writer = new DefaultWriter(time, objectStorage, config);
         } else {
@@ -68,8 +78,17 @@ public class ObjectWALService implements WriteAheadLog {
 
     @Override
     public void shutdownGracefully() {
+        if (!shutdown.compareAndSet(false, true)) {
+            return;
+        }
         log.info("Shutdown S3 WAL.");
-        writer.close();
+        try {
+            writer.close();
+        } finally {
+            if (closeObjectStorageOnShutdown) {
+                FutureUtil.suppress(objectStorage::close, log);
+            }
+        }
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java
@@ -90,12 +90,7 @@ public class ObjectWALService implements WriteAheadLog {
             return;
         }
         log.info("Shutdown S3 WAL.");
-        try {
-            writer.close();
-        } catch (RuntimeException | Error e) {
-            closeObjectStorage();
-            throw e;
-        }
+        writer.close();
         closeObjectStorage();
     }
 

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/DefaultWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/DefaultWriterTest.java
@@ -23,6 +23,8 @@ import com.automq.stream.utils.Time;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -30,6 +32,9 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("S3Unit")
 public class DefaultWriterTest {
     private DefaultWriter writer;
     private MockObjectStorage objectStorage;
@@ -64,6 +69,18 @@ public class DefaultWriterTest {
         random.nextBytes(bytes);
         byteBuf.writeBytes(bytes);
         return byteBuf;
+    }
+
+    /**
+     * Given a started writer, when it is closed repeatedly, then it remains closed and cannot restart.
+     */
+    @Test
+    public void testCloseIsIdempotentAndPreventsRestart() {
+        writer.close();
+        writer.close();
+        writer.start();
+
+        assertThrows(IllegalStateException.class, writer::objectList);
     }
 
     // TODO: fix the test

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -17,6 +17,7 @@ import com.automq.stream.utils.Time;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(120)
+@Tag("S3Unit")
 public class ObjectWALServiceTest {
     private MockObjectStorage objectStorage;
     private Random random;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/impl/object/ObjectWALServiceTest.java
@@ -6,6 +6,7 @@ import com.automq.stream.s3.model.StreamRecordBatch;
 import com.automq.stream.s3.operator.ObjectStorage;
 import com.automq.stream.s3.trace.context.TraceContext;
 import com.automq.stream.s3.wal.AppendResult;
+import com.automq.stream.s3.wal.OpenMode;
 import com.automq.stream.s3.wal.RecoverResult;
 import com.automq.stream.s3.wal.common.Record;
 import com.automq.stream.s3.wal.exception.OverCapacityException;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import io.netty.buffer.ByteBuf;
@@ -37,6 +39,8 @@ import io.netty.buffer.Unpooled;
 import static com.automq.stream.s3.wal.common.RecordHeader.RECORD_HEADER_SIZE;
 import static com.automq.stream.s3.wal.impl.object.RecoverIterator.getContinuousFromTrimOffset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(120)
 public class ObjectWALServiceTest {
@@ -55,6 +59,41 @@ public class ObjectWALServiceTest {
     public void tearDown() {
         objectStorage.triggerAll();
         objectStorage.close();
+    }
+
+    @Test
+    public void testShutdownClosesOwnedObjectStorageOnce() {
+        TrackingObjectStorage storage = new TrackingObjectStorage();
+        ObjectWALConfig config = ObjectWALConfig.builder().withOpenMode(OpenMode.FAILOVER).build();
+        ObjectWALService wal = new ObjectWALService(time, storage, config, true);
+
+        wal.shutdownGracefully();
+        wal.shutdownGracefully();
+
+        assertEquals(1, storage.closeCount.get());
+    }
+
+    @Test
+    public void testShutdownDoesNotCloseBorrowedObjectStorage() {
+        TrackingObjectStorage storage = new TrackingObjectStorage();
+        ObjectWALConfig config = ObjectWALConfig.builder().withOpenMode(OpenMode.READ_ONLY).build();
+        ObjectWALService wal = new ObjectWALService(time, storage, config);
+
+        wal.shutdownGracefully();
+
+        assertFalse(storage.closeCount.get() > 0);
+        storage.close();
+        assertTrue(storage.closeCount.get() > 0);
+    }
+
+    private static class TrackingObjectStorage extends MockObjectStorage {
+        private final AtomicInteger closeCount = new AtomicInteger();
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+            super.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why

Failover and reservation paths could leave their short-lived `ObjectStorage` and per-WAL writer resources alive.

## What

- Close reservation-scoped `ObjectStorage` after acquire completes or fails.
- Close `ObjectStorage` owned by failover-created WALs during WAL shutdown.
- Close each `DefaultWriter` callback `EventLoop` and cancel its monitor task.
- Ensure empty-WAL and failover startup/recovery failures still shut down the WAL.
- Keep shared provider `ObjectStorage` borrowed and unaffected.

## How

`DefaultWalFactory` enables storage close-on-shutdown only for `FAILOVER` WALs. `DefaultWalHandle` attaches cleanup to the acquire future. `ObjectWALService` and `DefaultWriter` make shutdown idempotent. Delayed delete retries stop when the writer is closed.

No cache or additional `finally` was introduced.

## Reviewer notes

Suggested reading order:

1. `core/src/main/scala/kafka/log/stream/s3/wal/DefaultWalFactory.java` — WAL storage ownership setup.
2. `s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java` — failover cleanup boundary.
3. `s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/ObjectWALService.java` — WAL shutdown behavior.
4. `s3stream/src/main/java/com/automq/stream/s3/wal/impl/object/DefaultWriter.java` — writer-local resource cleanup.
5. `s3stream/src/main/java/com/automq/stream/s3/wal/DefaultWalHandle.java` — reservation storage cleanup.