### PR TITLE
fix(autobalancer): support TLS for LoadRetriever

### DIFF
--- a/core/src/main/java/kafka/autobalancer/LoadRetriever.java
+++ b/core/src/main/java/kafka/autobalancer/LoadRetriever.java
@@ -95,7 +95,7 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
     private final ScheduledExecutorService mainExecutorService;
     private final Map<Integer, BrokerEndpoints> bootstrapServerMapInUse;
     private final Set<TopicPartition> currentAssignment = new HashSet<>();
-    private final StaticAutoBalancerConfig staticConfig;
+    private final Properties clientConfigs;
     private final String listenerName;
     private volatile boolean leaderEpochInitialized;
     private volatile boolean isLeader;
@@ -115,7 +115,8 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
         this.cond = lock.newCondition();
         this.mainExecutorService = Executors.newSingleThreadScheduledExecutor(new AutoBalancerThreadFactory("load-retriever-main"));
         leaderEpochInitialized = false;
-        staticConfig = new StaticAutoBalancerConfig(config.originals(), false);
+        StaticAutoBalancerConfig staticConfig = new StaticAutoBalancerConfig(config.originals(), false);
+        clientConfigs = StaticAutoBalancerConfigUtils.parseClientConfigs(config.originals());
         listenerName = staticConfig.getString(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG);
         metricReporterTopicPartition = config.getInt(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_METRICS_TOPIC_NUM_PARTITIONS_CONFIG);
         metricReporterTopicRetentionTime = config.getLong(AutoBalancerControllerConfig.AUTO_BALANCER_CONTROLLER_METRICS_TOPIC_RETENTION_MS_CONFIG);
@@ -161,6 +162,7 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
 
     protected Properties buildConsumerProps(String bootstrapServer) {
         Properties consumerProps = new Properties();
+        consumerProps.putAll(clientConfigs);
         long randomToken = RANDOM.nextLong();
         consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientIdPrefix + randomToken);
@@ -169,7 +171,6 @@ public class LoadRetriever extends AbstractResumableService implements BrokerSta
         consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MetricSerde.class.getName());
-        StaticAutoBalancerConfigUtils.addSslConfigs(consumerProps, this.staticConfig);
         return consumerProps;
     }
 

