### PR TITLE
feat(zerozone): support direct local writes

### DIFF
--- a/core/src/main/java/kafka/automq/AutoMQConfig.java
+++ b/core/src/main/java/kafka/automq/AutoMQConfig.java
@@ -19,6 +19,7 @@
 
 package kafka.automq;
 
+import kafka.automq.zerozone.LocalWriteMode;
 import kafka.server.KafkaConfig;
 
 import org.apache.kafka.common.config.ConfigDef;
@@ -221,6 +222,10 @@ public class AutoMQConfig {
     public static final String ZONE_ROUTER_CHANNELS_CONFIG = "automq.zonerouter.channels";
     public static final String ZONE_ROUTER_CHANNELS_DOC = "The channels to use for cross zone router. Currently it only support object storage channel."
         + " The format is '0@s3://$bucket?region=$region[&batchInterval=250][&maxBytesInBatch=8388608]'";
+    public static final String ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG = "automq.zonerouter.local.write.mode";
+    public static final String ZONE_ROUTER_LOCAL_WRITE_MODE_DOC = "The persistence path for ZeroZone writes whose target Partition is on the current Broker. "
+        + "In router_channel mode, local records are written to RouterChannel before the Partition stores a LinkRecord. "
+        + "In direct mode, local records are written directly to the Partition. Forwarded records always use RouterChannel.";
 
     // Deprecated config start
     public static final String S3_ENDPOINT_CONFIG = "s3.endpoint";
@@ -322,6 +327,8 @@ public class AutoMQConfig {
             .define(AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_CONFIG, LONG, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_DEFAULT, between(0, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_MAX), MEDIUM, AutoMQConfig.RETRY_STORM_BACKOFF_MAX_DELAY_MS_DOC)
             .define(AutoMQConfig.KAFKA_GO_METADATA_COMPATIBILITY_ENABLED_CONFIG, BOOLEAN, AutoMQConfig.KAFKA_GO_METADATA_COMPATIBILITY_ENABLED_DEFAULT, MEDIUM, AutoMQConfig.KAFKA_GO_METADATA_COMPATIBILITY_ENABLED_DOC)
             .define(AutoMQConfig.ZONE_ROUTER_CHANNELS_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, AutoMQConfig.ZONE_ROUTER_CHANNELS_DOC)
+            .define(AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG, STRING, LocalWriteMode.ROUTER_CHANNEL.configName(),
+                ConfigDef.CaseInsensitiveValidString.in(LocalWriteMode.configNames()), MEDIUM, AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_DOC)
             // Deprecated config start
             .define(AutoMQConfig.S3_ENDPOINT_CONFIG, STRING, null, HIGH, AutoMQConfig.S3_ENDPOINT_DOC)
             .define(AutoMQConfig.S3_REGION_CONFIG, STRING, null, HIGH, AutoMQConfig.S3_REGION_DOC)
@@ -350,6 +357,7 @@ public class AutoMQConfig {
     private List<Pair<String, String>> baseLabels;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private Optional<List<BucketURI>> zoneRouterChannels;
+    private LocalWriteMode zoneRouterLocalWriteMode;
 
     public AutoMQConfig setup(KafkaConfig config) {
         dataBuckets = genDataBuckets(config);
@@ -358,6 +366,7 @@ public class AutoMQConfig {
         metricsExporterURI = genMetricsExporterURI(config);
         baseLabels = parseBaseLabels(config);
         zoneRouterChannels = genZoneRouterChannels(config);
+        zoneRouterLocalWriteMode = LocalWriteMode.fromName(config.getString(ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG));
         return this;
     }
 
@@ -387,6 +396,13 @@ public class AutoMQConfig {
 
     public Optional<List<BucketURI>> zoneRouterChannels() {
         return zoneRouterChannels;
+    }
+
+    /**
+     * Returns the configured persistence path for ZeroZone writes targeting a local Partition.
+     */
+    public LocalWriteMode zoneRouterLocalWriteMode() {
+        return zoneRouterLocalWriteMode;
     }
 
     private static List<BucketURI> genDataBuckets(KafkaConfig config) {

--- a/core/src/main/java/kafka/automq/zerozone/LocalWriteMode.java
+++ b/core/src/main/java/kafka/automq/zerozone/LocalWriteMode.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.zerozone;
+
+import java.util.Arrays;
+
+/**
+ * Controls how ZeroZone V2 persists Produce records whose target Partition is on the current Broker.
+ */
+public enum LocalWriteMode {
+    ROUTER_CHANNEL("router_channel"),
+    DIRECT("direct");
+
+    private final String configName;
+
+    LocalWriteMode(String configName) {
+        this.configName = configName;
+    }
+
+    /**
+     * Returns the stable value accepted by broker configuration.
+     */
+    public String configName() {
+        return configName;
+    }
+
+    /**
+     * Resolves a broker configuration value without requiring a specific case.
+     *
+     * @param configName broker configuration value
+     * @return matching local write mode
+     * @throws IllegalArgumentException if the value does not identify a supported mode
+     */
+    public static LocalWriteMode fromName(String configName) {
+        return Arrays.stream(values())
+            .filter(mode -> mode.configName.equalsIgnoreCase(configName))
+            .findFirst()
+            .orElseThrow(() ->
+                new IllegalArgumentException("Unsupported ZeroZone local write mode: " + configName));
+    }
+
+    /**
+     * Returns all stable values accepted by broker configuration.
+     */
+    public static String[] configNames() {
+        return Arrays.stream(values()).map(LocalWriteMode::configName).toArray(String[]::new);
+    }
+}

--- a/core/src/main/java/kafka/automq/zerozone/RouterInV2.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterInV2.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -181,9 +182,16 @@ public class RouterInV2 implements NonBlockingLocalRouterHandler {
         ZoneRouterProduceRequest zoneRouterProduceRequest
     ) {
         CompletableFuture<AutomqZoneRouterResponseData.Response> cf = new CompletableFuture<>();
-        appendEventLoop(channelOffset.orderHint()).execute(() ->
+        short orderHint = channelOffset == null ? orderHint(zoneRouterProduceRequest) : channelOffset.orderHint();
+        appendEventLoop(orderHint).execute(() ->
             FutureUtil.propagate(append0(channelOffset, zoneRouterProduceRequest, true), cf));
         return cf;
+    }
+
+    private static short orderHint(ZoneRouterProduceRequest request) {
+        ProduceRequestData.TopicProduceData topic = request.data().topicData().iterator().next();
+        int partition = topic.partitionData().get(0).index();
+        return (short) (Objects.hash(topic.name(), partition) % Short.MAX_VALUE);
     }
 
     private CompletableFuture<AutomqZoneRouterResponseData.Response> append0(

--- a/core/src/main/java/kafka/automq/zerozone/RouterOutV2.java
+++ b/core/src/main/java/kafka/automq/zerozone/RouterOutV2.java
@@ -67,16 +67,19 @@ public class RouterOutV2 {
     private final Map<Node, Proxy> proxies = new ConcurrentHashMap<>();
 
     private final LocalProxy localProxy;
+    private final LocalWriteMode localWriteMode;
     private final GetRouterOutNode mapping;
     private final AsyncSender asyncSender;
     private final Time time;
 
     public RouterOutV2(Node currentNode, RouterChannel routerChannel, GetRouterOutNode mapping,
-        NonBlockingLocalRouterHandler localRouterHandler, AsyncSender asyncSender, Time time) {
+        NonBlockingLocalRouterHandler localRouterHandler, LocalWriteMode localWriteMode, AsyncSender asyncSender,
+        Time time) {
         this.currentNode = currentNode;
         this.routerChannel = routerChannel;
         this.mapping = mapping;
         this.localProxy = new LocalProxy(localRouterHandler);
+        this.localWriteMode = localWriteMode;
         this.asyncSender = asyncSender;
         this.time = time;
     }
@@ -90,26 +93,37 @@ public class RouterOutV2 {
         boolean acks0 = args.requiredAcks() == (short) 0;
         for (Map.Entry<TopicPartition, MemoryRecords> entry : args.entriesPerPartition().entrySet()) {
             TopicPartition tp = entry.getKey();
-            MemoryRecords records = LegacyRecordConverter.maybeConvert(entry.getValue());
             Node node = mapping.getRouteOutNode(tp.topic(), tp.partition(), args.clientId());
             if (node.id() == Node.noNode().id()) {
                 responseMap.put(tp, new ProduceResponse.PartitionResponse(Errors.NOT_LEADER_OR_FOLLOWER));
                 continue;
             }
             short orderHint = orderHint(tp, args.clientId().connectionId());
+            boolean directLocal = node.id() == currentNode.id() && localWriteMode == LocalWriteMode.DIRECT;
+            MemoryRecords records = directLocal ? entry.getValue() : LegacyRecordConverter.maybeConvert(entry.getValue());
             int recordSize = records.sizeInBytes();
             ZoneRouterProduceRequest zoneRouterProduceRequest = zoneRouterProduceRequest(args, flag, tp, records);
-            CompletableFuture<RouterChannel.AppendResult> channelCf = routerChannel.append(node.id(), orderHint, ZoneRouterPackWriter.encodeDataBlock(List.of(zoneRouterProduceRequest)));
-            CompletableFuture<Void> proxyCf = channelCf.thenCompose(channelRst -> {
-                long timeNanos = time.nanoseconds();
-                ZeroZoneMetricsManager.OUT_APPEND_CHANNEL_LATENCY.record(timeNanos - startNanos);
-                ProxyRequest proxyRequest = new ProxyRequest(tp, channelRst.epoch(), channelRst.channelOffset(), zoneRouterProduceRequest, recordSize, timeoutMillis);
+            CompletableFuture<ProxyRequest> requestCf;
+            if (directLocal) {
+                requestCf = CompletableFuture.completedFuture(new ProxyRequest(tp, -1L, null,
+                    zoneRouterProduceRequest, recordSize, timeoutMillis));
+            } else {
+                requestCf = routerChannel.append(node.id(), orderHint,
+                    ZoneRouterPackWriter.encodeDataBlock(List.of(zoneRouterProduceRequest))).thenApply(channelRst -> {
+                        ZeroZoneMetricsManager.OUT_APPEND_CHANNEL_LATENCY.record(time.nanoseconds() - startNanos);
+                        return new ProxyRequest(tp, channelRst.epoch(), channelRst.channelOffset(),
+                            zoneRouterProduceRequest, recordSize, timeoutMillis);
+                    });
+            }
+            CompletableFuture<Void> proxyCf = requestCf.thenCompose(proxyRequest -> {
                 sendProxyRequest(node, proxyRequest);
                 return proxyRequest.cf.thenAccept(response -> {
                     if (!acks0) {
                         responseMap.put(tp, response);
                     }
-                    ZeroZoneMetricsManager.OUT_HANDLE_REQUEST_LATENCY.record(time.nanoseconds() - startNanos);
+                    if (!directLocal) {
+                        ZeroZoneMetricsManager.OUT_HANDLE_REQUEST_LATENCY.record(time.nanoseconds() - startNanos);
+                    }
                 });
             }).exceptionally(ex -> {
                 LOGGER.error("Exception in processing append proxies", ex);
@@ -164,7 +178,8 @@ public class RouterOutV2 {
 
         @Override
         public void send(ProxyRequest request) {
-            localRouterHandler.append(ChannelOffset.of(request.channelOffset), request.zoneRouterProduceRequest)
+            ChannelOffset channelOffset = request.channelOffset == null ? null : ChannelOffset.of(request.channelOffset);
+            localRouterHandler.append(channelOffset, request.zoneRouterProduceRequest)
                 .whenComplete((resp, ex) -> {
                     if (ex != null) {
                         request.completeWithError(Errors.forException(ex));

--- a/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
+++ b/core/src/main/java/kafka/automq/zerozone/ZeroZoneTrafficInterceptor.java
@@ -132,7 +132,8 @@ public class ZeroZoneTrafficInterceptor implements TrafficInterceptor, MetadataP
 
         // Zero Zone V2
         this.routerInV2 = new RouterInV2(routerChannelProvider, kafkaApis, kafkaConfig.rack().get(), time);
-        this.routerOutV2 = new RouterOutV2(currentNode, routerChannelProvider.channel(), mapping::getRouteOutNode, routerInV2, asyncSender, time);
+        this.routerOutV2 = new RouterOutV2(currentNode, routerChannelProvider.channel(), mapping::getRouteOutNode,
+            routerInV2, kafkaConfig.automq().zoneRouterLocalWriteMode(), asyncSender, time);
         this.committedEpochManager = new CommittedEpochManager(nodeId);
         this.routerChannelProvider.addEpochListener(committedEpochManager);
         DefaultReplayer replayer = new DefaultReplayer();

--- a/core/src/test/java/kafka/automq/zerozone/LocalWriteModeTest.java
+++ b/core/src/test/java/kafka/automq/zerozone/LocalWriteModeTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.zerozone;
+
+import kafka.automq.AutoMQConfig;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the external configuration names for ZeroZone local write modes.
+ */
+@Tag("S3Unit")
+public class LocalWriteModeTest {
+
+    /**
+     * Given supported values with different cases, parsing returns the canonical enum constants.
+     */
+    @Test
+    public void testParseSupportedModesCaseInsensitively() {
+        assertEquals(LocalWriteMode.ROUTER_CHANNEL, LocalWriteMode.fromName("router_channel"));
+        assertEquals(LocalWriteMode.ROUTER_CHANNEL, LocalWriteMode.fromName("ROUTER_CHANNEL"));
+        assertEquals(LocalWriteMode.DIRECT, LocalWriteMode.fromName("direct"));
+    }
+
+    /**
+     * Given an unsupported value, parsing rejects it instead of silently selecting a write path.
+     */
+    @Test
+    public void testRejectUnsupportedMode() {
+        assertThrows(IllegalArgumentException.class, () -> LocalWriteMode.fromName("passthrough"));
+    }
+
+    /**
+     * Given no explicit setting, broker configuration preserves the RouterChannel write path.
+     */
+    @Test
+    public void testConfigDefaultsToRouterChannel() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        assertEquals(LocalWriteMode.ROUTER_CHANNEL.configName(),
+            configDef.defaultValues().get(AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG));
+    }
+
+    /**
+     * Given the direct setting in a different case, broker configuration accepts the value.
+     */
+    @Test
+    public void testConfigAcceptsModeCaseInsensitively() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        Map<String, Object> parsed = configDef.parse(Map.of(
+            AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG, "DIRECT"
+        ));
+
+        assertEquals("DIRECT", parsed.get(AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG));
+    }
+
+    /**
+     * Given an unsupported setting, broker configuration fails before startup.
+     */
+    @Test
+    public void testConfigRejectsUnsupportedMode() {
+        ConfigDef configDef = new ConfigDef();
+        AutoMQConfig.define(configDef);
+
+        assertThrows(ConfigException.class, () -> configDef.parse(Map.of(
+            AutoMQConfig.ZONE_ROUTER_LOCAL_WRITE_MODE_CONFIG, "passthrough"
+        )));
+    }
+}

--- a/core/src/test/java/kafka/automq/zerozone/RouterOutV2Test.java
+++ b/core/src/test/java/kafka/automq/zerozone/RouterOutV2Test.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026, AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.automq.zerozone;
+
+import kafka.automq.interceptor.ClientIdMetadata;
+import kafka.automq.interceptor.ProduceRequestArgs;
+import kafka.automq.utils.AsyncSender;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.message.AutomqZoneRouterResponseData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.requests.s3.AutomqZoneRouterResponse;
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies how RouterOut V2 selects and aggregates local write paths.
+ */
+@Tag("S3Unit")
+public class RouterOutV2Test {
+    private static final Node CURRENT_NODE = new Node(1, "localhost", 9092);
+    private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
+    private static final TopicPartition REMOTE_TOPIC_PARTITION = new TopicPartition("topic", 1);
+
+    /**
+     * Given DIRECT mode and a partition routed to the current Broker, the request writes the Partition without
+     * appending RouterChannel.
+     */
+    @Test
+    public void testDirectModeWritesLocalPartitionWithoutRouterChannel() {
+        StubRouterChannel routerChannel = new StubRouterChannel();
+        AtomicInteger localAppendCount = new AtomicInteger();
+        AtomicReference<ChannelOffset> channelOffset = new AtomicReference<>();
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            routerChannel,
+            (topic, partition, clientId) -> CURRENT_NODE,
+            (offset, request) -> {
+                localAppendCount.incrementAndGet();
+                channelOffset.set(offset);
+                return CompletableFuture.completedFuture(successResponse());
+            },
+            LocalWriteMode.DIRECT,
+            new FailedAsyncSender(),
+            new MockTime()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(result::set, (short) -1));
+
+        assertEquals(0, routerChannel.appendCount.get());
+        assertEquals(1, localAppendCount.get());
+        assertNull(channelOffset.get());
+        assertEquals(Errors.NONE, result.get().get(TOPIC_PARTITION).error);
+    }
+
+    /**
+     * Given ROUTER_CHANNEL mode and a partition routed to the current Broker, the request keeps the existing linked
+     * local append path.
+     */
+    @Test
+    public void testRouterChannelModeKeepsLinkedLocalWrite() {
+        StubRouterChannel routerChannel = new StubRouterChannel();
+        AtomicInteger linkedAppendCount = new AtomicInteger();
+        AtomicReference<ChannelOffset> channelOffset = new AtomicReference<>();
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            routerChannel,
+            (topic, partition, clientId) -> CURRENT_NODE,
+            (offset, request) -> {
+                linkedAppendCount.incrementAndGet();
+                channelOffset.set(offset);
+                return CompletableFuture.completedFuture(successResponse());
+            },
+            LocalWriteMode.ROUTER_CHANNEL,
+            new FailedAsyncSender(),
+            new MockTime()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(result::set, (short) -1));
+
+        assertEquals(1, routerChannel.appendCount.get());
+        assertEquals(1, linkedAppendCount.get());
+        assertEquals(Errors.NONE, result.get().get(TOPIC_PARTITION).error);
+        assertSame(routerChannel.offset, channelOffset.get().byteBuf());
+    }
+
+    /**
+     * Given DIRECT mode with local and remote partitions, only the local partition bypasses RouterChannel.
+     */
+    @Test
+    public void testDirectModeSplitsLocalAndRemotePartitions() {
+        StubRouterChannel routerChannel = new StubRouterChannel();
+        AtomicReference<ChannelOffset> directChannelOffset = new AtomicReference<>();
+        CompletableFuture<AutomqZoneRouterResponseData.Response> directResponse = new CompletableFuture<>();
+        AtomicInteger callbackCount = new AtomicInteger();
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        CompletableFuture<ClientResponse> remoteResponse = new CompletableFuture<>();
+        Node remoteNode = new Node(2, "remote", 9092);
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            routerChannel,
+            (topic, partition, clientId) -> partition == TOPIC_PARTITION.partition() ? CURRENT_NODE : remoteNode,
+            (channelOffset, request) -> {
+                directChannelOffset.set(channelOffset);
+                return directResponse;
+            },
+            LocalWriteMode.DIRECT,
+            new StubAsyncSender(remoteResponse),
+            new MockTime()
+        );
+        Map<TopicPartition, MemoryRecords> entries = Map.of(
+            TOPIC_PARTITION, records(),
+            REMOTE_TOPIC_PARTITION, records()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(entries, response -> {
+            callbackCount.incrementAndGet();
+            result.set(response);
+        }, (short) -1));
+
+        assertNull(directChannelOffset.get());
+        assertEquals(1, routerChannel.appendCount.get());
+        assertEquals(0, callbackCount.get());
+
+        directResponse.complete(successResponse());
+        assertEquals(0, callbackCount.get());
+
+        remoteResponse.complete(successClientResponse(REMOTE_TOPIC_PARTITION));
+        waitFor(() -> callbackCount.get() == 1);
+
+        assertEquals(1, callbackCount.get());
+        assertEquals(Errors.NONE, result.get().get(TOPIC_PARTITION).error);
+        assertEquals(Errors.NONE, result.get().get(REMOTE_TOPIC_PARTITION).error);
+    }
+
+    /**
+     * Given a DIRECT local write with acks=0, the client callback returns once without waiting for persistence.
+     */
+    @Test
+    public void testDirectModeAcksZeroReturnsOnceWithoutWaiting() {
+        StubRouterChannel routerChannel = new StubRouterChannel();
+        AtomicInteger directAppendCount = new AtomicInteger();
+        AtomicInteger callbackCount = new AtomicInteger();
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            routerChannel,
+            (topic, partition, clientId) -> CURRENT_NODE,
+            (channelOffset, request) -> {
+                directAppendCount.incrementAndGet();
+                return new CompletableFuture<>();
+            },
+            LocalWriteMode.DIRECT,
+            new FailedAsyncSender(),
+            new MockTime()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(response -> {
+            callbackCount.incrementAndGet();
+            result.set(response);
+        }, (short) 0));
+
+        assertEquals(1, directAppendCount.get());
+        assertEquals(1, callbackCount.get());
+        assertEquals(Errors.NONE, result.get().get(TOPIC_PARTITION).error);
+        assertEquals(0, routerChannel.appendCount.get());
+    }
+
+    /**
+     * Given no route target, neither local persistence path starts and the response remains retriable.
+     */
+    @Test
+    public void testNoRouteReturnsNotLeaderOrFollower() {
+        StubRouterChannel routerChannel = new StubRouterChannel();
+        AtomicInteger localAppendCount = new AtomicInteger();
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            routerChannel,
+            (topic, partition, clientId) -> Node.noNode(),
+            (channelOffset, request) -> {
+                localAppendCount.incrementAndGet();
+                return CompletableFuture.completedFuture(successResponse());
+            },
+            LocalWriteMode.DIRECT,
+            new FailedAsyncSender(),
+            new MockTime()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(result::set, (short) -1));
+
+        assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, result.get().get(TOPIC_PARTITION).error);
+        assertEquals(0, routerChannel.appendCount.get());
+        assertEquals(0, localAppendCount.get());
+    }
+
+    /**
+     * Given a failed direct append, the response preserves its Kafka protocol error.
+     */
+    @Test
+    public void testDirectModePreservesAppendError() {
+        AtomicReference<Map<TopicPartition, ProduceResponse.PartitionResponse>> result = new AtomicReference<>();
+        RouterOutV2 routerOut = new RouterOutV2(
+            CURRENT_NODE,
+            new StubRouterChannel(),
+            (topic, partition, clientId) -> CURRENT_NODE,
+            (channelOffset, request) -> CompletableFuture.failedFuture(
+                Errors.INVALID_PRODUCER_ID_MAPPING.exception()),
+            LocalWriteMode.DIRECT,
+            new FailedAsyncSender(),
+            new MockTime()
+        );
+
+        routerOut.handleProduceAppendProxy(produceArgs(result::set, (short) -1));
+
+        assertEquals(Errors.INVALID_PRODUCER_ID_MAPPING, result.get().get(TOPIC_PARTITION).error);
+    }
+
+    private static ProduceRequestArgs produceArgs(
+        java.util.function.Consumer<Map<TopicPartition, ProduceResponse.PartitionResponse>> callback,
+        short acks
+    ) {
+        return produceArgs(Map.of(TOPIC_PARTITION, records()), callback, acks);
+    }
+
+    private static ProduceRequestArgs produceArgs(
+        Map<TopicPartition, MemoryRecords> entries,
+        java.util.function.Consumer<Map<TopicPartition, ProduceResponse.PartitionResponse>> callback,
+        short acks
+    ) {
+        return ProduceRequestArgs.builder()
+            .apiVersion((short) 11)
+            .clientId(ClientIdMetadata.of("client", null, "connection"))
+            .timeout(10_000)
+            .requiredAcks(acks)
+            .entriesPerPartition(entries)
+            .responseCallback(callback)
+            .recordValidationStatsCallback(ignored -> { })
+            .build();
+    }
+
+    private static MemoryRecords records() {
+        MemoryRecords records = MemoryRecords.withRecords(
+            Compression.NONE,
+            new SimpleRecord("value".getBytes(StandardCharsets.UTF_8))
+        );
+        return records;
+    }
+
+    private static AutomqZoneRouterResponseData.Response successResponse() {
+        return successResponse(TOPIC_PARTITION);
+    }
+
+    private static AutomqZoneRouterResponseData.Response successResponse(TopicPartition topicPartition) {
+        ProduceResponseData.PartitionProduceResponse partition =
+            new ProduceResponseData.PartitionProduceResponse().setIndex(topicPartition.partition());
+        ProduceResponseData.TopicProduceResponse topic = new ProduceResponseData.TopicProduceResponse()
+            .setName(topicPartition.topic())
+            .setPartitionResponses(List.of(partition));
+        ProduceResponseData data = new ProduceResponseData().setResponses(
+            new ProduceResponseData.TopicProduceResponseCollection(List.of(topic).iterator())
+        );
+        return new AutomqZoneRouterResponseData.Response().setData(ZoneRouterResponseCodec.encode(data).array());
+    }
+
+    private static ClientResponse successClientResponse(TopicPartition topicPartition) {
+        AutomqZoneRouterResponse response = new AutomqZoneRouterResponse(new AutomqZoneRouterResponseData()
+            .setResponses(List.of(successResponse(topicPartition))));
+        return new ClientResponse(null, null, "remote", 0, 0, false, null, null, response);
+    }
+
+    private static void waitFor(java.util.function.BooleanSupplier condition) {
+        long deadlineNanos = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(5);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadlineNanos) {
+            Thread.onSpinWait();
+        }
+    }
+
+    private static final class StubRouterChannel implements RouterChannel {
+        private final AtomicInteger appendCount = new AtomicInteger();
+        private final ByteBuf offset = Unpooled.wrappedBuffer(new byte[] {1});
+        private AppendResult lastAppendResult;
+
+        @Override
+        public CompletableFuture<AppendResult> append(int targetNodeId, short orderHint, ByteBuf data) {
+            appendCount.incrementAndGet();
+            lastAppendResult = new AppendResult(1L, offset);
+            return CompletableFuture.completedFuture(lastAppendResult);
+        }
+
+        @Override
+        public CompletableFuture<ByteBuf> get(ByteBuf channelOffset) {
+            return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        }
+
+        @Override
+        public void nextEpoch(long epoch) {
+        }
+
+        @Override
+        public void trim(long epoch) {
+        }
+
+        @Override
+        public CompletableFuture<Void> close() {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class FailedAsyncSender implements AsyncSender {
+        @Override
+        public <T extends AbstractRequest> CompletableFuture<org.apache.kafka.clients.ClientResponse> sendRequest(
+            Node node,
+            AbstractRequest.Builder<T> requestBuilder
+        ) {
+            return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        }
+
+        @Override
+        public void initiateClose() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class StubAsyncSender implements AsyncSender {
+        private final CompletableFuture<ClientResponse> response;
+
+        private StubAsyncSender(CompletableFuture<ClientResponse> response) {
+            this.response = response;
+        }
+
+        @Override
+        public <T extends AbstractRequest> CompletableFuture<ClientResponse> sendRequest(
+            Node node,
+            AbstractRequest.Builder<T> requestBuilder
+        ) {
+            return response;
+        }
+
+        @Override
+        public void initiateClose() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
## Why

ZeroZone currently persists every Produce request to RouterChannel before writing the target Partition, including requests whose target Partition is already on the current Broker. RouterChannel reduces ConfirmWAL writes for forwarded requests, but on low-latency storage the extra local RouterChannel append adds latency without providing a cross-zone routing benefit.

ZeroZone needs an optional local write path that bypasses RouterChannel while preserving the existing path by default and continuing to use RouterChannel whenever a request must be forwarded to another Broker.

## What

Add `automq.zonerouter.local.write.mode` with two values:

- `router_channel` (default): preserve the existing behavior.
- `direct`: when the target Partition is local, send a `ProxyRequest` without a channel offset through the existing `LocalProxy` and write directly to the Partition. Requests targeting another Broker continue to use RouterChannel.

When a direct request has no channel offset, `RouterInV2` derives its event-loop ordering hint from the request's topic and partition. The change also covers configuration validation, mixed local and remote requests, `acks=0`, and error propagation.
