### PR TITLE
feat(controller): support gentle elastic broker shutdown

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -471,6 +471,29 @@ public class BrokerHeartbeatManager {
         }
     }
 
+    // AutoMQ inject start
+    /**
+     * Establish or advance the metadata barrier for a Broker in persisted controlled shutdown.
+     * Establishing the barrier restores heartbeat soft state after a Controller change.
+     */
+    void advanceControlledShutdownOffset(int brokerId, long controlledShutdownOffset) {
+        BrokerHeartbeatState broker = heartbeatStateOrThrow(brokerId);
+        if (broker.fenced()) {
+            throw new IllegalStateException("Fenced broker " + brokerId
+                + " cannot advance its controlled shutdown offset.");
+        }
+        active.remove(broker);
+        if (!broker.shuttingDown()) {
+            broker.lastControlledShutdownNs = time.nanoseconds();
+        }
+        if (broker.controlledShutdownOffset < controlledShutdownOffset) {
+            broker.controlledShutdownOffset = controlledShutdownOffset;
+            log.debug("Advanced the controlled shutdown offset for broker {} to {}.",
+                brokerId, controlledShutdownOffset);
+        }
+    }
+    // AutoMQ inject end
+
     /**
      * Return the time in monotonic nanoseconds at which we should check if a broker
      * session needs to be expired.

--- a/metadata/src/main/java/org/apache/kafka/controller/GentleControlledShutdownControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/GentleControlledShutdownControlManager.java
@@ -19,12 +19,12 @@
 
 package org.apache.kafka.controller;
 
-import com.automq.stream.utils.Threads;
-
 import org.apache.kafka.common.es.ElasticStreamSwitch;
 import org.apache.kafka.controller.errors.ControllerExceptions;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import com.automq.stream.utils.Threads;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/metadata/src/main/java/org/apache/kafka/controller/GentleControlledShutdownControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/GentleControlledShutdownControlManager.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import com.automq.stream.utils.Threads;
+
+import org.apache.kafka.common.es.ElasticStreamSwitch;
+import org.apache.kafka.controller.errors.ControllerExceptions;
+import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Owns periodic scheduling and ephemeral pacing state for Elastic controlled-shutdown drains.
+ * The scheduler only triggers work; all Controller state access and mutation runs through a
+ * {@link QuorumController.ControllerWriteOperation} on the Controller event queue.
+ * This manager cancels its scheduled task when closed but does not own the supplied scheduler.
+ */
+final class GentleControlledShutdownControlManager implements AutoCloseable {
+    static final String EVENT_NAME = "gentleControlledShutdownDrain";
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(GentleControlledShutdownControlManager.class);
+    private static final long INTERVAL_SECONDS = 1L;
+
+    private final QuorumController quorumController;
+    private final ClusterControlManager clusterControl;
+    private final ReplicationControlManager replicationControl;
+    private final ScheduledFuture<?> scheduledFuture;
+    private final Map<Integer, BrokerDrainState> drainStates = new HashMap<>();
+
+    GentleControlledShutdownControlManager(
+        QuorumController quorumController,
+        ClusterControlManager clusterControl,
+        ReplicationControlManager replicationControl
+    ) {
+        this(quorumController, clusterControl, replicationControl,
+            Threads.COMMON_SCHEDULER);
+    }
+
+    GentleControlledShutdownControlManager(
+        QuorumController quorumController,
+        ClusterControlManager clusterControl,
+        ReplicationControlManager replicationControl,
+        ScheduledExecutorService scheduler
+    ) {
+        this.quorumController = quorumController;
+        this.clusterControl = clusterControl;
+        this.replicationControl = replicationControl;
+        this.scheduledFuture = scheduler.scheduleWithFixedDelay(
+            this::runDrainTask, INTERVAL_SECONDS, INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    void activate() {
+        drainStates.clear();
+    }
+
+    void deactivate() {
+        drainStates.clear();
+    }
+
+    private void runDrainTask() {
+        if (!ElasticStreamSwitch.isEnabled() || !quorumController.isActive()) {
+            return;
+        }
+        try {
+            quorumController.appendWriteEvent(
+                EVENT_NAME, OptionalLong.empty(), new DrainOperation()).whenComplete((ignored, e) -> {
+                    if (e == null) {
+                        return;
+                    }
+                    Throwable cause = e instanceof CompletionException && e.getCause() != null
+                        ? e.getCause() : e;
+                    if (ControllerExceptions.isNotControllerException(cause)) {
+                        LOGGER.debug("Skipping gentle controlled-shutdown drain because this "
+                            + "Controller is no longer active");
+                    } else {
+                        LOGGER.warn("Gentle controlled-shutdown drain task failed", cause);
+                    }
+                });
+        } catch (Throwable e) {
+            LOGGER.warn("Unable to submit gentle controlled-shutdown drain task", e);
+        }
+    }
+
+    /**
+     * Cancel future drain triggers without shutting down the shared scheduler.
+     */
+    @Override
+    public void close() {
+        scheduledFuture.cancel(false);
+    }
+
+    private final class DrainOperation implements QuorumController.ControllerWriteOperation<Void> {
+        private final List<Integer> drainedBrokers = new ArrayList<>();
+
+        @Override
+        public ControllerResult<Void> generateRecordsAndResult() {
+            List<ApiMessageAndVersion> records = new ArrayList<>();
+            if (!ElasticStreamSwitch.isEnabled()) {
+                drainStates.clear();
+                return ControllerResult.of(records, null);
+            }
+            Map<Integer, BrokerRegistration> registrations = clusterControl.brokerRegistrations();
+            drainStates.keySet().removeIf(brokerId -> !registrations.containsKey(brokerId));
+            for (BrokerRegistration broker : registrations.values()) {
+                if (!broker.inControlledShutdown()
+                        || !replicationControl.hasControlledShutdownLeaders(broker.id())) {
+                    drainStates.remove(broker.id());
+                    continue;
+                }
+                BrokerDrainState drainState = drainStates.get(broker.id());
+                if (drainState == null || drainState.brokerEpoch != broker.epoch()) {
+                    int leaderCount = replicationControl.controlledShutdownLeaderCount(broker.id());
+                    drainState = new BrokerDrainState(
+                        broker.epoch(), Math.max((leaderCount + 59) / 60, 100));
+                    drainStates.put(broker.id(), drainState);
+                }
+                ControllerResult<Void> result = replicationControl.maybeDrainControlledShutdownBroker(
+                    broker.id(), drainState.batchTarget);
+                if (!result.records().isEmpty()) {
+                    records.addAll(result.records());
+                    drainedBrokers.add(broker.id());
+                }
+            }
+            return ControllerResult.of(records, null);
+        }
+
+        @Override
+        public void processBatchEndOffset(long offset) {
+            for (int brokerId : drainedBrokers) {
+                clusterControl.heartbeatManager().advanceControlledShutdownOffset(brokerId, offset);
+            }
+        }
+    }
+
+    private static final class BrokerDrainState {
+        private final long brokerEpoch;
+        private final int batchTarget;
+
+        private BrokerDrainState(long brokerEpoch, int batchTarget) {
+            this.brokerEpoch = brokerEpoch;
+            this.batchTarget = batchTarget;
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1364,6 +1364,9 @@ public final class QuorumController implements Controller {
             curClaimEpoch = epoch;
             offsetControl.activate(newNextWriteOffset);
             clusterControl.activate();
+            // AutoMQ inject start
+            gentleControlledShutdownControl.activate();
+            // AutoMQ inject end
             extension.activate();
 
             // Prepend the activate event. It is important that this event go at the beginning
@@ -1424,6 +1427,9 @@ public final class QuorumController implements Controller {
                     newWrongControllerException(OptionalInt.empty()));
             offsetControl.deactivate();
             clusterControl.deactivate();
+            // AutoMQ inject start
+            gentleControlledShutdownControl.deactivate();
+            // AutoMQ inject end
             extension.deactivate();
             cancelMaybeFenceReplicas();
             cancelMaybeBalancePartitionLeaders();
@@ -2101,6 +2107,10 @@ public final class QuorumController implements Controller {
      */
     private final RouterChannelEpochControlManager routerChannelEpochControlManager;
 
+    // AutoMQ inject start
+    private final GentleControlledShutdownControlManager gentleControlledShutdownControl;
+    // AutoMQ inject end
+
     private final QuorumControllerExtension extension;
     // AutoMQ for Kafka inject end
 
@@ -2273,6 +2283,10 @@ public final class QuorumController implements Controller {
         this.topicDeletionManager = new TopicDeletionManager(snapshotRegistry, this, streamControlManager, kvControlManager);
         this.nodeControlManager = new NodeControlManager(snapshotRegistry, new DefaultNodeRuntimeInfoManager(clusterControl, streamControlManager));
         this.routerChannelEpochControlManager = new RouterChannelEpochControlManager(snapshotRegistry, this, nodeControlManager, time);
+        // AutoMQ inject start
+        this.gentleControlledShutdownControl =
+            new GentleControlledShutdownControlManager(this, clusterControl, replicationControl);
+        // AutoMQ inject end
         this.extension = extension.apply(this);
 
         // set the nodeControlManager here to avoid circular dependency
@@ -2719,6 +2733,9 @@ public final class QuorumController implements Controller {
 
     @Override
     public void close() throws InterruptedException {
+        // AutoMQ inject start
+        gentleControlledShutdownControl.close();
+        // AutoMQ inject end
         queue.close();
         controllerMetrics.close();
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -387,6 +387,7 @@ public class ReplicationControlManager {
     private final Controller quorumController;
 
     private NodeControlManager nodeControlManager;
+
     // AutoMQ for Kafka inject end
 
 
@@ -1578,9 +1579,48 @@ public class ReplicationControlManager {
                 setInControlledShutdown(BrokerRegistrationInControlledShutdownChange.IN_CONTROLLED_SHUTDOWN.value()),
                 (short) 1));
         }
-        generateLeaderAndIsrUpdates("enterControlledShutdown[" + brokerId + "]",
-            brokerId, NO_LEADER, NO_LEADER, records, brokersToIsrs.partitionsWithBrokerInIsr(brokerId));
+        // AutoMQ inject start
+        if (!ElasticStreamSwitch.isEnabled()) {
+            generateLeaderAndIsrUpdates("enterControlledShutdown[" + brokerId + "]",
+                brokerId, NO_LEADER, NO_LEADER, records, brokersToIsrs.partitionsWithBrokerInIsr(brokerId));
+        }
+        // AutoMQ inject end
     }
+
+    // AutoMQ inject start
+    /**
+     * Generate one bounded migration batch for an Elastic Broker in controlled shutdown.
+     * The caller owns the fixed batch target for the active Controller lifecycle.
+     */
+    ControllerResult<Void> maybeDrainControlledShutdownBroker(int brokerId, int batchTarget) {
+        if (!ElasticStreamSwitch.isEnabled() || !clusterControl.inControlledShutdown(brokerId)) {
+            return ControllerResult.of(Collections.emptyList(), null);
+        }
+        List<TopicIdPartition> batch = new ArrayList<>(batchTarget);
+        Iterator<TopicIdPartition> leaders = brokersToIsrs.partitionsLedByBroker(brokerId);
+        while (leaders.hasNext() && batch.size() < batchTarget) {
+            batch.add(leaders.next());
+        }
+        List<ApiMessageAndVersion> records = new ArrayList<>(batch.size());
+        generateLeaderAndIsrUpdates("gentleControlledShutdown[" + brokerId + "]",
+            brokerId, NO_LEADER, NO_LEADER, records, batch.iterator());
+        return ControllerResult.of(records, null);
+    }
+
+    int controlledShutdownLeaderCount(int brokerId) {
+        int leaderCount = 0;
+        Iterator<TopicIdPartition> leaders = brokersToIsrs.partitionsLedByBroker(brokerId);
+        while (leaders.hasNext()) {
+            leaders.next();
+            leaderCount++;
+        }
+        return leaderCount;
+    }
+
+    boolean hasControlledShutdownLeaders(int brokerId) {
+        return brokersToIsrs.partitionsLedByBroker(brokerId).hasNext();
+    }
+    // AutoMQ inject end
 
     /**
      * Create partition change records to remove replicas from any ISR or ELR for brokers doing unclean shutdown.
@@ -2172,7 +2212,8 @@ public class ReplicationControlManager {
                                      int brokerWithUncleanShutdown,
                                      List<ApiMessageAndVersion> records,
                                      Iterator<TopicIdPartition> iterator) {
-        generateLeaderAndIsrUpdates0(context, brokerToRemove, brokerToAdd, brokerWithUncleanShutdown, records, iterator);
+        generateLeaderAndIsrUpdates0(context, brokerToRemove, brokerToAdd,
+            brokerWithUncleanShutdown, records, iterator);
     }
 
     void generateLeaderAndIsrUpdates0(String context,
@@ -2217,6 +2258,12 @@ public class ReplicationControlManager {
                 throw new RuntimeException("Partition " + topicIdPart +
                     " existed in isrMembers, but not in the partitions map.");
             }
+            // AutoMQ inject start
+            if (ElasticStreamSwitch.isEnabled() && brokerToAdd != NO_LEADER &&
+                    Arrays.stream(partition.replicas).anyMatch(clusterControl::isActive)) {
+                continue;
+            }
+            // AutoMQ inject end
             PartitionChangeBuilder builder = new PartitionChangeBuilder(
                 partition,
                 topicIdPart.topicId(),

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.controller.BrokerHeartbeatManager.UsableBrokerIterator;
 import org.apache.kafka.controller.stream.NodeState;
 import org.apache.kafka.metadata.placement.UsableBroker;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -254,6 +255,30 @@ public class BrokerHeartbeatManagerTest {
         manager.maybeUpdateControlledShutdownOffset(3, 102);
         assertEquals(OptionalLong.of(101), manager.controlledShutdownOffset(3));
     }
+
+    // AutoMQ inject start
+    /**
+     * Given a persisted controlled shutdown whose heartbeat soft state was lost, when a resumed
+     * drain batch completes, then its real metadata offset restores and advances the barrier.
+     */
+    @Test
+    @Tag("S3Unit")
+    public void testAdvanceControlledShutdownOffsetRestoresSoftState() {
+        BrokerHeartbeatManager manager = newBrokerHeartbeatManager();
+        manager.register(0, false);
+        manager.register(1, false);
+        manager.touch(0, false, 98);
+        manager.touch(1, false, 100);
+        assertEquals(BrokerControlState.UNFENCED, manager.currentBrokerState(0));
+        assertEquals(98L, manager.lowestActiveOffset());
+
+        manager.advanceControlledShutdownOffset(0, 101);
+
+        assertEquals(BrokerControlState.CONTROLLED_SHUTDOWN, manager.currentBrokerState(0));
+        assertEquals(OptionalLong.of(101), manager.controlledShutdownOffset(0));
+        assertEquals(100L, manager.lowestActiveOffset());
+    }
+    // AutoMQ inject end
 
     @Test
     public void testBrokerHeartbeatStateList() {

--- a/metadata/src/test/java/org/apache/kafka/controller/ElasticReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ElasticReplicationControlManagerTest.java
@@ -19,6 +19,427 @@
 
 package org.apache.kafka.controller;
 
-// TODO: add test for partition change
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.es.ElasticStreamSwitch;
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.metadata.BrokerRegistrationInControlledShutdownChange;
+import org.apache.kafka.metadata.FakeKafkaConfigSchema;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.placement.StripedReplicaPlacer;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.server.util.MockRandom;
+import org.apache.kafka.timeline.SnapshotRegistry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.protocol.Errors.NONE;
+import static org.apache.kafka.controller.ControllerRequestContextUtil.anonymousContextFor;
+import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Tag("S3Unit")
+@Timeout(40)
 public class ElasticReplicationControlManagerTest {
+    private TestContext context;
+
+    @BeforeEach
+    public void setUp() {
+        ElasticStreamSwitch.setSwitch(false);
+        context = new TestContext();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ElasticStreamSwitch.setSwitch(false);
+    }
+
+    /**
+     * Given a leaderless Elastic Partition assigned to an active Broker, when another Broker
+     * unfences, then the in-progress assignment is preserved for the active owner.
+     */
+    @Test
+    public void testUnfencePreservesLeaderlessPartitionAssignedToActiveBroker() {
+        context.registerBrokers(0, 1, 2);
+        context.unfenceBrokers(0, 1);
+        Uuid topicId = context.createTopic("active-owner", 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.fenceBroker(0);
+        context.assertPartition(topicId, NO_LEADER, 1);
+
+        context.unfenceBrokers(2);
+
+        context.assertPartition(topicId, NO_LEADER, 1);
+    }
+
+    /**
+     * Given a leaderless Elastic Partition whose assigned Broker is fenced, when a new Broker
+     * unfences, then the abandoned assignment is claimed to recover from scale zero.
+     */
+    @Test
+    public void testUnfenceClaimsPartitionAssignedToFencedBroker() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0);
+        Uuid topicId = context.createTopic("fenced-owner", 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.fenceBroker(0);
+        context.assertPartition(topicId, NO_LEADER, 0);
+
+        context.unfenceBrokers(1);
+
+        context.assertPartition(topicId, NO_LEADER, 1);
+    }
+
+    /**
+     * Given a leaderless Elastic Partition whose assigned Broker is in controlled shutdown,
+     * when another Broker unfences, then the shutting-down owner is treated as inactive.
+     */
+    @Test
+    public void testUnfenceClaimsPartitionAssignedToBrokerInControlledShutdown() {
+        context.registerBrokers(0, 1, 2);
+        context.unfenceBrokers(0, 1);
+        Uuid topicId = context.createTopic("shutting-down-owner", 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.fenceBroker(0);
+        context.assertPartition(topicId, NO_LEADER, 1);
+        context.putBrokerInControlledShutdown(1);
+
+        context.unfenceBrokers(2);
+
+        context.assertPartition(topicId, NO_LEADER, 2);
+    }
+
+    /**
+     * Given an active Elastic Broker that still leads a Partition, when it enters controlled
+     * shutdown, then the Controller records the Broker state without migrating the Partition.
+     */
+    @Test
+    public void testControlledShutdownDefersElasticPartitionMigration() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        Uuid topicId = context.createTopic("deferred-drain", 0);
+        ElasticStreamSwitch.setSwitch(true);
+
+        List<ApiMessageAndVersion> records = context.controlledShutdownRecords(0);
+
+        assertEquals(1, records.size());
+        assertEquals(BrokerRegistrationChangeRecord.class, records.get(0).message().getClass());
+        context.replay(records);
+        context.assertPartition(topicId, 0, 0);
+    }
+
+    /**
+     * Given an Elastic Broker leading 205 Partitions in one Topic, when three drain ticks run,
+     * then the fixed minimum target splits the Topic into batches of 100, 100, and 5.
+     */
+    @Test
+    public void testDrainUsesFixedBatchTargetAndSplitsTopicAtBoundary() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        Uuid topicId = context.createTopic("paced-drain", 205, 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.replay(context.controlledShutdownRecords(0));
+
+        List<ApiMessageAndVersion> firstBatch = context.drainBroker(0);
+        assertEquals(100, firstBatch.size());
+        context.assertPartitionChangesTarget(firstBatch, topicId, 1);
+        context.replay(firstBatch);
+
+        List<ApiMessageAndVersion> secondBatch = context.drainBroker(0);
+        assertEquals(100, secondBatch.size());
+        context.assertPartitionChangesTarget(secondBatch, topicId, 1);
+        context.replay(secondBatch);
+
+        List<ApiMessageAndVersion> finalBatch = context.drainBroker(0);
+        assertEquals(5, finalBatch.size());
+        context.assertPartitionChangesTarget(finalBatch, topicId, 1);
+    }
+
+    /**
+     * Given an Elastic Broker leading 6001 Partitions, when a drain receives a scaled target,
+     * then record generation honors that 101-Partition batch boundary.
+     */
+    @Test
+    public void testDrainHonorsScaledBatchTarget() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        context.createTopic("scaled-drain", 6001, 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.replay(context.controlledShutdownRecords(0));
+
+        List<ApiMessageAndVersion> batch = context.drainBroker(0, 101);
+
+        assertEquals(101, batch.size());
+    }
+
+    /**
+     * Given an Elastic drain with no active target, when a batch is generated, then the existing
+     * leader-election fallback makes the Partition leaderless without changing its assignment.
+     */
+    @Test
+    public void testDrainWithoutTargetUsesExistingLeaderElectionFallback() {
+        context.registerBrokers(0);
+        context.unfenceBrokers(0);
+        Uuid topicId = context.createTopic("no-target", 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.replay(context.controlledShutdownRecords(0));
+
+        List<ApiMessageAndVersion> batch = context.drainBroker(0);
+
+        assertEquals(1, batch.size());
+        context.replay(batch);
+        context.assertPartition(topicId, NO_LEADER, 0);
+    }
+
+    /**
+     * Given Partitions from two Topics fit only partially in one batch, when a drain tick runs,
+     * then Topic grouping is retained and the second Topic is split at the fixed boundary.
+     */
+    @Test
+    public void testDrainKeepsTopicGroupsContiguousWithinBatch() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        Uuid firstTopicId = context.createTopic("first-topic", 60, 0);
+        Uuid secondTopicId = context.createTopic("second-topic", 60, 0);
+        ElasticStreamSwitch.setSwitch(true);
+        context.replay(context.controlledShutdownRecords(0));
+
+        List<ApiMessageAndVersion> batch = context.drainBroker(0);
+
+        assertEquals(100, batch.size());
+        int firstTopicChanges = context.countPartitionChanges(batch, firstTopicId);
+        int secondTopicChanges = context.countPartitionChanges(batch, secondTopicId);
+        assertEquals(100, firstTopicChanges + secondTopicChanges);
+        assertEquals(60, Math.max(firstTopicChanges, secondTopicChanges));
+        assertEquals(40, Math.min(firstTopicChanges, secondTopicChanges));
+        context.assertTopicChangesContiguous(batch);
+    }
+
+    /**
+     * Given the non-Elastic storage path, when a Broker enters controlled shutdown,
+     * then the upstream all-at-once Partition migration remains unchanged.
+     */
+    @Test
+    public void testNonElasticControlledShutdownMigratesImmediately() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        context.createTopic("kafka-compatible", 0);
+
+        List<ApiMessageAndVersion> records = context.controlledShutdownRecords(0);
+
+        assertEquals(2, records.size());
+        assertEquals(PartitionChangeRecord.class, records.get(1).message().getClass());
+    }
+
+    /**
+     * Given the Elastic storage path, when a Broker is fenced unexpectedly,
+     * then failure recovery migrates its Partition immediately rather than waiting for a tick.
+     */
+    @Test
+    public void testElasticFencingStillMigratesImmediately() {
+        context.registerBrokers(0, 1);
+        context.unfenceBrokers(0, 1);
+        Uuid topicId = context.createTopic("fencing-recovery", 0);
+        ElasticStreamSwitch.setSwitch(true);
+
+        context.fenceBroker(0);
+
+        context.assertPartition(topicId, NO_LEADER, 1);
+    }
+
+    private static final class TestContext {
+        private final SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+        private final ClusterControlManager clusterControl;
+        private final ConfigurationControlManager configurationControl;
+        private final ReplicationControlManager replicationControl;
+
+        private TestContext() {
+            LogContext logContext = new LogContext();
+            FeatureControlManager featureControl = new FeatureControlManager.Builder()
+                .setSnapshotRegistry(snapshotRegistry)
+                .setQuorumFeatures(new QuorumFeatures(0,
+                    QuorumFeatures.defaultFeatureMap(true), Collections.singletonList(0)))
+                .setMetadataVersion(MetadataVersion.latestTesting())
+                .build();
+            configurationControl = new ConfigurationControlManager.Builder()
+                .setSnapshotRegistry(snapshotRegistry)
+                .setStaticConfig(Collections.emptyMap())
+                .setKafkaConfigSchema(FakeKafkaConfigSchema.INSTANCE)
+                .build();
+            clusterControl = new ClusterControlManager.Builder()
+                .setLogContext(logContext)
+                .setTime(new MockTime())
+                .setSnapshotRegistry(snapshotRegistry)
+                .setSessionTimeoutNs(TimeUnit.SECONDS.toNanos(1))
+                .setReplicaPlacer(new StripedReplicaPlacer(new MockRandom()))
+                .setFeatureControlManager(featureControl)
+                .setBrokerUncleanShutdownHandler((brokerId, records) -> { })
+                .setQuorumVoters(Collections.emptyList())
+                .build();
+            replicationControl = new ReplicationControlManager.Builder()
+                .setSnapshotRegistry(snapshotRegistry)
+                .setLogContext(logContext)
+                .setMaxElectionsPerImbalance(Integer.MAX_VALUE)
+                .setConfigurationControl(configurationControl)
+                .setClusterControl(clusterControl)
+                .setCreateTopicPolicy(Optional.empty())
+                .setFeatureControl(featureControl)
+                .build();
+            clusterControl.activate();
+        }
+
+        private void registerBrokers(int... brokerIds) {
+            for (int brokerId : brokerIds) {
+                RegisterBrokerRecord record = new RegisterBrokerRecord()
+                    .setBrokerId(brokerId)
+                    .setBrokerEpoch(brokerEpoch(brokerId))
+                    .setLogDirs(Collections.singletonList(Uuid.randomUuid()));
+                replay(Collections.singletonList(new ApiMessageAndVersion(record, (short) 3)));
+            }
+        }
+
+        private void unfenceBrokers(int... brokerIds) {
+            List<ApiMessageAndVersion> records = new ArrayList<>();
+            for (int brokerId : brokerIds) {
+                replicationControl.handleBrokerUnfenced(brokerId, brokerEpoch(brokerId), records);
+            }
+            replay(records);
+        }
+
+        private void fenceBroker(int brokerId) {
+            List<ApiMessageAndVersion> records = new ArrayList<>();
+            replicationControl.handleBrokerFenced(brokerId, records);
+            replay(records);
+        }
+
+        private void putBrokerInControlledShutdown(int brokerId) {
+            BrokerRegistrationChangeRecord record = new BrokerRegistrationChangeRecord()
+                .setBrokerId(brokerId)
+                .setBrokerEpoch(brokerEpoch(brokerId))
+                .setInControlledShutdown(
+                    BrokerRegistrationInControlledShutdownChange.IN_CONTROLLED_SHUTDOWN.value());
+            replay(Collections.singletonList(new ApiMessageAndVersion(record, (short) 1)));
+        }
+
+        private List<ApiMessageAndVersion> controlledShutdownRecords(int brokerId) {
+            List<ApiMessageAndVersion> records = new ArrayList<>();
+            replicationControl.handleBrokerInControlledShutdown(
+                brokerId, brokerEpoch(brokerId), records);
+            return records;
+        }
+
+        private List<ApiMessageAndVersion> drainBroker(int brokerId) {
+            return drainBroker(brokerId, 100);
+        }
+
+        private List<ApiMessageAndVersion> drainBroker(int brokerId, int batchTarget) {
+            return replicationControl.maybeDrainControlledShutdownBroker(brokerId, batchTarget).records();
+        }
+
+        private Uuid createTopic(String name, int brokerId) {
+            return createTopic(name, 1, brokerId);
+        }
+
+        private Uuid createTopic(String name, int partitionCount, int brokerId) {
+            CreateTopicsRequestData request = new CreateTopicsRequestData();
+            CreatableTopic creatableTopic = new CreatableTopic()
+                .setName(name)
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1);
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                creatableTopic.assignments().add(new CreatableReplicaAssignment()
+                    .setPartitionIndex(partitionId)
+                    .setBrokerIds(Collections.singletonList(brokerId)));
+            }
+            request.topics().add(creatableTopic);
+            ControllerResult<CreateTopicsResponseData> result = replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Collections.singleton(name));
+            CreatableTopicResult topic = result.response().topics().find(name);
+            assertNotNull(topic);
+            assertEquals(NONE.code(), topic.errorCode());
+            replay(result.records());
+            return topic.topicId();
+        }
+
+        private void assertPartitionChangesTarget(
+            List<ApiMessageAndVersion> records,
+            Uuid topicId,
+            int targetBroker
+        ) {
+            for (ApiMessageAndVersion apiMessageAndVersion : records) {
+                PartitionChangeRecord record = (PartitionChangeRecord) apiMessageAndVersion.message();
+                assertEquals(topicId, record.topicId());
+                assertEquals(Collections.singletonList(targetBroker), record.replicas());
+                assertEquals(Collections.singletonList(targetBroker), record.isr());
+                assertEquals(NO_LEADER, record.leader());
+            }
+        }
+
+        private int countPartitionChanges(List<ApiMessageAndVersion> records, Uuid topicId) {
+            int count = 0;
+            for (ApiMessageAndVersion record : records) {
+                if (((PartitionChangeRecord) record.message()).topicId().equals(topicId)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        private void assertTopicChangesContiguous(List<ApiMessageAndVersion> records) {
+            Uuid previousTopicId = null;
+            Uuid completedTopicId = null;
+            for (ApiMessageAndVersion apiMessageAndVersion : records) {
+                Uuid topicId = ((PartitionChangeRecord) apiMessageAndVersion.message()).topicId();
+                if (previousTopicId != null && !previousTopicId.equals(topicId)) {
+                    completedTopicId = previousTopicId;
+                }
+                if (completedTopicId != null) {
+                    assertFalse(completedTopicId.equals(topicId));
+                }
+                previousTopicId = topicId;
+            }
+        }
+
+        private void assertPartition(Uuid topicId, int leader, int assignedBroker) {
+            PartitionRegistration partition = replicationControl.getPartition(topicId, 0);
+            assertNotNull(partition);
+            assertEquals(leader, partition.leader);
+            assertArrayEquals(new int[] {assignedBroker}, partition.replicas);
+            assertArrayEquals(new int[] {assignedBroker}, partition.isr);
+        }
+
+        private void replay(List<ApiMessageAndVersion> records) {
+            RecordTestUtils.replayAll(clusterControl, records);
+            RecordTestUtils.replayAll(configurationControl, records);
+            RecordTestUtils.replayAll(replicationControl, records);
+        }
+
+        private static long brokerEpoch(int brokerId) {
+            return 100L + brokerId;
+        }
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/GentleControlledShutdownControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/GentleControlledShutdownControlManagerTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.es.ElasticStreamSwitch;
+import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("S3Unit")
+class GentleControlledShutdownControlManagerTest {
+    /**
+     * Given a periodic gentle-drain trigger with no drain work, when Elastic mode is enabled,
+     * then the active Controller runs a record-free scan without a heartbeat wakeup.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPeriodicTriggerRunsIdleScanWithoutHeartbeatWakeup() throws Exception {
+        QuorumController controller = mock(QuorumController.class);
+        ClusterControlManager clusterControl = mock(ClusterControlManager.class);
+        ReplicationControlManager replicationControl = mock(ReplicationControlManager.class);
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<Object> scheduledFuture = mock(ScheduledFuture.class);
+        doReturn(scheduledFuture).when(scheduler)
+            .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+        when(clusterControl.brokerRegistrations()).thenReturn(Map.of());
+        when(controller.appendWriteEvent(
+            any(), any(OptionalLong.class), any(QuorumController.ControllerWriteOperation.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        try (GentleControlledShutdownControlManager manager =
+                 new GentleControlledShutdownControlManager(
+                     controller, clusterControl, replicationControl, scheduler)) {
+            var taskCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+            verify(scheduler).scheduleWithFixedDelay(
+                taskCaptor.capture(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+            ElasticStreamSwitch.setSwitch(true);
+            manager.activate();
+            when(controller.isActive()).thenReturn(true);
+            taskCaptor.getValue().run();
+            var operationCaptor = org.mockito.ArgumentCaptor
+                .forClass(QuorumController.ControllerWriteOperation.class);
+            verify(controller).appendWriteEvent(
+                eq("gentleControlledShutdownDrain"), eq(OptionalLong.empty()),
+                operationCaptor.capture());
+            assertTrue(operationCaptor.getValue().generateRecordsAndResult().records().isEmpty());
+
+            when(controller.isActive()).thenReturn(false);
+            taskCaptor.getValue().run();
+            verify(controller).appendWriteEvent(
+                eq("gentleControlledShutdownDrain"), eq(OptionalLong.empty()),
+                any(QuorumController.ControllerWriteOperation.class));
+        } finally {
+            ElasticStreamSwitch.setSwitch(false);
+        }
+    }
+
+    /**
+     * Given a scheduled drain whose Controller event is still pending, when the scheduler task
+     * runs, then the scheduler does not block waiting for the Controller event.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testSchedulerDoesNotWaitForControllerEventCompletion() throws Exception {
+        QuorumController controller = mock(QuorumController.class);
+        ClusterControlManager clusterControl = mock(ClusterControlManager.class);
+        ReplicationControlManager replicationControl = mock(ReplicationControlManager.class);
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<Object> scheduledFuture = mock(ScheduledFuture.class);
+        doReturn(scheduledFuture).when(scheduler)
+            .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+        BrokerRegistration broker = controlledShutdownBroker(0, 1L);
+        when(clusterControl.brokerRegistrations()).thenReturn(Map.of(0, broker));
+        when(replicationControl.hasControlledShutdownLeaders(0)).thenReturn(true);
+        when(controller.isActive()).thenReturn(true);
+        CompletableFuture<Void> controllerEvent = new CompletableFuture<>();
+        when(controller.appendWriteEvent(
+            any(), any(OptionalLong.class), any(QuorumController.ControllerWriteOperation.class)))
+            .thenReturn(controllerEvent);
+
+        try (GentleControlledShutdownControlManager manager =
+                 new GentleControlledShutdownControlManager(
+                     controller, clusterControl, replicationControl, scheduler)) {
+            var taskCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+            verify(scheduler).scheduleWithFixedDelay(
+                taskCaptor.capture(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+            ElasticStreamSwitch.setSwitch(true);
+            manager.activate();
+
+            CompletableFuture<Void> schedulerRun = CompletableFuture.runAsync(taskCaptor.getValue());
+            schedulerRun.get(1, TimeUnit.SECONDS);
+            assertFalse(controllerEvent.isDone());
+            verify(controller).appendWriteEvent(eq("gentleControlledShutdownDrain"),
+                eq(OptionalLong.empty()), any(QuorumController.ControllerWriteOperation.class));
+        } finally {
+            ElasticStreamSwitch.setSwitch(false);
+        }
+    }
+
+    /**
+     * Given two Brokers are draining concurrently, when one periodic operation runs, then each
+     * Broker receives its independently computed batch and shares the real batch-end barrier.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testConcurrentBrokersReceiveIndependentBatches() throws Exception {
+        QuorumController controller = mock(QuorumController.class);
+        ClusterControlManager clusterControl = mock(ClusterControlManager.class);
+        ReplicationControlManager replicationControl = mock(ReplicationControlManager.class);
+        BrokerHeartbeatManager heartbeatManager = mock(BrokerHeartbeatManager.class);
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<Object> scheduledFuture = mock(ScheduledFuture.class);
+        BrokerRegistration firstBroker = controlledShutdownBroker(0, 10L);
+        BrokerRegistration secondBroker = controlledShutdownBroker(1, 20L);
+        ApiMessageAndVersion firstRecord = mock(ApiMessageAndVersion.class);
+        ApiMessageAndVersion secondRecord = mock(ApiMessageAndVersion.class);
+        doReturn(scheduledFuture).when(scheduler)
+            .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+        when(clusterControl.brokerRegistrations()).thenReturn(Map.of(0, firstBroker, 1, secondBroker));
+        when(clusterControl.heartbeatManager()).thenReturn(heartbeatManager);
+        when(replicationControl.hasControlledShutdownLeaders(0)).thenReturn(true);
+        when(replicationControl.hasControlledShutdownLeaders(1)).thenReturn(true);
+        when(replicationControl.controlledShutdownLeaderCount(0)).thenReturn(150);
+        when(replicationControl.controlledShutdownLeaderCount(1)).thenReturn(6001);
+        when(replicationControl.maybeDrainControlledShutdownBroker(0, 100))
+            .thenReturn(ControllerResult.of(List.of(firstRecord), null));
+        when(replicationControl.maybeDrainControlledShutdownBroker(1, 101))
+            .thenReturn(ControllerResult.of(List.of(secondRecord), null));
+        when(controller.isActive()).thenReturn(true);
+        when(controller.appendWriteEvent(
+            any(), any(OptionalLong.class), any(QuorumController.ControllerWriteOperation.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        try (GentleControlledShutdownControlManager manager =
+                 new GentleControlledShutdownControlManager(
+                     controller, clusterControl, replicationControl, scheduler)) {
+            var taskCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+            verify(scheduler).scheduleWithFixedDelay(
+                taskCaptor.capture(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+            ElasticStreamSwitch.setSwitch(true);
+            manager.activate();
+            taskCaptor.getValue().run();
+
+            var operationCaptor = org.mockito.ArgumentCaptor
+                .forClass(QuorumController.ControllerWriteOperation.class);
+            verify(controller).appendWriteEvent(eq("gentleControlledShutdownDrain"),
+                eq(OptionalLong.empty()), operationCaptor.capture());
+            ControllerResult<?> result = operationCaptor.getValue().generateRecordsAndResult();
+            assertEquals(2, result.records().size());
+            assertTrue(result.records().contains(firstRecord));
+            assertTrue(result.records().contains(secondRecord));
+
+            operationCaptor.getValue().processBatchEndOffset(42L);
+            verify(heartbeatManager).advanceControlledShutdownOffset(0, 42L);
+            verify(heartbeatManager).advanceControlledShutdownOffset(1, 42L);
+        } finally {
+            ElasticStreamSwitch.setSwitch(false);
+        }
+    }
+
+    /**
+     * Given a Broker retains leaders across a Controller lifecycle change, when the next tick
+     * runs, then its fixed batch target is recomputed from the remaining leaders.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testLifecycleChangeRecomputesBatchTarget() throws Exception {
+        QuorumController controller = mock(QuorumController.class);
+        ClusterControlManager clusterControl = mock(ClusterControlManager.class);
+        ReplicationControlManager replicationControl = mock(ReplicationControlManager.class);
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<Object> scheduledFuture = mock(ScheduledFuture.class);
+        BrokerRegistration broker = controlledShutdownBroker(0, 10L);
+        doReturn(scheduledFuture).when(scheduler)
+            .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+        when(clusterControl.brokerRegistrations()).thenReturn(Map.of(0, broker));
+        when(replicationControl.hasControlledShutdownLeaders(0)).thenReturn(true);
+        when(replicationControl.controlledShutdownLeaderCount(0)).thenReturn(6001, 5900);
+        when(replicationControl.maybeDrainControlledShutdownBroker(anyInt(), anyInt()))
+            .thenReturn(ControllerResult.of(List.of(), null));
+        when(controller.isActive()).thenReturn(true);
+        when(controller.appendWriteEvent(
+            any(), any(OptionalLong.class), any(QuorumController.ControllerWriteOperation.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        try (GentleControlledShutdownControlManager manager =
+                 new GentleControlledShutdownControlManager(
+                     controller, clusterControl, replicationControl, scheduler)) {
+            var taskCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+            verify(scheduler).scheduleWithFixedDelay(
+                taskCaptor.capture(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+            ElasticStreamSwitch.setSwitch(true);
+            manager.activate();
+
+            taskCaptor.getValue().run();
+            var operationCaptor = org.mockito.ArgumentCaptor
+                .forClass(QuorumController.ControllerWriteOperation.class);
+            verify(controller).appendWriteEvent(any(), any(OptionalLong.class), operationCaptor.capture());
+            operationCaptor.getValue().generateRecordsAndResult();
+            verify(replicationControl).maybeDrainControlledShutdownBroker(0, 101);
+
+            manager.deactivate();
+            manager.activate();
+            clearInvocations(controller, replicationControl);
+            taskCaptor.getValue().run();
+            verify(controller).appendWriteEvent(any(), any(OptionalLong.class), operationCaptor.capture());
+            operationCaptor.getValue().generateRecordsAndResult();
+            verify(replicationControl).maybeDrainControlledShutdownBroker(0, 100);
+        } finally {
+            ElasticStreamSwitch.setSwitch(false);
+        }
+    }
+
+    private static BrokerRegistration controlledShutdownBroker(int brokerId, long brokerEpoch) {
+        BrokerRegistration broker = mock(BrokerRegistration.class);
+        when(broker.id()).thenReturn(brokerId);
+        when(broker.epoch()).thenReturn(brokerEpoch);
+        when(broker.inControlledShutdown()).thenReturn(true);
+        return broker;
+    }
+}


### PR DESCRIPTION
## Why

An AutoMQ Broker can lead a large number of Partitions. Migrating all leadership in one controlled-shutdown heartbeat produces a large metadata burst. Controller changes must also preserve completed progress and continue draining the remaining leadership.

## What

Introduce gentle controlled shutdown that migrates leadership in periodic batches. Multiple Brokers drain concurrently with independent batch budgets, and a newly active Controller reconstructs ephemeral pacing state from the remaining Leader Partitions.

Upstream Kafka controlled-shutdown behavior remains unchanged outside AutoMQ mode.

## How

A dedicated `GentleControlledShutdownControlManager` uses the shared scheduler to submit a Controller write event once per second while the Controller is active. The write event scans persisted controlled-shutdown Broker registrations and drains one independent batch for each Broker.

Each Broker batch target is computed once per Controller lifecycle as the larger of 100 Partitions or approximately one sixtieth of its remaining leaders. Actual Partition changes remain owned by `ReplicationControlManager`, which keeps same-topic work contiguous where possible and advances the controlled-shutdown offset barrier from the committed batch-end offset.

Controller activation and renounce clear ephemeral per-Broker pacing state. Scheduling is non-blocking; inactive Controllers skip submission, and shutdown cancels the manager task without closing the shared scheduler.

## Reviewer notes

Suggested reading order:

1. `GentleControlledShutdownControlManager` for scheduling, lifecycle, concurrent Broker pacing, and barrier advancement.
2. `ReplicationControlManager` for controlled-shutdown deferral and bounded Partition migration.
3. `BrokerHeartbeatManager` for restoring and advancing the ephemeral controlled-shutdown offset barrier.
4. The AutoMQ-specific `S3Unit` tests for fixed and scaled batches, topic grouping, concurrent drains, lifecycle recomputation, and Kafka-compatible fallback behavior.