--- a/core/src/main/java/kafka/autobalancer/config/StaticAutoBalancerConfig.java
+++ b/core/src/main/java/kafka/autobalancer/config/StaticAutoBalancerConfig.java
@@ -30,11 +30,12 @@ import java.util.Map;
 public class StaticAutoBalancerConfig extends AbstractConfig {
     protected static final ConfigDef CONFIG;
     private static final String PREFIX = "autobalancer.";
+    public static final String AUTO_BALANCER_CLIENT_AUTH_PREFIX = PREFIX + "client.auth.";
 
     /* Configurations */
-    public static final String AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL = PREFIX + "client.auth." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
-    public static final String AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM = PREFIX + "client.auth." + SaslConfigs.SASL_MECHANISM;
-    public static final String AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG = PREFIX + "client.auth." + SaslConfigs.SASL_JAAS_CONFIG;
+    public static final String AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL = clientAuthConfig(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
+    public static final String AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM = clientAuthConfig(SaslConfigs.SASL_MECHANISM);
+    public static final String AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG = clientAuthConfig(SaslConfigs.SASL_JAAS_CONFIG);
     public static final String AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG = PREFIX + "client.listener.name";
     /* Default values */
     public static final String DEFAULT_AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL = CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL;
@@ -50,21 +51,6 @@ public class StaticAutoBalancerConfig extends AbstractConfig {
 
     static {
         CONFIG = new ConfigDef()
-                .define(AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL,
-                        ConfigDef.Type.STRING,
-                        DEFAULT_AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL,
-                        ConfigDef.Importance.MEDIUM,
-                        AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL_DOC)
-                .define(AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM,
-                        ConfigDef.Type.STRING,
-                        DEFAULT_AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM,
-                        ConfigDef.Importance.MEDIUM,
-                        AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM_DOC)
-                .define(AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG,
-                        ConfigDef.Type.PASSWORD,
-                        DEFAULT_AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG,
-                        ConfigDef.Importance.MEDIUM,
-                        AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG_DOC)
                 .define(AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG,
                         ConfigDef.Type.STRING,
                         DEFAULT_AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG,
@@ -75,4 +61,15 @@ public class StaticAutoBalancerConfig extends AbstractConfig {
     public StaticAutoBalancerConfig(Map<?, ?> originals, boolean doLogs) {
         super(CONFIG, originals, doLogs);
     }
+
+    /**
+     * Build the Auto Balancer client authentication key for a standard Kafka client configuration.
+     *
+     * @param baseConfigName standard Kafka client configuration name
+     * @return configuration name shared by the Auto Balancer producer and consumer
+     */
+    public static String clientAuthConfig(String baseConfigName) {
+        return AUTO_BALANCER_CLIENT_AUTH_PREFIX + baseConfigName;
+    }
+
 }

--- a/core/src/main/java/kafka/autobalancer/config/StaticAutoBalancerConfigUtils.java
+++ b/core/src/main/java/kafka/autobalancer/config/StaticAutoBalancerConfigUtils.java
@@ -19,11 +19,7 @@
 
 package kafka.autobalancer.config;
 
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.types.Password;
-
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -33,41 +29,21 @@ import java.util.Properties;
 public class StaticAutoBalancerConfigUtils {
 
     /**
-     * Parse AdminClient configs based on the given {@link StaticAutoBalancerConfig configs}.
+     * Convert shared Auto Balancer client settings to standard Kafka client settings. The Kafka producer and
+     * consumer ConfigDefs are responsible for validation and type conversion.
      *
-     * @param clientConfigs Configs that will be return with SSL configs.
-     * @param configs            Configs to be used for parsing AdminClient SSL configs.
+     * @param configs Auto Balancer settings
+     * @return shared Kafka client settings
      */
-    public static void addSslConfigs(Properties clientConfigs, StaticAutoBalancerConfig configs) {
-        // Add security protocol (if specified).
-        try {
-            setStringConfigIfExists(configs, clientConfigs, StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL,
-                    CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
-            setStringConfigIfExists(configs, clientConfigs, StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM,
-                    SaslConfigs.SASL_MECHANISM);
-            setPasswordConfigIfExists(configs, clientConfigs, StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG,
-                    SaslConfigs.SASL_JAAS_CONFIG);
-        } catch (ConfigException ce) {
-            // let it go.
-        }
-    }
-
-    private static void setPasswordConfigIfExists(StaticAutoBalancerConfig configs, Properties props, String name, String originalName) {
-        try {
-            Password pwd = configs.getPassword(name);
-            if (pwd != null) {
-                props.put(originalName, pwd);
+    public static Properties parseClientConfigs(Map<String, ?> configs) {
+        Properties clientConfigs = new Properties();
+        for (Map.Entry<String, ?> entry : configs.entrySet()) {
+            if (entry.getKey().startsWith(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_PREFIX)
+                    && entry.getValue() != null) {
+                clientConfigs.put(entry.getKey().substring(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_PREFIX.length()),
+                        entry.getValue());
             }
-        } catch (ConfigException ce) {
-            // let it go.
         }
-    }
-
-    private static void setStringConfigIfExists(StaticAutoBalancerConfig configs, Properties props, String name, String originalName) {
-        try {
-            props.put(originalName, configs.getString(name));
-        } catch (ConfigException ce) {
-            // let it go.
-        }
+        return clientConfigs;
     }
 }

--- a/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
+++ b/core/src/main/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporter.java
@@ -245,7 +245,8 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
         }
 
         StaticAutoBalancerConfig staticAutoBalancerConfig = new StaticAutoBalancerConfig(configs, false);
-        Properties producerProps = AutoBalancerMetricsReporterConfig.parseProducerConfigs(configs);
+        Properties producerProps = StaticAutoBalancerConfigUtils.parseClientConfigs(configs);
+        producerProps.putAll(AutoBalancerMetricsReporterConfig.parseProducerConfigs(configs));
 
         // Add BootstrapServers if not set
         if (!producerProps.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)) {
@@ -269,8 +270,6 @@ public class AutoBalancerMetricsReporter implements MetricsRegistryListener, Met
         setIfAbsent(producerProps, ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         setIfAbsent(producerProps, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, MetricSerde.class.getName());
         setIfAbsent(producerProps, ProducerConfig.ACKS_CONFIG, "all");
-        StaticAutoBalancerConfigUtils.addSslConfigs(producerProps, staticAutoBalancerConfig);
-
         metricsReporterCreateRetries = reporterConfig.getInt(
                 AutoBalancerMetricsReporterConfig.AUTO_BALANCER_METRICS_REPORTER_CREATE_RETRIES_CONFIG);
 

--- a/core/src/test/java/kafka/autobalancer/LoadRetrieverTest.java
+++ b/core/src/test/java/kafka/autobalancer/LoadRetrieverTest.java
@@ -20,20 +20,32 @@
 package kafka.autobalancer;
 
 import kafka.autobalancer.config.AutoBalancerControllerConfig;
+import kafka.autobalancer.config.StaticAutoBalancerConfig;
 import kafka.autobalancer.model.ClusterModel;
 
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.controller.Controller;
 import org.apache.kafka.metadata.BrokerRegistrationFencingChange;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
+@Tag("S3Unit")
 public class LoadRetrieverTest {
 
     @Test
@@ -77,5 +89,46 @@ public class LoadRetrieverTest {
         loadRetriever.onBrokerUnregister(new UnregisterBrokerRecord().setBrokerId(1));
         Assertions.assertFalse(loadRetriever.hasAvailableBrokerInUse());
         Assertions.assertFalse(loadRetriever.hasAvailableBroker());
+    }
+
+    /**
+     * Given shared client settings, the load retriever passes them to its Kafka consumer while retaining
+     * authoritative values for its internal settings.
+     */
+    @Test
+    public void testMetricsConsumerUsesSharedClientConfig() {
+        Password keyStorePassword = new Password("key-store-password");
+        Password keyPassword = new Password("key-password");
+        Password trustStorePassword = new Password("trust-store-password");
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), SecurityProtocol.SSL.name);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG), "/ssl/client.keystore.jks");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), keyStorePassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEY_PASSWORD_CONFIG), keyPassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), "/ssl/client.truststore.jks");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), trustStorePassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG), "");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig("future.kafka.config"), "future-value");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), "shared:9092");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.CLIENT_ID_CONFIG), "shared-client");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG), "9999");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), String.class.getName());
+        AutoBalancerControllerConfig controllerConfig = new AutoBalancerControllerConfig(configs, false);
+        LoadRetriever loadRetriever = new LoadRetriever(controllerConfig, Mockito.mock(Controller.class), Mockito.mock(ClusterModel.class));
+
+        Properties consumerProps = loadRetriever.buildConsumerProps("broker:9095");
+
+        Assertions.assertEquals(SecurityProtocol.SSL.name, consumerProps.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals("/ssl/client.keystore.jks", consumerProps.getProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals(keyStorePassword, consumerProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals(keyPassword, consumerProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+        Assertions.assertEquals("/ssl/client.truststore.jks", consumerProps.getProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals(trustStorePassword, consumerProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals("", consumerProps.getProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
+        Assertions.assertEquals("future-value", consumerProps.getProperty("future.kafka.config"));
+        Assertions.assertEquals("broker:9095", consumerProps.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        Assertions.assertNotEquals("shared-client", consumerProps.getProperty(ConsumerConfig.CLIENT_ID_CONFIG));
+        Assertions.assertEquals("1000", consumerProps.getProperty(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG));
+        Assertions.assertEquals(StringDeserializer.class.getName(), consumerProps.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
     }
 }

--- a/core/src/test/java/kafka/autobalancer/config/AutoBalancerConfigTest.java
+++ b/core/src/test/java/kafka/autobalancer/config/AutoBalancerConfigTest.java
@@ -19,19 +19,22 @@
 
 package kafka.autobalancer.config;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.StringDeserializer;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+@Tag("S3Unit")
 public class AutoBalancerConfigTest {
 
     @Test
@@ -45,21 +48,26 @@ public class AutoBalancerConfigTest {
     }
 
     @Test
-    public void testSSLConfig() {
+    public void testClientConfigPassthrough() {
         Map<String, Object> props = new HashMap<>();
-        props.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name);
-        props.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SASL_MECHANISM, "PLAIN");
-        Password pwd = new Password("jaas-config");
-        props.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_AUTH_SASL_JAAS_CONFIG, pwd);
-        props.put(AutoBalancerMetricsReporterConfig.AUTO_BALANCER_METRICS_REPORTER_LINGER_MS_CONFIG, "20");
-        AutoBalancerMetricsReporterConfig reporterConfig = new AutoBalancerMetricsReporterConfig(props, false);
-        Assertions.assertEquals(20L, reporterConfig.getLong(AutoBalancerMetricsReporterConfig.AUTO_BALANCER_METRICS_REPORTER_LINGER_MS_CONFIG));
+        props.put(StaticAutoBalancerConfig.clientAuthConfig(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), "SSL");
+        props.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG), "TLSv1.2,TLSv1.3");
+        props.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), "trust-store-password");
+        props.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), StringDeserializer.class.getName());
+        props.put(StaticAutoBalancerConfig.clientAuthConfig(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), StringDeserializer.class.getName());
+        props.put(StaticAutoBalancerConfig.clientAuthConfig("future.kafka.config"), "future-value");
+        props.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG, "INTERNAL_SSL");
 
