### PR TITLE
docs(automq-shell): fix build and run instructions

### DIFF
--- a/automq-shell/README.md
+++ b/automq-shell/README.md
@@ -1,12 +1,15 @@
 # AutoMQ CLI
 
-## Build
+## Build and run
 
 ```bash
 # In the root directory
-./gradlew :cli:jar -x test
-java -jar cli/build/libs/cli-3.8.0-SNAPSHOT.jar -h
+./gradlew releaseTarGz
 
-# Build native image
-native-image -jar cli/build/libs/cli-3.8.0-SNAPSHOT.jar --initialize-at-build-time=org.slf4j.LoggerFactory
+# Extract the distribution, then run the CLI
+tar -xzf core/build/distributions/kafka_*.tgz
+cd kafka_*
+./bin/automq-cli.sh -h
 ```
+
+The `:automq-shell:jar` artifact is a thin JAR and is not intended to be run with `java -jar`.


### PR DESCRIPTION
## Why

The AutoMQ CLI README points to the unrelated `:cli` project and tries to run its thin JAR with `java -jar`. The documented native-image command uses the same incorrect artifact.

## What

- build the repository's existing release distribution
- run AutoMQ CLI through `bin/automq-cli.sh`
- clarify that `:automq-shell:jar` is a thin JAR

## How

This follows the existing `:core:releaseTarGz` packaging task, which includes the AutoMQ shell JAR and its runtime dependencies.

## Reviewer notes

Documentation-only change. No build logic or runtime behavior changes.

## Testing

- `./gradlew help --task releaseTarGz` (passed; resolves to `:core:releaseTarGz`)
- `./gradlew releaseTarGz` (not completed within the local 120-second verification window)