### PR TITLE
refactor(s3stream): simplify proxy writer operation replay

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/MultiPartWriter.java
@@ -30,6 +30,7 @@ import com.automq.stream.utils.FutureUtil;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -242,7 +243,14 @@ public class MultiPartWriter implements Writer {
         public void write(ByteBuf data) {
             size += data.readableBytes();
             // ensure addComponent happen before following write or copyWrite.
-            this.lastRangeReadCf = lastRangeReadCf.thenAccept(nil -> partBuf.addComponent(true, data));
+            this.lastRangeReadCf = lastRangeReadCf.handle((nil, ex) -> {
+                if (ex != null) {
+                    data.release();
+                    throw new CompletionException(ex);
+                }
+                partBuf.addComponent(true, data);
+                return null;
+            });
         }
 
         public void copyOnWrite() {
@@ -271,6 +279,7 @@ public class MultiPartWriter implements Writer {
         public void upload() {
             this.lastRangeReadCf.whenComplete((nil, ex) -> {
                 if (ex != null) {
+                    partBuf.release();
                     partCf.completeExceptionally(ex);
                 } else {
                     upload0();

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/ProxyWriter.java
@@ -26,26 +26,35 @@ import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.operator.ObjectStorage.WriteOptions;
 import com.automq.stream.utils.FutureUtil;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 /**
- * If object data size is less than ObjectWriter.MAX_UPLOAD_SIZE, we should use single upload to upload it.
- * Else, we should use multi-part upload to upload it.
+ * Selects PutObject or multipart upload after observing the object operations. Before the selection is made,
+ * operations are retained in call order and their buffers are owned by this writer. Closing replays them to the
+ * PutObject path, while exceeding the multipart upload threshold replays them to a multipart writer.
+ *
+ * <p>This writer expects calls to be serialized. After {@link #copyOnWrite()} returns, callers may safely modify
+ * buffers passed to earlier {@link #write(ByteBuf)} calls. {@link #release()} releases every retained buffer that
+ * has not already been transferred to the selected writer.</p>
  */
 public class ProxyWriter implements Writer {
-    final ObjectWriter objectWriter = new ObjectWriter();
+    private static final long MULTIPART_UPLOAD_THRESHOLD = 32L * 1024 * 1024;
     private final WriteOptions writeOptions;
     private final ObjectStorage objectStorage;
     private final String path;
     private final long minPartSize;
-    Writer largeObjectWriter = null;
-    // Ordered chain that serializes every operation issued to largeObjectWriter once we escalate. It is
-    // only touched by the (single) calling thread; see newLargeObjectWriter for why it exists.
-    private CompletableFuture<Void> mpwChain = null;
+    private final List<PendingOperation> pendingOperations = new ArrayList<>();
+    private final CompletableFuture<Void> objectCf = new CompletableFuture<>();
+    private final TimerUtil timerUtil = new TimerUtil();
+    private Writer multiPartObjectWriter = null;
+    private long size;
 
     public ProxyWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path, long minPartSize) {
         this.writeOptions = writeOptions;
@@ -60,101 +69,63 @@ public class ProxyWriter implements Writer {
 
     @Override
     public CompletableFuture<Void> write(ByteBuf part) {
-        if (largeObjectWriter != null) {
-            return writeToLargeObject(part);
-        } else {
-            objectWriter.write(part);
-            if (objectWriter.isFull()) {
-                newLargeObjectWriter(writeOptions, objectStorage, path);
-            }
-            return objectWriter.cf;
+        if (multiPartObjectWriter != null) {
+            return multiPartObjectWriter.write(part);
         }
+        size += part.readableBytes();
+        pendingOperations.add(new PendingWrite(part));
+        if (exceedsMultipartUploadThreshold()) {
+            newMultiPartObjectWriter();
+        }
+        return objectCf;
     }
 
     @Override
     public void copyOnWrite() {
-        if (largeObjectWriter != null) {
-            largeObjectWriter.copyOnWrite();
+        if (multiPartObjectWriter != null) {
+            multiPartObjectWriter.copyOnWrite();
         } else {
-            objectWriter.copyOnWrite();
+            pendingOperations.forEach(PendingOperation::copyOnWrite);
         }
     }
 
     @Override
     public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-        if (largeObjectWriter != null) {
-            copyWriteToLargeObject(s3ObjectMetadata, start, end);
+        if (multiPartObjectWriter != null) {
+            multiPartObjectWriter.copyWrite(s3ObjectMetadata, start, end);
             return;
         }
-        if (end - start >= minPartSize) {
-            // Large enough to benefit from a zero-download server-side UploadPartCopy, so it's worth paying
-            // the multipart upload overhead (createMultipartUpload/completeMultipartUpload).
-            newLargeObjectWriter(writeOptions, objectStorage, path);
-            copyWriteToLargeObject(s3ObjectMetadata, start, end);
-            return;
+        size += end - start;
+        pendingOperations.add(new PendingCopyWrite(s3ObjectMetadata, start, end));
+        if (exceedsMultipartUploadThreshold()) {
+            newMultiPartObjectWriter();
         }
-        // Below minPartSize, S3 can't do a server-side UploadPartCopy for it anyway, so just buffer the range
-        // read like write() does and let it ride the single PutObject path instead of forcing multipart.
-        objectWriter.copyWrite(s3ObjectMetadata, start, end);
-        if (objectWriter.isFull()) {
-            newLargeObjectWriter(writeOptions, objectStorage, path);
-        }
-    }
-
-    /**
-     * Issue a copyWrite to largeObjectWriter in order, after the buffered-data handoff and any previously
-     * issued operations. Never call largeObjectWriter.copyWrite directly - it must go through mpwChain so
-     * parts are appended in call order and MultiPartWriter is only ever touched by a single thread.
-     */
-    private void copyWriteToLargeObject(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-        mpwChain = mpwChain.thenRun(() -> largeObjectWriter.copyWrite(s3ObjectMetadata, start, end));
-    }
-
-    /**
-     * Issue a write to largeObjectWriter in order (see {@link #copyWriteToLargeObject}). The returned future
-     * tracks the actual part upload; if an earlier operation in the chain failed we surface that failure and
-     * release the part so it is not leaked.
-     */
-    private CompletableFuture<Void> writeToLargeObject(ByteBuf part) {
-        CompletableFuture<Void> writeCf = new CompletableFuture<>();
-        mpwChain = mpwChain.thenRun(() -> FutureUtil.propagate(largeObjectWriter.write(part), writeCf));
-        mpwChain.whenComplete((nil, ex) -> {
-            if (ex != null && !writeCf.isDone()) {
-                part.release();
-                writeCf.completeExceptionally(ex);
-            }
-        });
-        return writeCf;
     }
 
     @Override
     public boolean hasBatchingPart() {
-        if (largeObjectWriter != null) {
-            return largeObjectWriter.hasBatchingPart();
-        } else {
-            return objectWriter.hasBatchingPart();
+        if (multiPartObjectWriter != null) {
+            return multiPartObjectWriter.hasBatchingPart();
         }
+        return true;
     }
 
     @Override
     public CompletableFuture<Void> close() {
-        if (largeObjectWriter != null) {
-            // Wait until the handoff and every issued copyWrite/write has actually been submitted to
-            // largeObjectWriter (registered as a part) before closing, otherwise close could complete the
-            // multipart upload before the buffered data lands - dropping it.
-            return mpwChain.thenCompose(nil -> largeObjectWriter.close());
-        } else {
-            return objectWriter.close();
+        if (multiPartObjectWriter != null) {
+            return multiPartObjectWriter.close();
         }
+        return closeWithPutObject();
     }
 
     @Override
     public CompletableFuture<Void> release() {
-        if (largeObjectWriter != null) {
-            return largeObjectWriter.release();
-        } else {
-            return objectWriter.release();
+        if (multiPartObjectWriter != null) {
+            return multiPartObjectWriter.release();
         }
+        pendingOperations.forEach(PendingOperation::release);
+        pendingOperations.clear();
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -162,107 +133,128 @@ public class ProxyWriter implements Writer {
         return writeOptions.bucketId();
     }
 
-    protected void newLargeObjectWriter(WriteOptions writeOptions, ObjectStorage objectStorage, String path) {
-        this.largeObjectWriter = new MultiPartWriter(writeOptions, objectStorage, path, minPartSize);
-        // Hand off everything already buffered in objectWriter as the first multipart operation, then serialize
-        // every subsequent largeObjectWriter call onto this chain (see copyWriteToLargeObject/writeToLargeObject).
-        // This guarantees two things:
-        //   (a) parts are issued in the exact order copyWrite/write were called. Byte order in the final object
-        //       must match, since the compaction index block encodes absolute byte offsets into the object.
-        //   (b) MultiPartWriter, which assumes a single-threaded caller, is only ever touched by one thread at a
-        //       time - even though the handoff below waits on range reads that complete on a different thread.
-        // whenComplete keeps mpwChain mirroring lastOpCf, so a failed range read short-circuits the whole chain.
-        this.mpwChain = objectWriter.lastOpCf.whenComplete((nil, ex) -> {
-            if (ex != null) {
-                objectWriter.data.release();
-                objectWriter.cf.completeExceptionally(ex);
-            } else if (objectWriter.data.readableBytes() > 0) {
-                FutureUtil.propagate(largeObjectWriter.write(objectWriter.data), objectWriter.cf);
-            } else {
-                objectWriter.data.release();
-                objectWriter.cf.complete(null);
-            }
-        });
+    private void newMultiPartObjectWriter() {
+        this.multiPartObjectWriter = new MultiPartWriter(writeOptions, objectStorage, path, minPartSize);
+        List<CompletableFuture<Void>> writeCfs = new ArrayList<>();
+        for (PendingOperation operation : pendingOperations) {
+            writeCfs.add(operation.apply(multiPartObjectWriter));
+        }
+        pendingOperations.clear();
+        FutureUtil.propagate(CompletableFuture.allOf(writeCfs.toArray(new CompletableFuture[0])), objectCf);
     }
 
-    class ObjectWriter implements Writer {
-        // max upload size, when object data size is larger than MAX_UPLOAD_SIZE, we should use multi-part upload to upload it.
-        static final long MAX_UPLOAD_SIZE = 32L * 1024 * 1024;
-        CompletableFuture<Void> cf = new CompletableFuture<>();
+    private CompletableFuture<Void> closeWithPutObject() {
         CompositeByteBuf data = ByteBufAlloc.compositeByteBuffer();
-        TimerUtil timerUtil = new TimerUtil();
-        // tracks the size synchronously so isFull() is accurate even while copyWrite's range reads are in flight.
-        private long size = 0;
-        private CompletableFuture<Void> lastOpCf = CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> replayCf = CompletableFuture.completedFuture(null);
+        for (PendingOperation operation : pendingOperations) {
+            replayCf = operation.apply(replayCf, data);
+        }
+        pendingOperations.clear();
+        S3ObjectMetrics.recordReadyCloseStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+        replayCf.whenComplete((nil, ex) -> {
+            if (ex != null) {
+                data.release();
+                objectCf.completeExceptionally(ex);
+            } else {
+                FutureUtil.propagate(objectStorage.write(writeOptions, path, data).thenApply(rst -> null), objectCf);
+            }
+        });
+        objectCf.whenComplete((nil, e) -> {
+            S3ObjectMetrics.recordTotalStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
+            S3ObjectMetrics.recordObject();
+        });
+        return objectCf;
+    }
+
+    private boolean exceedsMultipartUploadThreshold() {
+        return size > MULTIPART_UPLOAD_THRESHOLD;
+    }
+
+    private interface PendingOperation {
+        CompletableFuture<Void> apply(Writer writer);
+
+        CompletableFuture<Void> apply(CompletableFuture<Void> previousCf, CompositeByteBuf data);
+
+        default void copyOnWrite() {
+        }
+
+        default void release() {
+        }
+    }
+
+    private class PendingWrite implements PendingOperation {
+        private ByteBuf part;
+
+        private PendingWrite(ByteBuf part) {
+            this.part = part;
+        }
 
         @Override
-        public CompletableFuture<Void> write(ByteBuf part) {
-            size += part.readableBytes();
-            lastOpCf = lastOpCf.thenAccept(nil -> data.addComponent(true, part));
+        public CompletableFuture<Void> apply(Writer writer) {
+            CompletableFuture<Void> cf = writer.write(part);
+            part = null;
             return cf;
+        }
+
+        @Override
+        public CompletableFuture<Void> apply(CompletableFuture<Void> previousCf, CompositeByteBuf data) {
+            ByteBuf dataPart = part;
+            part = null;
+            return previousCf.handle((nil, ex) -> {
+                if (ex != null) {
+                    dataPart.release();
+                    throw new CompletionException(ex);
+                }
+                data.addComponent(true, dataPart);
+                return null;
+            });
         }
 
         @Override
         public void copyOnWrite() {
-            int readable = data.readableBytes();
-            if (readable > 0) {
-                ByteBuf buf = ByteBufAlloc.byteBuffer(readable, writeOptions.allocType());
-                buf.writeBytes(data.duplicate());
-                CompositeByteBuf copy = ByteBufAlloc.compositeByteBuffer().addComponent(true, buf);
-                this.data.release();
-                this.data = copy;
+            ByteBuf copy = ByteBufAlloc.byteBuffer(part.readableBytes(), writeOptions.allocType());
+            copy.writeBytes(part.duplicate());
+            part.release();
+            part = copy;
+        }
+
+        @Override
+        public void release() {
+            if (part != null) {
+                part.release();
+                part = null;
+            }
+        }
+    }
+
+    private class PendingCopyWrite implements PendingOperation {
+        private final S3ObjectMetadata s3ObjectMetadata;
+        private final long start;
+        private final long end;
+
+        private PendingCopyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
+            this.s3ObjectMetadata = s3ObjectMetadata;
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public CompletableFuture<Void> apply(Writer writer) {
+            try {
+                writer.copyWrite(s3ObjectMetadata, start, end);
+                return CompletableFuture.completedFuture(null);
+            } catch (Throwable ex) {
+                return CompletableFuture.failedFuture(ex);
             }
         }
 
         @Override
-        public void copyWrite(S3ObjectMetadata s3ObjectMetadata, long start, long end) {
-            size += end - start;
-            lastOpCf = lastOpCf
+        public CompletableFuture<Void> apply(CompletableFuture<Void> previousCf, CompositeByteBuf data) {
+            return previousCf
                 .thenCompose(nil -> objectStorage.rangeRead(
                     new ObjectStorage.ReadOptions().throttleStrategy(writeOptions.throttleStrategy()).bucket(s3ObjectMetadata.bucket()),
                     s3ObjectMetadata.key(), start, end))
                 .thenAccept(buf -> data.addComponent(true, buf));
-        }
-
-        @Override
-        public boolean hasBatchingPart() {
-            return true;
-        }
-
-        @Override
-        public CompletableFuture<Void> close() {
-            S3ObjectMetrics.recordReadyCloseStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-            // wait for any in-flight copyWrite range reads to land in data before issuing the single PutObject.
-            lastOpCf.whenComplete((nil, ex) -> {
-                if (ex != null) {
-                    // A range read failed, so we'll never issue the PutObject that would consume data - release
-                    // the partially accumulated buffer instead of leaking it.
-                    data.release();
-                    cf.completeExceptionally(ex);
-                } else {
-                    FutureUtil.propagate(objectStorage.write(writeOptions, path, data).thenApply(rst -> null), cf);
-                }
-            });
-            cf.whenComplete((nil, e) -> {
-                S3ObjectMetrics.recordTotalStage(timerUtil.elapsedAs(TimeUnit.NANOSECONDS));
-                S3ObjectMetrics.recordObject();
-            });
-            return cf;
-        }
-
-        @Override
-        public CompletableFuture<Void> release() {
-            data.release();
-            return CompletableFuture.completedFuture(null);
-        }
-
-        public boolean isFull() {
-            return size > MAX_UPLOAD_SIZE;
-        }
-
-        @Override
-        public short bucketId() {
-            return writeOptions.bucketId();
         }
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/operator/ProxyWriterTest.java
@@ -25,19 +25,20 @@ import com.automq.stream.s3.metadata.S3ObjectType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -48,6 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Tag("S3Unit")
 public class ProxyWriterTest {
 
     AbstractObjectStorage operator;
@@ -72,41 +74,52 @@ public class ProxyWriterTest {
     }
 
     @Test
-    public void testWrite_dataLargerThanMaxUploadSize() {
+    public void testSmallCopyWritesExceedingMultipartUploadThreshold() {
+        // Given small copy operations total exactly 32 MiB, stay on the PutObject path until one additional byte
+        // makes the cumulative object size exceed the multipart upload threshold.
         when(operator.createMultipartUpload(any(), eq("testpath"))).thenReturn(CompletableFuture.completedFuture("test_upload_id"));
-        when(operator.uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(1), any())).thenReturn(CompletableFuture.completedFuture(new AbstractObjectStorage.ObjectStorageCompletedPart(1, "etag1", "checksum1")));
-        when(operator.uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(2), any())).thenReturn(CompletableFuture.completedFuture(new AbstractObjectStorage.ObjectStorageCompletedPart(2, "etag2", "checksum2")));
+        when(operator.rangeRead(any(), any(), anyLong(), anyLong())).thenAnswer(inv ->
+            CompletableFuture.completedFuture(TestUtils.random((int) ((long) inv.getArgument(3) - (long) inv.getArgument(2)))));
+        when(operator.uploadPart(any(), eq("testpath"), eq("test_upload_id"), anyInt(), any())).thenAnswer(inv ->
+            CompletableFuture.completedFuture(new AbstractObjectStorage.ObjectStorageCompletedPart(
+                inv.getArgument(3), "etag", "checksum")));
         when(operator.completeMultipartUpload(any(), eq("testpath"), eq("test_upload_id"), any())).thenReturn(CompletableFuture.completedFuture(null));
-        writer.write(TestUtils.random(17 * 1024 * 1024));
-        assertTrue(writer.hasBatchingPart());
-        assertNull(writer.largeObjectWriter);
-        writer.write(TestUtils.random(33 * 1024 * 1024));
-        assertNotNull(writer.largeObjectWriter);
-        assertFalse(writer.hasBatchingPart());
-        writer.write(TestUtils.random(33 * 1024 * 1024));
-        assertNotNull(writer.largeObjectWriter);
-        assertFalse(writer.hasBatchingPart());
-        writer.close();
-        verify(operator, times(2)).uploadPart(any(), any(), any(), anyInt(), any());
+
+        for (int i = 0; i < 8; i++) {
+            S3ObjectMetadata object = new S3ObjectMetadata(i + 1, 4L * 1024 * 1024, S3ObjectType.STREAM);
+            writer.copyWrite(object, 0, 4L * 1024 * 1024);
+        }
+        verify(operator, times(0)).createMultipartUpload(any(), any());
+        verify(operator, times(0)).rangeRead(any(), any(), anyLong(), anyLong());
+
+        S3ObjectMetadata lastObject = new S3ObjectMetadata(9, 1, S3ObjectType.STREAM);
+        writer.copyWrite(lastObject, 0, 1);
+        assertTrue(writer.close().isDone());
+
+        verify(operator, times(1)).createMultipartUpload(any(), eq("testpath"));
+        verify(operator, times(0)).write(any(), eq("testpath"), any());
     }
 
     @Test
-    public void testWrite_copyWrite() {
-        when(operator.createMultipartUpload(any(), eq("testpath"))).thenReturn(CompletableFuture.completedFuture("test_upload_id"));
-        when(operator.uploadPartCopy(any(), eq("test_src_path"), eq("testpath"), eq(0L), eq(15L * 1024 * 1024), eq("test_upload_id"), eq(1)))
-            .thenReturn(CompletableFuture.completedFuture(new AbstractObjectStorage.ObjectStorageCompletedPart(1, "etag1", "checksum1")));
-        when(operator.completeMultipartUpload(any(), eq("testpath"), eq("test_upload_id"), any())).thenReturn(CompletableFuture.completedFuture(null));
+    public void testStandaloneLargeCopyUsesPutObject() {
+        // Given a standalone copy remains below the multipart threshold, use rangeRead plus one PutObject even
+        // when it is large enough for UploadPartCopy.
+        when(operator.rangeRead(any(), any(), eq(0L), eq(15L * 1024 * 1024)))
+            .thenReturn(CompletableFuture.completedFuture(TestUtils.random(15 * 1024 * 1024)));
+        when(operator.write(any(), eq("testpath"), any())).thenReturn(CompletableFuture.completedFuture(null));
 
         S3ObjectMetadata s3ObjectMetadata = new S3ObjectMetadata(1, 15 * 1024 * 1024, S3ObjectType.STREAM);
         writer.copyWrite(s3ObjectMetadata, 0, 15 * 1024 * 1024);
         Assertions.assertTrue(writer.close().isDone());
 
-        verify(operator, times(1)).uploadPartCopy(any(), any(), any(), anyLong(), anyLong(), any(), anyInt());
+        verify(operator, times(1)).rangeRead(any(), any(), eq(0L), eq(15L * 1024 * 1024));
+        verify(operator, times(1)).write(any(), eq("testpath"), any());
+        verify(operator, times(0)).createMultipartUpload(any(), any());
     }
 
     @Test
     public void testCopyWrite_smallObjectsUseSinglePut() {
-        // Below minPartSize (5MiB default): should buffer via rangeRead and issue a single PutObject,
+        // Below minPartSize (5MiB default): should buffer via rangeRead and issue one PutObject request,
         // never touching the multipart APIs (createMultipartUpload/uploadPart/completeMultipartUpload).
         when(operator.write(any(), eq("testpath"), any())).thenReturn(CompletableFuture.completedFuture(null));
         when(operator.rangeRead(any(), any(), eq(0L), eq(2L * 1024 * 1024)))
@@ -118,53 +131,59 @@ public class ProxyWriterTest {
         S3ObjectMetadata object2 = new S3ObjectMetadata(2, 3 * 1024 * 1024, S3ObjectType.STREAM);
         writer.copyWrite(object1, 0, 2 * 1024 * 1024);
         writer.copyWrite(object2, 0, 3 * 1024 * 1024);
-        assertNull(writer.largeObjectWriter);
+        verify(operator, times(0)).rangeRead(any(), any(), anyLong(), anyLong());
         Assertions.assertTrue(writer.close().isDone());
 
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(operator, times(1)).write(any(), eq("testpath"), captor.capture());
         Assertions.assertEquals(5 * 1024 * 1024, captor.getValue().readableBytes());
         verify(operator, times(0)).createMultipartUpload(any(), any());
-        verify(operator, times(0)).uploadPart(any(), any(), any(), anyInt(), any());
-        verify(operator, times(0)).completeMultipartUpload(any(), any(), any(), any());
     }
 
     @Test
     public void testCopyWrite_escalationPreservesOrder() {
-        // Buffer many small copyWrites until the accumulated size crosses MAX_UPLOAD_SIZE (32MiB) and forces an
-        // escalation to multipart mid-stream. The range reads only complete AFTER close() is called, so this
-        // exercises the deferred-handoff path: the buffered data must be flushed to the MultiPartWriter as the
-        // first part, before the copyWrite/write issued after escalation, and none of it may be dropped even
-        // though close() has already been invoked. This is the scenario a MINOR/MAJOR group (up to 128MiB) hits.
+        // Given small copyWrites buffered before multipart selection, replay must preserve their call order before
+        // operations issued after selection, independent of multipart boundaries.
         int mib = 1024 * 1024;
         when(operator.createMultipartUpload(any(), eq("testpath"))).thenReturn(CompletableFuture.completedFuture("test_upload_id"));
+        Map<Integer, ByteBuf> uploadedParts = new HashMap<>();
         when(operator.uploadPart(any(), eq("testpath"), eq("test_upload_id"), anyInt(), any()))
-            .thenAnswer(inv -> CompletableFuture.completedFuture(
-                new AbstractObjectStorage.ObjectStorageCompletedPart(inv.getArgument(3), "etag", "checksum")));
+            .thenAnswer(inv -> {
+                int partNumber = inv.getArgument(3);
+                uploadedParts.put(partNumber, inv.getArgument(4));
+                return CompletableFuture.completedFuture(
+                    new AbstractObjectStorage.ObjectStorageCompletedPart(partNumber, "etag", "checksum"));
+            });
         when(operator.completeMultipartUpload(any(), eq("testpath"), eq("test_upload_id"), any()))
             .thenReturn(CompletableFuture.completedFuture(null));
 
         // rangeRead hands back a not-yet-completed future per call so we can drive completion order by hand. The
-        // ObjectWriter chains reads sequentially, so each read is only issued once the previous one completes.
+        // multipart replay chain issues each read only after the previous one completes.
         List<CompletableFuture<ByteBuf>> reads = new ArrayList<>();
         List<Integer> readSizes = new ArrayList<>();
+        List<Byte> readMarkers = new ArrayList<>();
+        Map<String, Byte> markers = new HashMap<>();
         when(operator.rangeRead(any(), any(), anyLong(), anyLong())).thenAnswer(inv -> {
             long start = inv.getArgument(2);
             long end = inv.getArgument(3);
             CompletableFuture<ByteBuf> cf = new CompletableFuture<>();
             reads.add(cf);
             readSizes.add((int) (end - start));
+            readMarkers.add(markers.get(inv.getArgument(1)));
             return cf;
         });
 
-        // 9 * 4MiB = 36MiB > 32MiB, so the writer escalates after the 9th buffered copyWrite; the 10th copyWrite
-        // is then issued directly to the multipart writer.
-        int smallObjectCount = 10;
-        for (int i = 1; i <= smallObjectCount; i++) {
-            S3ObjectMetadata object = new S3ObjectMetadata(i, 4L * mib, S3ObjectType.STREAM);
-            writer.copyWrite(object, 0, 4L * mib);
+        // The first nine ranges total 33MiB and trigger selection. The tenth range is sent directly to the
+        // selected writer.
+        int[] copySizes = {4, 2, 3, 4, 4, 4, 4, 4, 4, 2};
+        for (int i = 0; i < 9; i++) {
+            S3ObjectMetadata object = new S3ObjectMetadata(i + 1, (long) copySizes[i] * mib, S3ObjectType.STREAM);
+            markers.put(object.key(), (byte) (i + 1));
+            writer.copyWrite(object, 0, (long) copySizes[i] * mib);
         }
-        assertNotNull(writer.largeObjectWriter);
+        S3ObjectMetadata lastObject = new S3ObjectMetadata(10, (long) copySizes[9] * mib, S3ObjectType.STREAM);
+        markers.put(lastObject.key(), (byte) 10);
+        writer.copyWrite(lastObject, 0, (long) copySizes[9] * mib);
         // Index block written last, exactly like StreamObjectCompactor does after the per-object copyWrites.
         writer.write(TestUtils.random(mib));
         CompletableFuture<Void> closeCf = writer.close();
@@ -172,27 +191,115 @@ public class ProxyWriterTest {
 
         // Drive the reads to completion in issue order; completing one may lazily trigger the next.
         for (int i = 0; i < reads.size(); i++) {
-            reads.get(i).complete(TestUtils.random(readSizes.get(i)));
+            ByteBuf read = TestUtils.random(readSizes.get(i));
+            read.setByte(0, readMarkers.get(i));
+            reads.get(i).complete(read);
         }
 
         assertTrue(closeCf.isDone());
         assertFalse(closeCf.isCompletedExceptionally());
-        assertEquals(smallObjectCount, reads.size(), "one range read per small copyWrite");
-
-        // Single-PUT path must not be used; the multipart upload must be completed exactly once.
+        // PutObject must not be used; the multipart upload must be completed exactly once.
         verify(operator, times(0)).write(any(), eq("testpath"), any());
         verify(operator, times(1)).completeMultipartUpload(any(), any(), any(), any());
-        verify(operator, times(2)).uploadPart(any(), eq("testpath"), eq("test_upload_id"), anyInt(), any());
 
-        // Part 1 must be the handoff of the 9 buffered objects (36MiB), in order - NOT the object copyWritten
-        // after escalation. Part 2 is the 10th object (4MiB) plus the index block (1MiB). A reorder/drop would
-        // make part 1 the 4MiB object and lose the 36MiB, so this pins down both ordering and no-data-loss.
-        ArgumentCaptor<ByteBuf> part1 = ArgumentCaptor.forClass(ByteBuf.class);
-        verify(operator).uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(1), part1.capture());
-        assertEquals(9 * 4 * mib, part1.getValue().readableBytes());
-        ArgumentCaptor<ByteBuf> part2 = ArgumentCaptor.forClass(ByteBuf.class);
-        verify(operator).uploadPart(any(), eq("testpath"), eq("test_upload_id"), eq(2), part2.capture());
-        assertEquals(4 * mib + mib, part2.getValue().readableBytes());
+        List<ByteBuf> parts = uploadedParts.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(Map.Entry::getValue)
+            .toList();
+        assertEquals(36L * mib, parts.stream().mapToLong(ByteBuf::readableBytes).sum());
+        long operationOffset = 0;
+        int partIndex = 0;
+        long partOffset = 0;
+        for (int i = 0; i < copySizes.length; i++) {
+            while (operationOffset >= partOffset + parts.get(partIndex).readableBytes()) {
+                partOffset += parts.get(partIndex).readableBytes();
+                partIndex++;
+            }
+            assertEquals(i + 1, parts.get(partIndex).getByte((int) (operationOffset - partOffset)));
+            operationOffset += (long) copySizes[i] * mib;
+        }
+    }
+
+    @Test
+    public void testCopyOnWriteSnapshotsPendingBuffers() {
+        // Given an operation is still pending, copyOnWrite must snapshot it immediately so later caller mutation
+        // cannot change the uploaded object.
+        when(operator.write(any(), eq("testpath"), any())).thenReturn(CompletableFuture.completedFuture(null));
+        ByteBuf source = TestUtils.randomPooled(16);
+        byte originalFirstByte = source.getByte(0);
+        writer.write(source.retainedDuplicate());
+
+        writer.copyOnWrite();
+        source.setByte(0, originalFirstByte + 1);
+        writer.close();
+
+        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(operator).write(any(), eq("testpath"), captor.capture());
+        assertEquals(originalFirstByte, captor.getValue().getByte(0));
+        source.release();
+    }
+
+    @Test
+    public void testFailedCopyWriteReleasesFollowingPendingWrite() {
+        // Given a range read fails, a later write buffer that cannot be appended must still be released.
+        when(operator.rangeRead(any(), any(), anyLong(), anyLong()))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("read failed")));
+        S3ObjectMetadata object = new S3ObjectMetadata(1, 1024, S3ObjectType.STREAM);
+        ByteBuf part = TestUtils.randomPooled(1024);
+        writer.copyWrite(object, 0, 1024);
+        writer.write(part);
+
+        CompletableFuture<Void> closeCf = writer.close();
+
+        assertTrue(closeCf.isCompletedExceptionally());
+        assertEquals(0, part.refCnt());
+        verify(operator, times(0)).write(any(), eq("testpath"), any());
+    }
+
+    @Test
+    public void testFailedMultipartReplayReleasesOwnedBuffers() {
+        // Given multipart replay has accumulated one range buffer, a later failed range read must release both
+        // that accumulated buffer and a following write that can no longer be appended.
+        when(operator.createMultipartUpload(any(), eq("testpath")))
+            .thenReturn(CompletableFuture.completedFuture("test_upload_id"));
+        when(operator.uploadPartCopy(any(), any(), eq("testpath"), anyLong(), anyLong(), eq("test_upload_id"), anyInt()))
+            .thenAnswer(inv -> CompletableFuture.completedFuture(
+                new AbstractObjectStorage.ObjectStorageCompletedPart(inv.getArgument(6), "etag", "checksum")));
+        CompletableFuture<ByteBuf> firstReadCf = new CompletableFuture<>();
+        when(operator.rangeRead(any(), any(), anyLong(), anyLong()))
+            .thenReturn(firstReadCf)
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("read failed")));
+
+        int mib = 1024 * 1024;
+        writer.copyWrite(new S3ObjectMetadata(1, 30L * mib, S3ObjectType.STREAM), 0, 30L * mib);
+        writer.copyWrite(new S3ObjectMetadata(2, mib, S3ObjectType.STREAM), 0, mib);
+        writer.copyWrite(new S3ObjectMetadata(3, mib, S3ObjectType.STREAM), 0, mib);
+        ByteBuf followingWrite = TestUtils.randomPooled(1);
+        writer.write(followingWrite);
+        CompletableFuture<Void> closeCf = writer.close();
+
+        ByteBuf firstRead = TestUtils.randomPooled(mib);
+        firstReadCf.complete(firstRead);
+
+        assertTrue(closeCf.isCompletedExceptionally());
+        assertEquals(0, firstRead.refCnt());
+        assertEquals(0, followingWrite.refCnt());
+        verify(operator, times(0)).uploadPart(any(), any(), any(), anyInt(), any());
+    }
+
+    @Test
+    public void testReleaseDiscardsPendingOperationsWithoutStartingReads() {
+        // Given no upload strategy has been selected, release owns and frees pending buffers without applying
+        // copy operations or starting remote reads.
+        S3ObjectMetadata object = new S3ObjectMetadata(1, 1024, S3ObjectType.STREAM);
+        ByteBuf part = TestUtils.randomPooled(1024);
+        writer.copyWrite(object, 0, 1024);
+        writer.write(part);
+
+        assertTrue(writer.release().isDone());
+
+        assertEquals(0, part.refCnt());
+        verify(operator, times(0)).rangeRead(any(), any(), anyLong(), anyLong());
     }
 
 }


### PR DESCRIPTION
## Why

`ProxyWriter` previously kept a separate `ObjectWriter` state machine and an additional future chain to hand buffered data to `MultiPartWriter`. This duplicated write state and made ordering, failure propagation, and buffer ownership difficult to reason about.

The upload strategy only needs to be selected after observing the cumulative object size. Objects at or below 32 MiB can use one `PutObject`; larger objects use multipart upload. A standalone large copy below that threshold intentionally uses `rangeRead` plus `PutObject`, avoiding multipart request overhead.

## What

- Represent pending writes and copy writes as ordered operations directly in `ProxyWriter`.
- Select multipart upload only when cumulative object size exceeds the 32 MiB threshold.
- Replay pending operations into a local PutObject buffer on close, or into `MultiPartWriter` when the threshold is crossed.
- Preserve operation order and express asynchronous failures through returned futures.
- Release buffers owned by multipart replay when a preceding range read fails.

## How

Before upload strategy selection, `ProxyWriter` owns an ordered list of pending operations. `copyOnWrite` snapshots retained write buffers in place. Closing the writer sequentially applies the operations to a local composite buffer and issues one `PutObject`.

Crossing the multipart threshold constructs a `MultiPartWriter` and immediately transfers every pending operation in call order. Its existing serialized range-read chain preserves object byte order. If a range read fails, writes that can no longer join the part release their buffers, and the accumulated part buffer is released before the part future fails.

The multipart ownership change is intentionally limited to preceding range-read failure handling; it does not add defensive behavior for `CompositeByteBuf.addComponent` failures.

## Reviewer notes

Start with `ProxyWriter`: `PendingOperation`, `closeWithPutObject`, and `newMultiPartObjectWriter` define strategy selection and replay ownership. Then review `MultiPartWriter.ObjectPart` for failure cleanup. `ProxyWriterTest` covers the exact 32 MiB boundary, ordered multipart replay, the standalone-copy PutObject path, copy-on-write, release without reads, and failure cleanup.