-        StaticAutoBalancerConfig config = new StaticAutoBalancerConfig(reporterConfig.originals(), false);
-        Properties clientConfig = new Properties();
-        StaticAutoBalancerConfigUtils.addSslConfigs(clientConfig, config);
-        Assertions.assertEquals(SecurityProtocol.SASL_PLAINTEXT.name, clientConfig.getProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG));
-        Assertions.assertEquals("PLAIN", clientConfig.getProperty(SaslConfigs.SASL_MECHANISM));
-        Assertions.assertEquals(pwd, clientConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+        Properties clientConfigs = StaticAutoBalancerConfigUtils.parseClientConfigs(props);
+
+        Assertions.assertEquals("SSL", clientConfigs.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals("TLSv1.2,TLSv1.3", clientConfigs.getProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG));
+        Assertions.assertEquals("trust-store-password", clientConfigs.getProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals("future-value", clientConfigs.getProperty("future.kafka.config"));
+        Assertions.assertFalse(clientConfigs.containsKey(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG));
+
+        ConsumerConfig consumerConfig = new ConsumerConfig(clientConfigs);
+        Assertions.assertEquals(new Password("trust-store-password"),
+                consumerConfig.getPassword(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
     }
 }

--- a/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
+++ b/core/src/test/java/kafka/autobalancer/metricsreporter/AutoBalancerMetricsReporterTest.java
@@ -17,9 +17,14 @@
 
 package kafka.autobalancer.metricsreporter;
 
+import kafka.autobalancer.config.AutoBalancerMetricsReporterConfig;
 import kafka.autobalancer.config.StaticAutoBalancerConfig;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.network.SocketServerConfigs;
 import org.apache.kafka.server.config.KRaftConfigs;
 
@@ -35,11 +40,21 @@ import org.mockito.Mockito;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 @Timeout(60)
 @Tag("S3Unit")
 public class AutoBalancerMetricsReporterTest {
+
+    private static class CapturingAutoBalancerMetricsReporter extends AutoBalancerMetricsReporter {
+        private Properties producerProps;
+
+        @Override
+        protected void createAutoBalancerMetricsProducer(Properties producerProps) {
+            this.producerProps = producerProps;
+        }
+    }
 
     @Test
     public void testBootstrapServersConfig() {
@@ -127,4 +142,73 @@ public class AutoBalancerMetricsReporterTest {
         );
     }
 
+    /**
+     * Given shared Auto Balancer mTLS settings, the metrics reporter passes them to its Kafka producer.
+     */
+    @Test
+    public void testMetricsProducerReceivesClientSslConfig() {
+        Password keyStorePassword = new Password("key-store-password");
+        Password keyPassword = new Password("key-password");
+        Password trustStorePassword = new Password("trust-store-password");
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL_SSL://localhost:9095");
+        configs.put(KRaftConfigs.NODE_ID_CONFIG, "1");
+        configs.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG, "INTERNAL_SSL");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), SecurityProtocol.SSL.name);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG), "/ssl/client.keystore.jks");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), keyStorePassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_KEY_PASSWORD_CONFIG), keyPassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), "/ssl/client.truststore.jks");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), trustStorePassword);
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG), "");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig("future.kafka.config"), "future-value");
+        CapturingAutoBalancerMetricsReporter reporter = new CapturingAutoBalancerMetricsReporter();
+
+        reporter.configure(configs);
+
+        Assertions.assertEquals("localhost:9095", reporter.producerProps.getProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
+        Assertions.assertEquals(SecurityProtocol.SSL.name, reporter.producerProps.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals("/ssl/client.keystore.jks", reporter.producerProps.getProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals(keyStorePassword, reporter.producerProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals(keyPassword, reporter.producerProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+        Assertions.assertEquals("/ssl/client.truststore.jks", reporter.producerProps.getProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals(trustStorePassword, reporter.producerProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals("", reporter.producerProps.getProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
+        Assertions.assertEquals("future-value", reporter.producerProps.getProperty("future.kafka.config"));
+    }
+
+    /**
+     * Given a reporter-specific SSL value and no shared value, the metrics producer retains the reporter value.
+     */
+    @Test
+    public void testMetricsProducerRetainsReporterSslConfigWithoutSharedOverride() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL_SSL://localhost:9095");
+        configs.put(KRaftConfigs.NODE_ID_CONFIG, "1");
+        configs.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG, "INTERNAL_SSL");
+        configs.put(AutoBalancerMetricsReporterConfig.config(SslConfigs.SSL_PROTOCOL_CONFIG), "TLSv1.2");
+        CapturingAutoBalancerMetricsReporter reporter = new CapturingAutoBalancerMetricsReporter();
+
+        reporter.configure(configs);
+
+        Assertions.assertEquals("TLSv1.2", reporter.producerProps.getProperty(SslConfigs.SSL_PROTOCOL_CONFIG));
+    }
+
+    /**
+     * Given reporter-specific and shared SSL values, the metrics producer uses the reporter-specific value.
+     */
+    @Test
+    public void testReporterConfigOverridesSharedClientConfig() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL_SSL://localhost:9095");
+        configs.put(KRaftConfigs.NODE_ID_CONFIG, "1");
+        configs.put(StaticAutoBalancerConfig.AUTO_BALANCER_CLIENT_LISTENER_NAME_CONFIG, "INTERNAL_SSL");
+        configs.put(StaticAutoBalancerConfig.clientAuthConfig(SslConfigs.SSL_PROTOCOL_CONFIG), "TLSv1.2");
+        configs.put(AutoBalancerMetricsReporterConfig.config(SslConfigs.SSL_PROTOCOL_CONFIG), "TLSv1.3");
+        CapturingAutoBalancerMetricsReporter reporter = new CapturingAutoBalancerMetricsReporter();
+
+        reporter.configure(configs);
+
+        Assertions.assertEquals("TLSv1.3", reporter.producerProps.getProperty(SslConfigs.SSL_PROTOCOL_CONFIG));
+    }
 }


### PR DESCRIPTION
## Why

Backport the merged AutoBalancer mTLS fix from #3536 to `1.8`. AutoBalancer load retrieval and metrics reporting must support TLS/mTLS while preserving existing configuration compatibility.

## What

- Propagate the shared client security protocol and SSL configuration to `LoadRetriever`.
- Apply the same shared configuration to `AutoBalancerMetricsReporter` with the documented compatibility precedence.
- Include focused coverage for TLS configuration propagation and reporter behavior.

## How

This is a backport of #3536, adapted to the current `1.8` branch and retaining the branch-specific controller-only reporter tests.

## Reviewer notes

Please review the configuration translation and precedence in `StaticAutoBalancerConfigUtils`, then the `LoadRetriever` and `AutoBalancerMetricsReporter` wiring and focused tests.