### PR TITLE
fix(cli): negotiate broker API versions for backward compatibility(#3494)

### DIFF
--- a/automq-shell/src/main/java/com/automq/shell/util/CLIUtils.java
+++ b/automq-shell/src/main/java/com/automq/shell/util/CLIUtils.java
@@ -72,7 +72,7 @@ public class CLIUtils {
             config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
             config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
             time,
-            false,
+            true,
             new ApiVersions(),
             logContext,
             MetadataRecoveryStrategy.NONE


### PR DESCRIPTION
Backport #3494 to main.

## Summary

- enable broker API version discovery in CLIUtils
- negotiate request versions before sending AutoMQ-specific requests
- allow the 1.7 client to downgrade GET_KVS to v0 for older data planes
- update the standard Docker Compose and Bitnami examples to 1.7.3-rc0