### PR TITLE
feat(docker): use Java 21 in the Bitnami runtime image

### DIFF
--- a/container/bitnami/Dockerfile
+++ b/container/bitnami/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y ca-certificates curl procps zlib1g libj
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
     COMPONENTS=( \
-      "jre-17.0.14-10-1-linux-${OS_ARCH}-debian-12" \
+      "jre-21.0.6-10-1-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \


### PR DESCRIPTION
## Why

The AutoMQ image used by the Bitnami Helm deployment still runs Java 17, while the corresponding AutoMQ runtime supports Java 21.

## What

Upgrade the Bitnami-compatible AutoMQ container runtime from JRE 17.0.14 to JRE 21.0.6. The build JVM and existing Bitnami filesystem and entrypoint contracts remain unchanged.