### PR TITLE
fix(s3stream): avoid multipart upload overhead for small MINOR_V1 copyWrite objects

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
@@ -79,10 +79,23 @@ public class ProxyWriter implements Writer {
 
     @Override
     public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-        if (largeObjectWriter == null) {
+        if (largeObjectWriter != null) {
+            largeObjectWriter.copyWrite(s3ObjectMetadata, start, end);
+            return;
+        }
+        if (end - start >= minPartSize) {
+            // Large enough to benefit from a zero-download server-side UploadPartCopy, so it's worth paying
+            // the multipart upload overhead (createMultipartUpload/completeMultipartUpload).
+            newLargeObjectWriter(writeOptions, objectStorage, path);
+            largeObjectWriter.copyWrite(s3ObjectMetadata, start, end);
+            return;
+        }
+        // Below minPartSize, S3 can't do a server-side UploadPartCopy for it anyway, so just buffer the range
+        // read like write() does and let it ride the single PutObject path instead of forcing multipart.
+        objectWriter.copyWrite(s3ObjectMetadata, start, end);
+        if (objectWriter.isFull()) {
             newLargeObjectWriter(writeOptions, objectStorage, path);
         }
-        largeObjectWriter.copyWrite(s3ObjectMetadata, start, end);
     }
 
     @Override
@@ -119,12 +132,17 @@ public class ProxyWriter implements Writer {
 
     protected void newLargeObjectWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path) {
         this.largeObjectWriter = new MultiPartWriter(writeOptions, objectStorage, path, minPartSize);
-        if (objectWriter.data.readableBytes() > 0) {
-            FutureUtil.propagate(largeObjectWriter.write(objectWriter.data), objectWriter.cf);
-        } else {
-            objectWriter.data.release();
-            objectWriter.cf.complete(null);
-        }
+        // wait for any in-flight copyWrite range reads to land in objectWriter.data before handing it off.
+        objectWriter.lastOpCf.whenComplete((nil, ex) -> {
+            if (ex != null) {
+                objectWriter.cf.completeExceptionally(ex);
+            } else if (objectWriter.data.readableBytes() > 0) {
+                FutureUtil.propagate(largeObjectWriter.write(objectWriter.data), objectWriter.cf);
+            } else {
+                objectWriter.data.release();
+                objectWriter.cf.complete(null);
+            }
+        });
     }
 
     class ObjectWriter implements Writer {
@@ -133,10 +151,14 @@ public class ProxyWriter implements Writer {
         CompletableFuture<Void> cf = new CompletableFuture<>();
         CompositeByteBuf data = ByteBufAlloc.compositeByteBuffer();
         TimerUtil timerUtil = new TimerUtil();
+        // tracks the size synchronously so isFull() is accurate even while copyWrite's range reads are in flight.
+        private long size = 0;
+        private CompletableFuture<Void> lastOpCf = CompletableFuture.completedFuture(null);
 
         @Override
         public CompletableFuture<Void> write(ByteBuf part) {
-            data.addComponent(true, part);
+            size += part.readableBytes();
+            lastOpCf = lastOpCf.thenAccept(nil -> data.addComponent(true, part));
             return cf;
         }
 
@@ -154,7 +176,12 @@ public class ProxyWriter implements Writer {
 
         @Override
         public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-            throw new UnsupportedOperationException();
+            size += end - start;
+            lastOpCf = lastOpCf
+                .thenCompose(nil -> objectStorage.rangeRead(
+                    new ObjectStorage.ReadOptions().throttleStrategy(writeOptions.throttleStrategy()).bucket(s3ObjectMetadata.bucket()),
+                    s3ObjectMetadata.key(), start, end))
+                .thenAccept(buf -> data.addComponent(true, buf));
         }
 
         @Override
@@ -165,7 +192,14 @@ public class ProxyWriter implements Writer {
         @Override
         public CompletableFuture<Void> close() {
             S3ObjectMetrics.recordReadyCloseStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-            FutureUtil.propagate(objectStorage.write(writeOptions, path, data).thenApply(rst -> null), cf);
+            // wait for any in-flight copyWrite range reads to land in data before issuing the single PutObject.
+            lastOpCf.whenComplete((nil, ex) -> {
+                if (ex != null) {
+                    cf.completeExceptionally(ex);
+                } else {
+                    FutureUtil.propagate(objectStorage.write(writeOptions, path, data).thenApply(rst -> null), cf);
+                }
+            });
             cf.whenComplete((nil, e) -> {
                 S3ObjectMetrics.recordTotalStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
                 S3ObjectMetrics.recordObject();
@@ -180,7 +214,7 @@ public class ProxyWriter implements Writer {
         }
 
         public boolean isFull() {
-            return data.readableBytes() > MAX_UPLOAD_SIZE;
+            return size > MAX_UPLOAD_SIZE;
         }
 
         @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
@@ -43,6 +43,9 @@ public class ProxyWriter implements Writer {
     private final String path;
     private final long minPartSize;
     Writer largeObjectWriter = null;
+    // Ordered chain that serializes every operation issued to largeObjectWriter once we escalate. It is
+    // only touched by the (single) calling thread; see newLargeObjectWriter for why it exists.
+    private CompletableFuture<Void> mpwChain = null;
 
     public ProxyWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path, long minPartSize) {
         this.writeOptions = writeOptions;
@@ -58,7 +61,7 @@ public class ProxyWriter implements Writer {
     @Override
     public CompletableFuture<Void> write(ByteBuf part) {
         if (largeObjectWriter != null) {
-            return largeObjectWriter.write(part);
+            return writeToLargeObject(part);
         } else {
             objectWriter.write(part);
             if (objectWriter.isFull()) {
@@ -80,14 +83,14 @@ public class ProxyWriter implements Writer {
     @Override
     public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
         if (largeObjectWriter != null) {
-            largeObjectWriter.copyWrite(s3ObjectMetadata, start, end);
+            copyWriteToLargeObject(s3ObjectMetadata, start, end);
             return;
         }
         if (end - start >= minPartSize) {
             // Large enough to benefit from a zero-download server-side UploadPartCopy, so it's worth paying
             // the multipart upload overhead (createMultipartUpload/completeMultipartUpload).
             newLargeObjectWriter(writeOptions, objectStorage, path);
-            largeObjectWriter.copyWrite(s3ObjectMetadata, start, end);
+            copyWriteToLargeObject(s3ObjectMetadata, start, end);
             return;
         }
         // Below minPartSize, S3 can't do a server-side UploadPartCopy for it anyway, so just buffer the range
@@ -96,6 +99,32 @@ public class ProxyWriter implements Writer {
         if (objectWriter.isFull()) {
             newLargeObjectWriter(writeOptions, objectStorage, path);
         }
+    }
+
+    /**
+     * Issue a copyWrite to largeObjectWriter in order, after the buffered-data handoff and any previously
+     * issued operations. Never call largeObjectWriter.copyWrite directly - it must go through mpwChain so
+     * parts are appended in call order and MultiPartWriter is only ever touched by a single thread.
+     */
+    private void copyWriteToLargeObject(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+        mpwChain = mpwChain.thenRun(() -> largeObjectWriter.copyWrite(s3ObjectMetadata, start, end));
+    }
+
+    /**
+     * Issue a write to largeObjectWriter in order (see {@link #copyWriteToLargeObject}). The returned future
+     * tracks the actual part upload; if an earlier operation in the chain failed we surface that failure and
+     * release the part so it is not leaked.
+     */
+    private CompletableFuture<Void> writeToLargeObject(ByteBuf part) {
+        CompletableFuture<Void> writeCf = new CompletableFuture<>();
+        mpwChain = mpwChain.thenRun(() -> FutureUtil.propagate(largeObjectWriter.write(part), writeCf));
+        mpwChain.whenComplete((nil, ex) -> {
+            if (ex != null && !writeCf.isDone()) {
+                part.release();
+                writeCf.completeExceptionally(ex);
+            }
+        });
+        return writeCf;
     }
 
     @Override
@@ -110,7 +139,10 @@ public class ProxyWriter implements Writer {
     @Override
     public CompletableFuture<Void> close() {
         if (largeObjectWriter != null) {
-            return largeObjectWriter.close();
+            // Wait until the handoff and every issued copyWrite/write has actually been submitted to
+            // largeObjectWriter (registered as a part) before closing, otherwise close could complete the
+            // multipart upload before the buffered data lands - dropping it.
+            return mpwChain.thenCompose(nil -> largeObjectWriter.close());
         } else {
             return objectWriter.close();
         }
@@ -132,9 +164,17 @@ public class ProxyWriter implements Writer {
 
     protected void newLargeObjectWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path) {
         this.largeObjectWriter = new MultiPartWriter(writeOptions, objectStorage, path, minPartSize);
-        // wait for any in-flight copyWrite range reads to land in objectWriter.data before handing it off.
-        objectWriter.lastOpCf.whenComplete((nil, ex) -> {
+        // Hand off everything already buffered in objectWriter as the first multipart operation, then serialize
+        // every subsequent largeObjectWriter call onto this chain (see copyWriteToLargeObject/writeToLargeObject).
+        // This guarantees two things:
+        //   (a) parts are issued in the exact order copyWrite/write were called. Byte order in the final object
+        //       must match, since the compaction index block encodes absolute byte offsets into the object.
+        //   (b) MultiPartWriter, which assumes a single-threaded caller, is only ever touched by one thread at a
+        //       time - even though the handoff below waits on range reads that complete on a different thread.
+        // whenComplete keeps mpwChain mirroring lastOpCf, so a failed range read short-circuits the whole chain.
+        this.mpwChain = objectWriter.lastOpCf.whenComplete((nil, ex) -> {
             if (ex != null) {
+                objectWriter.data.release();
                 objectWriter.cf.completeExceptionally(ex);
             } else if (objectWriter.data.readableBytes() > 0) {
                 FutureUtil.propagate(largeObjectWriter.write(objectWriter.data), objectWriter.cf);
@@ -164,9 +204,9 @@ public class ProxyWriter implements Writer {
 
         @Override
         public void copyOnWrite() {
-            int size = data.readableBytes();
-            if (size > 0) {
-                ByteBuf buf = ByteBufAlloc.byteBuffer(size, writeOptions.allocType());
+            int readable = data.readableBytes();
+            if (readable > 0) {
+                ByteBuf buf = ByteBufAlloc.byteBuffer(readable, writeOptions.allocType());
                 buf.writeBytes(data.duplicate());
                 CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
                 this.data.release();
@@ -195,6 +235,9 @@ public class ProxyWriter implements Writer {
             // wait for any in-flight copyWrite range reads to land in data before issuing the single PutObject.
             lastOpCf.whenComplete((nil, ex) -> {
                 if (ex != null) {
+                    // A range read failed, so we'll never issue the PutObject that would consume data - release
+                    // the partially accumulated buffer instead of leaking it.
+                    data.release();
                     cf.completeExceptionally(ex);
                 } else {
                     FutureUtil.propagate(objectStorage.write(writeOptions, path, data).thenApply(rst -> null), cf);

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
@@ -28,10 +28,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -124,6 +127,72 @@ public class ProxyWriterTest {
         verify(operator, times(0)).createMultipartUpload(any(), any());
         verify(operator, times(0)).uploadPart(any(), any(), any(), anyInt(), any());
         verify(operator, times(0)).completeMultipartUpload(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testCopyWrite_escalationPreservesOrder() {
+        // Buffer many small copyWrites until the accumulated size crosses MAX_UPLOAD_SIZE (32MiB) and forces an
+        // escalation to multipart mid-stream. The range reads only complete AFTER close() is called, so this
+        // exercises the deferred-handoff path: the buffered data must be flushed to the MultiPartWriter as the
+        // first part, before the copyWrite/write issued after escalation, and none of it may be dropped even
+        // though close() has already been invoked. This is the scenario a MINOR/MAJOR group (up to 128MiB) hits.
+        int mib = 1024 * 1024;
+        when(operator.createMultipartUpload(any(), eq("testpath"))).thenReturn(CompletableFuture.completedFuture("test_upload_id"));
+        when(operator.uploadPart(any(), eq("testpath"), eq("test_upload_id"), anyInt(), any()))
+            .thenAnswer(inv -> CompletableFuture.completedFuture(
+                new AbstractObjectStorage.ObjectStorageCompletedPart(inv.getArgument(3), "etag", "checksum")));
+        when(operator.completeMultipartUpload(any(), eq("testpath"), eq("test_upload_id"), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        // rangeRead hands back a not-yet-completed future per call so we can drive completion order by hand. The
+        // ObjectWriter chains reads sequentially, so each read is only issued once the previous one completes.
+        List<CompletableFuture<ByteBuf>> reads = new ArrayList<>();
+        List<Integer> readSizes = new ArrayList<>();
+        when(operator.rangeRead(any(), any(), anyLong(), anyLong())).thenAnswer(inv -> {
+            long start = inv.getArgument(2);
+            long end = inv.getArgument(3);
+            CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
+            reads.add(cf);
+            readSizes.add((int) (end - start));
+            return cf;
+        });
+
+        // 9 * 4MiB = 36MiB > 32MiB, so the writer escalates after the 9th buffered copyWrite; the 10th copyWrite
+        // is then issued directly to the multipart writer.
+        int smallObjectCount = 10;
+        for (int i = 1; i <= smallObjectCount; i++) {
+            S3ObjectMetadata object = new S3ObjectMetadata(i, 4L * mib, S3ObjectType.STREAM);
+            writer.copyWrite(object, 0, 4L * mib);
+        }
+        assertNotNull(writer.largeObjectWriter);
+        // Index block written last, exactly like StreamObjectCompactor does after the per-object copyWrites.
+        writer.write(TestUtils.random(mib));
+        CompletableFuture<Void> closeCf = writer.close();
+        assertFalse(closeCf.isDone(), "close must wait for the buffered range reads to be flushed");
+
+        // Drive the reads to completion in issue order; completing one may lazily trigger the next.
+        for (int i = 0; i < reads.size(); i++) {
+            reads.get(i).complete(TestUtils.random(readSizes.get(i)));
+        }
+
+        assertTrue(closeCf.isDone());
+        assertFalse(closeCf.isCompletedExceptionally());
+        assertEquals(smallObjectCount, reads.size(), "one range read per small copyWrite");
+
+        // Single-PUT path must not be used; the multipart upload must be completed exactly once.
+        verify(operator, times(0)).write(any(), eq("testpath"), any());
+        verify(operator, times(1)).completeMultipartUpload(any(), any(), any(), any());
+        verify(operator, times(2)).uploadPart(any(), eq("testpath"), eq("test_upload_id"), anyInt(), any());
+
+        // Part 1 must be the handoff of the 9 buffered objects (36MiB), in order - NOT the object copyWritten
+        // after escalation. Part 2 is the 10th object (4MiB) plus the index block (1MiB). A reorder/drop would
+        // make part 1 the 4MiB object and lose the 36MiB, so this pins down both ordering and no-data-loss.
+        ArgumentCaptor<ByteBuf> part1 = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(operator).uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(1), part1.capture());
+        assertEquals(9 * 4 * mib, part1.getValue().readableBytes());
+        ArgumentCaptor<ByteBuf> part2 = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(operator).uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(2), part2.capture());
+        assertEquals(4 * mib + mib, part2.getValue().readableBytes());
     }
 
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
@@ -101,4 +101,29 @@ public class ProxyWriterTest {
         verify(operator, times(1)).uploadPartCopy(any(), any(), any(), anyLong(), anyLong(), any(), anyInt());
     }
 
+    @Test
+    public void testCopyWrite_smallObjectsUseSinglePut() {
+        // Below minPartSize (5MiB default): should buffer via rangeRead and issue a single PutObject,
+        // never touching the multipart APIs (createMultipartUpload/uploadPart/completeMultipartUpload).
+        when(operator.write(any(), eq("testpath"), any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(operator.rangeRead(any(), any(), eq(0L), eq(2L * 1024 * 1024)))
+            .thenReturn(CompletableFuture.completedFuture(TestUtils.random(2 * 1024 * 1024)));
+        when(operator.rangeRead(any(), any(), eq(0L), eq(3L * 1024 * 1024)))
+            .thenReturn(CompletableFuture.completedFuture(TestUtils.random(3 * 1024 * 1024)));
+
+        S3ObjectMetadata object1 = new S3ObjectMetadata(1, 2 * 1024 * 1024, S3ObjectType.STREAM);
+        S3ObjectMetadata object2 = new S3ObjectMetadata(2, 3 * 1024 * 1024, S3ObjectType.STREAM);
+        writer.copyWrite(object1, 0, 2 * 1024 * 1024);
+        writer.copyWrite(object2, 0, 3 * 1024 * 1024);
+        assertNull(writer.largeObjectWriter);
+        Assertions.assertTrue(writer.close().isDone());
+
+        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(operator, times(1)).write(any(), eq("testpath"), captor.capture());
+        Assertions.assertEquals(5 * 1024 * 1024, captor.getValue().readableBytes());
+        verify(operator, times(0)).createMultipartUpload(any(), any());
+        verify(operator, times(0)).uploadPart(any(), any(), any(), anyInt(), any());
+        verify(operator, times(0)).completeMultipartUpload(any(), any(), any(), any());
+    }
+
 }


### PR DESCRIPTION
## Summary
- `ProxyWriter.copyWrite()` unconditionally escalated to `MultiPartWriter` on the very first call, regardless of the copied range's size. For MINOR_V1 stream object compaction, source objects are always below `Writer.MIN_PART_SIZE` (5MiB), so every compaction group paid the full multipart upload overhead (`CreateMultipartUpload` + `CompleteMultipartUpload`, 2 extra requests) instead of a single `PutObject`, even though the merged group total is small enough to fit comfortably under `ProxyWriter`'s existing single-PUT threshold (`MAX_UPLOAD_SIZE`, 32MiB).
- This change makes `ProxyWriter.copyWrite()` behave consistently with `write()`: ranges below `minPartSize` (which can't use a real server-side `UploadPartCopy` anyway) are read via `rangeRead` and buffered into the same single-PUT `ObjectWriter` path, only escalating to `MultiPartWriter` once the accumulated size crosses `MAX_UPLOAD_SIZE`. Ranges at/above `minPartSize` keep using the existing zero-download `UploadPartCopy` fast path unchanged.

## Test plan
- [x] `:s3stream:test --tests ProxyWriterTest` — added `testCopyWrite_smallObjectsUseSinglePut` verifying multiple small copyWrite calls result in exactly one `PutObject` and zero multipart API calls.
- [x] `:s3stream:test --tests MultiPartWriterTest` — unaffected, still green.
- [x] `:s3stream:test --tests com.automq.stream.s3.compact.*` — unaffected, still green.