### PR TITLE
fix(s3stream): burst WAL uploads on cache backoff

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -159,7 +159,7 @@ public class S3Storage implements Storage {
      */
     private final AtomicBoolean forceUploadScheduled = new AtomicBoolean();
     /**
-     * A lock to ensure only one thread can trigger {@link #forceUpload()} in {@link #forceUploadCallback()}
+     * A flag to trigger another force upload after the scheduled one completes.
      */
     private final AtomicBoolean needForceUpload = new AtomicBoolean();
     private final ScheduledExecutorService backgroundExecutor = Threads.newSingleThreadScheduledExecutor(
@@ -434,6 +434,7 @@ public class S3Storage implements Storage {
             return true;
         }
         if (!tryAcquirePermit()) {
+            maybeForceUpload();
             if (!fromBackoff) {
                 backoffRecords.offer(request);
             }
@@ -617,21 +618,16 @@ public class S3Storage implements Storage {
      * Limit the number of inflight force upload tasks to 1 to avoid too many S3 objects.
      */
     private void maybeForceUpload() {
-        if (hasInflightForceUploadTask()) {
-            // There is already an inflight force upload task, trigger another one later after it completes.
+        if (!forceUploadScheduled.compareAndSet(false, true)) {
             needForceUpload.set(true);
             return;
         }
-        if (forceUploadScheduled.compareAndSet(false, true)) {
-            forceUpload();
-        } else {
-            // There is already a force upload task scheduled, do nothing.
-            needForceUpload.set(true);
-        }
-    }
-
-    private boolean hasInflightForceUploadTask() {
-        return inflightWALUploadTasks.stream().anyMatch(it -> it.force);
+        forceUpload().whenComplete((nil, ignored) -> {
+            forceUploadScheduled.set(false);
+            if (needForceUpload.compareAndSet(true, false)) {
+                maybeForceUpload();
+            }
+        });
     }
 
     /**
@@ -653,8 +649,8 @@ public class S3Storage implements Storage {
         return lazyCommit.awaitTrim ? lazyCommit.trimCf : lazyCommit.commitCf;
     }
 
-    private void notifyLazyUpload(List<LazyCommit> tasks) {
-        CompletableFuture.allOf(inflightWALUploadTasks.stream().map(t -> t.cf).collect(Collectors.toList()).toArray(new CompletableFuture[0]))
+    private void notifyLazyUpload(List<LazyCommit> tasks, List<DeltaWALUploadTaskContext> uploadTasks) {
+        CompletableFuture.allOf(uploadTasks.stream().map(t -> t.cf).toArray(CompletableFuture[]::new))
             .whenComplete((nil, ex) -> {
                 for (LazyCommit task : tasks) {
                     if (ex != null) {
@@ -665,7 +661,7 @@ public class S3Storage implements Storage {
                 }
             });
 
-        CompletableFuture.allOf(inflightWALUploadTasks.stream().map(t -> t.trimCf).collect(Collectors.toList()).toArray(new CompletableFuture[0]))
+        CompletableFuture.allOf(uploadTasks.stream().map(t -> t.trimCf).toArray(CompletableFuture[]::new))
             .whenComplete((nil, ex) -> {
                 for (LazyCommit task : tasks) {
                     if (ex != null) {
@@ -678,18 +674,7 @@ public class S3Storage implements Storage {
     }
 
     private CompletableFuture<Void> forceUpload() {
-        CompletableFuture<Void> cf = forceUpload(LogCache.MATCH_ALL_STREAMS);
-        cf.whenComplete((nil, ignored) -> forceUploadCallback());
-        return cf;
-    }
-
-    private void forceUploadCallback() {
-        // Reset the force upload flag after the task completes.
-        forceUploadScheduled.set(false);
-        if (needForceUpload.compareAndSet(true, false)) {
-            // Force upload needs to be triggered again.
-            forceUpload();
-        }
+        return forceUpload(LogCache.MATCH_ALL_STREAMS);
     }
 
     /**
@@ -719,6 +704,17 @@ public class S3Storage implements Storage {
             }
         });
         return cf;
+    }
+
+    private void burstInflightUploadTasks() {
+        inflightWALUploadTasks.forEach(context -> {
+            synchronized (context) {
+                context.force = true;
+                if (context.task != null) {
+                    context.task.burst();
+                }
+            }
+        });
     }
 
     @Override
@@ -770,8 +766,6 @@ public class S3Storage implements Storage {
 
     CompletableFuture<Void> uploadDeltaWAL(long streamId, boolean force) {
         CompletableFuture<Void> cf;
-        List<LazyCommit> lazyUploadTasks = new ArrayList<>();
-        lazyUploadQueue.drainTo(lazyUploadTasks);
 
         synchronized (deltaWALCache) {
             Optional<LogCache.LogCacheBlock> blockOpt = deltaWALCache.archiveCurrentBlockIfContains(streamId);
@@ -784,10 +778,10 @@ public class S3Storage implements Storage {
             } else {
                 cf = CompletableFuture.completedFuture(null);
             }
+            if (force) {
+                burstInflightUploadTasks();
+            }
         }
-
-        // notify lazy upload tasks
-        notifyLazyUpload(lazyUploadTasks);
         return cf;
     }
 
@@ -807,18 +801,12 @@ public class S3Storage implements Storage {
         context.cf = cf;
         inflightWALUploadTasks.add(context);
 
+        List<LazyCommit> lazyUploadTasks = new ArrayList<>();
+        lazyUploadQueue.drainTo(lazyUploadTasks);
+        notifyLazyUpload(lazyUploadTasks, new ArrayList<>(inflightWALUploadTasks));
+
         long size = context.cache.size();
         pendingUploadBytes.addAndGet(size);
-
-        if (context.force) {
-            // trigger previous task burst.
-            inflightWALUploadTasks.forEach(ctx -> {
-                ctx.force = true;
-                if (ctx.task != null) {
-                    ctx.task.burst();
-                }
-            });
-        }
 
         backgroundExecutor.execute(() -> FutureUtil.exec(() -> uploadDeltaWAL0(context), cf, LOGGER, "uploadDeltaWAL"));
         cf.whenComplete((nil, ex) -> {
@@ -833,19 +821,21 @@ public class S3Storage implements Storage {
     }
 
     private void uploadDeltaWAL0(DeltaWALUploadTaskContext context) {
-        // calculate upload rate
-        long elapsed = System.currentTimeMillis() - context.cache.createdTimestamp();
-        double rate;
-        if (context.force || elapsed <= 100L) {
-            rate = Long.MAX_VALUE;
-        } else {
-            rate = context.cache.size() * 1000.0 / Math.min(20000L, elapsed);
-            if (rate > maxDataWriteRate) {
-                maxDataWriteRate = rate;
+        synchronized (context) {
+            // calculate upload rate
+            long elapsed = System.currentTimeMillis() - context.cache.createdTimestamp();
+            double rate;
+            if (context.force || elapsed <= 100L) {
+                rate = Long.MAX_VALUE;
+            } else {
+                rate = context.cache.size() * 1000.0 / Math.min(20000L, elapsed);
+                if (rate > maxDataWriteRate) {
+                    maxDataWriteRate = rate;
+                }
+                rate = maxDataWriteRate;
             }
-            rate = maxDataWriteRate;
+            context.task = newUploadWriteAheadLogTask(context.cache.records(), objectManager, rate);
         }
-        context.task = newUploadWriteAheadLogTask(context.cache.records(), objectManager, rate);
         boolean walObjectPrepareQueueEmpty = walPrepareQueue.isEmpty();
         walPrepareQueue.add(context);
         if (!walObjectPrepareQueueEmpty) {

--- a/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/S3StorageTest.java
@@ -19,6 +19,7 @@
 
 package com.automq.stream.s3;
 
+import com.automq.stream.Context;
 import com.automq.stream.api.ReadOptions;
 import com.automq.stream.api.exceptions.ErrorCode;
 import com.automq.stream.api.exceptions.StreamClientException;
@@ -56,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -488,6 +490,72 @@ public class S3StorageTest {
         assertEquals(233L, range.getStreamId());
         assertEquals(10L, range.getStartOffset());
         assertEquals(12L, range.getEndOffset());
+    }
+
+    /**
+     * Given archived uploads consume the full WAL cache and the active block is empty, when another append backs off,
+     * then the existing upload bursts without creating an empty upload task.
+     */
+    @Test
+    public void testCacheFullBurstsInflightUploadWhenActiveBlockIsEmpty() throws Exception {
+        Config smallCacheConfig = new Config();
+        smallCacheConfig.blockCacheSize(0);
+        smallCacheConfig.walCacheSize(128);
+        smallCacheConfig.walUploadThreshold(64);
+        UploadWriteAheadLogTask uploadTask = mock(UploadWriteAheadLogTask.class);
+        CompletableFuture<Long> prepareFuture = new CompletableFuture<>();
+        Mockito.when(uploadTask.prepare()).thenReturn(prepareFuture);
+        Mockito.when(uploadTask.upload()).thenReturn(CompletableFuture.completedFuture(
+            new CommitStreamSetObjectRequest()));
+        Mockito.when(uploadTask.commit()).thenReturn(CompletableFuture.completedFuture(null));
+        AtomicInteger createdUploadTaskCount = new AtomicInteger();
+        S3Storage smallCacheStorage = new S3Storage(smallCacheConfig, wal, streamManager, objectManager, blockCache,
+            objectStorage, storageFailureHandler) {
+            @Override
+            protected UploadWriteAheadLogTask newUploadWriteAheadLogTask(
+                Map<Long, List<StreamRecordBatch>> streamRecordsMap,
+                ObjectManager objectManager, double rate) {
+                createdUploadTaskCount.incrementAndGet();
+                return uploadTask;
+            }
+        };
+        smallCacheStorage.append(StreamRecordBatch.of(233L, 0, 10L, 1, random(256),
+            DefaultByteBufSupplier.INSTANCE)).get(1, TimeUnit.SECONDS);
+        smallCacheStorage.uploadDeltaWAL();
+        verify(uploadTask, timeout(1000)).prepare();
+
+        CompletableFuture<Void> backedOffAppend = smallCacheStorage.append(newRecord(233L, 11L));
+
+        assertFalse(backedOffAppend.isDone());
+        verify(uploadTask, timeout(1000)).burst();
+        assertEquals(1, createdUploadTaskCount.get());
+
+        prepareFuture.complete(1L);
+
+        backedOffAppend.get(1, TimeUnit.SECONDS);
+        verify(uploadTask).burst();
+        smallCacheStorage.shutdown();
+    }
+
+    /**
+     * Given a lazy commit and an active block that does not contain the forced stream, when that stream is force
+     * uploaded, then the lazy commit remains pending until an upload archives the active block.
+     */
+    @Test
+    public void testStreamForceUploadDoesNotNotifyLazyCommitWithoutMatchingActiveData() throws Exception {
+        Mockito.when(objectManager.prepareObject(eq(1), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(16L));
+        Mockito.when(objectManager.commitStreamSetObject(any()))
+            .thenReturn(CompletableFuture.completedFuture(new CommitStreamSetObjectResponse()));
+        storage.append(newRecord(234L, 10L)).get(1, TimeUnit.SECONDS);
+        CompletableFuture<Void> lazyCommit = Context.instance().confirmWAL().commit(TimeUnit.MINUTES.toMillis(1),
+            false);
+
+        storage.forceUpload(233L).get(1, TimeUnit.SECONDS);
+
+        assertFalse(lazyCommit.isDone());
+        storage.uploadDeltaWAL().get(1, TimeUnit.SECONDS);
+        lazyCommit.get(1, TimeUnit.SECONDS);
     }
 
 }


### PR DESCRIPTION
## Why

When the delta-WAL cache reaches capacity, `S3Storage` queues new appends in the backoff queue but does not force existing WAL uploads to drain faster. A rate-limited historical upload can therefore keep the cache full and extend foreground append latency.

Lazy commits can also be consumed by a stream-scoped force upload even when the active cache block does not contain that stream, completing the lazy barrier before an actual matching upload is created.

## What

- Request a force upload when append admission fails because the delta-WAL cache is full.
- Burst existing inflight WAL uploads even when the active cache block is empty.
- Keep force-upload scheduling single-flight and coalesce one follow-up request.
- Bind lazy commits only after an upload context is actually added, using one stable inflight snapshot for commit and trim barriers.

## How

`maybeForceUpload` now owns the complete scheduling state transition. It acquires `forceUploadScheduled`, starts the force upload, clears the flag on completion, and re-enters itself when `needForceUpload` records another request.

Force upload explicitly bursts all inflight tasks after the active-block archival decision. Access to each context's force flag and task publication is synchronized so a force request either creates an unlimited-rate task or bursts the already-created task.

Lazy commits are drained immediately after a new upload context enters `inflightWALUploadTasks`. If a stream-scoped force upload does not find matching active data, it creates no context and leaves the lazy commits for the next actual upload.

## Reviewer notes

Suggested reading order:

1. `S3Storage.append0` and `maybeForceUpload` for cache-full escalation and single-flight ownership.
2. `uploadDeltaWAL(long, boolean)` and `burstInflightUploadTasks` for active-empty burst behavior.
3. `uploadDeltaWAL(DeltaWALUploadTaskContext)` and `notifyLazyUpload` for lazy barrier binding.
4. `S3StorageTest` for cache-full recovery and stream-scoped lazy-commit coverage.

Validation:

- `./gradlew --build-cache s3stream:test`
- `./gradlew :s3stream:checkstyleMain :s3stream:checkstyleTest`
- `git diff --check`
