### PR TITLE
docs(metrics): fix object-storage exporter URI examples

### DIFF
--- a/automq-metrics/README.md
+++ b/automq-metrics/README.md
@@ -198,14 +198,16 @@ AutoMQTelemetryManager manager = AutoMQTelemetryManager.initializeInstance(
 
 #### S3 Metrics Exporter
 ```java
-// Use s3:// URI scheme
+// Use ops:// URI scheme
 AutoMQTelemetryManager manager = AutoMQTelemetryManager.initializeInstance(
-    "s3://access-key:secret-key@my-bucket.s3.amazonaws.com",
+    "ops://?",
     "automq-kafka",
     "broker-1",
     config // config.clusterId(), nodeId(), isLeader() used for S3 export
 );
 ```
+
+The `ops://?` URI selects the object-storage exporter. The bucket, endpoint, and credentials are provided by `MetricsExportConfig.objectStorage()`.
 
 Example usage with S3 exporter:
 
@@ -247,7 +249,7 @@ ObjectStorage objectStorage = // Create your object storage instance
 MetricsExportConfig config = new S3MetricsExportConfig(objectStorage);
 
 AutoMQTelemetryManager manager = AutoMQTelemetryManager.initializeInstance(
-    "s3://access-key:secret-key@my-bucket.s3.amazonaws.com",
+    "ops://?",
     "automq-kafka",
     "broker-1", 
     config


### PR DESCRIPTION
## Why

The metrics README documents the object-storage exporter with an `s3://` URI containing credentials. The parser recognizes this built-in exporter by the `ops` scheme and obtains object-storage access from `MetricsExportConfig.objectStorage()`.

## What

- replace both invalid `s3://` examples with `ops://?`
- explain where bucket, endpoint, and credentials are supplied

## How

The examples now match `MetricsExporterType.OPS` and the existing `MetricsExporterURI` dispatch path.

## Reviewer notes

Documentation-only change. No runtime behavior changes.

## Testing

- verified both examples use `ops://?`
- verified the README no longer contains the invalid `s3://access-key` example