### PR TITLE
fix(s3stream): account for small record cache overhead

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -73,6 +73,8 @@ public class LogCache {
         .operation(MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_HIT);
     private static final DeltaHistogram READ_STORAGE_LOG_CACHE_MISS_LATENCY = OperationLatencyMetrics
         .operation(MetricsLevel.INFO, S3Operation.READ_STORAGE_LOG_CACHE, S3StreamMetricsConstant.LABEL_STATUS_MISS);
+    // Controlling the overhead of each cached record can prevent excessive heap memory usage for small-sized records
+    private static final int RECORD_OVERHEAD = 1024;
     static final int MERGE_BLOCK_THRESHOLD = 8;
     final List<LogCacheBlock> blocks = new ArrayList<>();
     final AtomicInteger blockCount = new AtomicInteger(1);
@@ -123,7 +125,7 @@ public class LogCache {
             readLock.unlock();
         }
         if (added) {
-            size.addAndGet(recordBatch.occupiedSize());
+            size.addAndGet(recordBatch.size() + RECORD_OVERHEAD);
         }
         APPEND_STORAGE_LOG_CACHE_LATENCY.record(TimerUtil.timeElapsedSince(startTime, TimeUnit.NANOSECONDS));
         return added;
@@ -484,7 +486,7 @@ public class LogCache {
                 overflow = true;
                 return false;
             }
-            size.addAndGet(recordBatch.occupiedSize());
+            size.addAndGet(recordBatch.size() + RECORD_OVERHEAD);
             return true;
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/model/StreamRecordBatch.java
@@ -39,7 +39,6 @@ import static com.automq.stream.s3.StreamRecordBatchCodec.PAYLOAD_POS;
 import static com.automq.stream.s3.StreamRecordBatchCodec.STREAM_ID_POS;
 
 public class StreamRecordBatch implements Comparable<StreamRecordBatch>, ComparableItem<Long> {
-    private static final int OBJECT_OVERHEAD = 48 /* fields */ + 48 /* ByteBuf payload */ + 48 /* ByteBuf encoded */;
     // Cache the frequently used fields
     private final long baseOffset;
     private final int count;
@@ -89,10 +88,6 @@ public class StreamRecordBatch implements Comparable<StreamRecordBatch>, Compara
 
     public int size() {
         return encoded.getInt(encoded.readerIndex() + PAYLOAD_LENGTH_POS);
-    }
-
-    public int occupiedSize() {
-        return size() + OBJECT_OVERHEAD;
     }
 
     public void retain() {

--- a/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/WALRecoveryTest.java
@@ -117,8 +117,8 @@ public class WALRecoveryTest {
 
     @Test
     public void testSegmentedRecovery() {
-        // Each record occupies ~145 bytes (1 byte payload + 144 overhead).
-        // With maxCacheSize=200, a block becomes full after 2 records (290 bytes >= 200).
+        // Each record occupies 1025 bytes (1 byte payload + 1 KiB cache overhead).
+        // With maxCacheSize=2000, a block becomes full after 2 records (2050 bytes >= 2000).
         List<RecoverResult> recoverResults = List.of(
             new TestRecoverResult(newRecord(42L, 10L)),
             new TestRecoverResult(newRecord(42L, 11L)),
@@ -129,7 +129,7 @@ public class WALRecoveryTest {
 
         Map<Long, Long> streamEndOffsets = new HashMap<>(Map.of(42L, 10L));
         List<LogCache.LogCacheBlock> results = new ArrayList<>();
-        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 200L, LOGGER, results::add);
+        WALRecovery.recover(recoverResults.iterator(), streamEndOffsets, 2_000L, LOGGER, results::add);
         assertEquals(3, results.size());
 
         // block 0: [10, 11] — full


### PR DESCRIPTION
## Why

Log cache capacity accounting only included the encoded record size plus a small object estimate. Workloads with very small records can retain substantially more heap per record than this estimate, allowing the cache to admit too many records and consume excessive heap.

## What

Charge a conservative 1 KiB overhead for every record admitted into the log cache, in addition to its encoded size.

## How

LogCache owns the cache-specific accounting policy and applies the same fixed overhead in both the active cache and individual cache blocks. StreamRecordBatch no longer exposes an object-overhead estimate because that estimate is specific to cache admission rather than the record model itself.

## Reviewer notes

Start with LogCache to review the updated capacity accounting in both insertion paths, then review StreamRecordBatch for removal of the cache-specific occupied-size API.

## Verification

- `./gradlew --build-cache s3stream:test --tests com.automq.stream.s3.cache.LogCacheTest`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`