### PR TITLE
perf(s3stream): force WAL upload before cache backoff

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -216,12 +216,13 @@ public class S3Storage implements Storage {
         } else {
             delayTrim = new DelayTrim(0);
         }
-        // Adjust the walUploadThreshold to be less than 2/5 of deltaWALCacheSize to avoid the upload speed being slower than the append speed.
-        long walUploadThreadhold = Math.min(deltaWALCacheSize * 2 / 5, config.walUploadThreshold());
-        if (walUploadThreadhold != config.walUploadThreshold()) {
-            LOGGER.info("The configured walUploadThreshold {} is too large, adjust to {}", config.walUploadThreshold(), walUploadThreadhold);
+        // Adjust the walUploadThreshold to be less than 1/3 of deltaWALCacheSize to leave enough cache capacity
+        // for inflight uploads and new appends.
+        long walUploadThreshold = Math.min(deltaWALCacheSize / 3, config.walUploadThreshold());
+        if (walUploadThreshold != config.walUploadThreshold()) {
+            LOGGER.info("The configured walUploadThreshold {} is too large, adjust to {}", config.walUploadThreshold(), walUploadThreshold);
         }
-        this.deltaWALCache = new LogCache(deltaWALCacheSize, walUploadThreadhold, config.maxStreamNumPerStreamSetObject());
+        this.deltaWALCache = new LogCache(deltaWALCacheSize, walUploadThreshold, config.maxStreamNumPerStreamSetObject());
         this.snapshotReadCache = new LogCache(snapshotReadCacheSize, Math.max(snapshotReadCacheSize / 6, 1));
         DELTA_WAL_CACHE_SIZE.record(() -> deltaWALCache.size() + snapshotReadCache.size());
         Context.instance().snapshotReadCache(new SnapshotReadCache(streamManager, snapshotReadCache, objectStorage, linkRecordDecoder));
@@ -434,7 +435,6 @@ public class S3Storage implements Storage {
             return true;
         }
         if (!tryAcquirePermit()) {
-            maybeForceUpload();
             if (!fromBackoff) {
                 backoffRecords.offer(request);
             }
@@ -505,7 +505,26 @@ public class S3Storage implements Storage {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean tryAcquirePermit() {
-        return deltaWALCache.size() < deltaWALCache.capacity();
+        long cacheSize = deltaWALCache.size();
+        long cacheCapacity = deltaWALCache.capacity();
+        long forceUploadThreshold = cacheCapacity * 4 / 5;
+        boolean acquired = cacheSize < cacheCapacity;
+        if (!acquired) {
+            // Keep cache-full escalation as a fallback because concurrent callbacks or a large record may cause the
+            // cache to cross the pressure threshold before the next append checks it.
+            maybeForceUpload();
+            return false;
+        }
+        if (cacheSize >= forceUploadThreshold) {
+            long uploadPressureSize = cacheSize - deltaWALCache.evictableSize();
+            if (uploadPressureSize >= forceUploadThreshold) {
+                // Two upload blocks may occupy about 2/3 of the cache while being rate limited. Force them to burst
+                // when the non-evictable data reaches 80%, leaving 20% capacity for new appends while uploads drain
+                // instead of waiting for the cache to fill and putting foreground appends into backoff.
+                maybeForceUpload();
+            }
+        }
+        return true;
     }
 
     private void tryDrainBackoffRecords() {

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/LogCache.java
@@ -82,6 +82,7 @@ public class LogCache {
     private final long cacheBlockMaxSize;
     private final int maxCacheBlockStreamCount;
     private final AtomicLong size = new AtomicLong();
+    private final AtomicLong evictableSize = new AtomicLong();
     private final Consumer<LogCacheBlock> blockFreeListener;
     // read write lock which guards the <code>LogCache.blocks</code>
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -276,7 +277,13 @@ public class LogCache {
     }
 
     public CompletableFuture<Void> markFree(LogCacheBlock block) {
-        block.free = true;
+        writeLock.lock();
+        try {
+            block.free = true;
+            updateEvictableSize();
+        } finally {
+            writeLock.unlock();
+        }
         tryRealFree();
         CompletableFuture<Void> cf = new CompletableFuture<>();
         LOG_CACHE_ASYNC_EXECUTOR.execute(() -> {
@@ -288,6 +295,17 @@ public class LogCache {
             }
         });
         return cf;
+    }
+
+    private void updateEvictableSize() {
+        long size = 0L;
+        for (LogCacheBlock block : blocks) {
+            if (!block.free) {
+                break;
+            }
+            size += block.size();
+        }
+        evictableSize.set(size);
     }
 
     private void tryRealFree() {
@@ -316,10 +334,11 @@ public class LogCache {
                     break;
                 }
             }
+            size.addAndGet(-freeSize);
+            updateEvictableSize();
         } finally {
             writeLock.unlock();
         }
-        size.addAndGet(-freeSize);
         LOG_CACHE_ASYNC_EXECUTOR.execute(() -> removed.forEach(b -> {
             blockFreeListener.accept(b);
             b.free();
@@ -394,6 +413,13 @@ public class LogCache {
 
     public long capacity() {
         return capacity;
+    }
+
+    /**
+     * Returns the size of the contiguous free blocks at the head of the FIFO cache that can be evicted immediately.
+     */
+    public long evictableSize() {
+        return evictableSize.get();
     }
 
     public void clearStreamRecords(long streamId) {


### PR DESCRIPTION
## Why

WAL uploads are rate limited to smooth object storage traffic. Under steady load, two upload blocks can occupy about two thirds of the delta-WAL cache while new appends continue filling the active block. A traffic increase or slower upload can therefore fill the remaining cache before the existing cache-full path bursts inflight uploads, putting foreground appends into backoff.

## What

- Cap the WAL upload block threshold at one third of the delta-WAL cache.
- Track the FIFO-prefix cache bytes that are immediately evictable when blocks are marked free or removed.
- Trigger `maybeForceUpload` when non-evictable cache pressure reaches 80%, leaving 20% headroom for uploads to drain.
- Keep cache-full force upload as a fallback for large records and concurrent append callbacks, with all cache admission escalation owned by `tryAcquirePermit`.

## Validation

- `./gradlew :s3stream:checkstyleMain`
- `git diff --check`

Tests were not run per request; CI will provide test coverage.