### PR TITLE
fix(core): detect OPS exporter by URI scheme

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -430,13 +431,17 @@ public class AutoMQConfig {
         return walConfig;
     }
 
-    private static String genMetricsExporterURI(KafkaConfig config) {
+    static String genMetricsExporterURI(KafkaConfig config) {
         Password pwd = config.getPassword(S3_TELEMETRY_METRICS_EXPORTER_URI_CONFIG);
         String uri = pwd == null ? null : pwd.value();
         if (uri == null) {
             uri = buildMetrixExporterURIWithOldConfigs(config);
         }
-        if (!uri.contains(TELEMETRY_EXPORTER_TYPE_OPS)) {
+        String opsSchemePrefix = TELEMETRY_EXPORTER_TYPE_OPS + "://";
+        boolean hasOpsExporter = Arrays.stream(uri.split(","))
+            .map(String::trim)
+            .anyMatch(exporter -> exporter.regionMatches(true, 0, opsSchemePrefix, 0, opsSchemePrefix.length()));
+        if (!hasOpsExporter) {
             uri += "," + buildOpsExporterURI();
         }
         return uri;

--- a/core/src/test/java/kafka/automq/AutoMQConfigTest.java
+++ b/core/src/test/java/kafka/automq/AutoMQConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq;
+
+import kafka.server.KafkaConfig;
+
+import org.apache.kafka.common.config.types.Password;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static kafka.automq.AutoMQConfig.S3_TELEMETRY_METRICS_EXPORTER_URI_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AutoMQConfigTest {
+
+    /**
+     * Given an OTLP endpoint containing "ops", only an exporter with the OPS scheme should suppress the default.
+     */
+    @Test
+    @Tag("S3Unit")
+    public void testMetricsExporterDetectionUsesScheme() {
+        KafkaConfig config = mock(KafkaConfig.class);
+        String otlpUri = "otlp://?endpoint=https://telemetry.ops.example.com";
+        when(config.getPassword(S3_TELEMETRY_METRICS_EXPORTER_URI_CONFIG)).thenReturn(new Password(otlpUri));
+
+        assertEquals(otlpUri + ",ops://?", AutoMQConfig.genMetricsExporterURI(config));
+
+        String uriWithOpsExporter = otlpUri + ",OPS://?";
+        when(config.getPassword(S3_TELEMETRY_METRICS_EXPORTER_URI_CONFIG)).thenReturn(new Password(uriWithOpsExporter));
+        assertEquals(uriWithOpsExporter, AutoMQConfig.genMetricsExporterURI(config));
+    }
+}


### PR DESCRIPTION
## Why

`genMetricsExporterURI` currently checks `uri.contains("ops")` to decide whether the built-in OPS exporter is configured. An unrelated OTLP endpoint or path containing `ops` therefore suppresses the required default `ops://?` exporter.

## What

- detect OPS exporters by their URI scheme prefix instead of an arbitrary substring
- keep scheme matching case-insensitive, consistent with `MetricsExporterType.fromString`
- add an S3Unit regression test for an OTLP endpoint containing `ops` and an explicit uppercase OPS scheme

## How

The existing comma-separated exporter list is split and trimmed, then each entry is compared with the `ops://` scheme prefix. The existing default exporter append path is unchanged.

## Reviewer notes

The visibility of `genMetricsExporterURI` is package-private so the regression test can exercise the complete configuration behavior without constructing unrelated `AutoMQConfig.setup` dependencies.

## Testing

Passed:
- `./gradlew core:S3UnitTest --tests kafka.automq.AutoMQConfigTest`
- regression test fails on the old substring implementation and passes with this change
- `git diff --check`
- Checkstyle report contains zero violations for `AutoMQConfigTest.java`

Local gate limitations:
- `./gradlew --build-cache rat core:checkstyleMain core:checkstyleTest spotlessJavaCheck` reaches the repository's existing generated `PersonProto.java` checkstyle failures (1,590 violations); the new test file has no violations
- the complete root gate exceeded the local 120-second verification window