### PR TITLE
fix(metadata): schedule prepared object timeout at deadline

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/stream/S3ObjectControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/stream/S3ObjectControlManager.java
@@ -545,7 +545,7 @@ public class S3ObjectControlManager {
 
     private Timeout newPreparedObjectTimeout(long objectId, long deadline) {
         return preparedObjectsTimer.newTimeout(
-            t -> handlePreparedObjectTimeout(objectId), Math.max(time.milliseconds() - deadline, TimeUnit.MINUTES.toMillis(30)),
+            t -> handlePreparedObjectTimeout(objectId), Math.max(deadline - time.milliseconds(), 0L),
             TimeUnit.MILLISECONDS
         );
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/stream/S3ObjectControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/stream/S3ObjectControlManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.metadata.stream.S3Object;
 import org.apache.kafka.metadata.stream.S3ObjectState;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.automq.AutoMQVersion;
+import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import com.automq.stream.s3.Config;
@@ -139,6 +140,20 @@ public class S3ObjectControlManagerTest {
             assertEquals(time.milliseconds() + 60 * 1000, s3Object.getTimestamp());
         });
         assertEquals(8, manager.nextAssignedObjectId());
+    }
+
+    /**
+     * Given a prepared object with a short TTL, the timeout should be delivered near its deadline.
+     */
+    @Test
+    public void testPreparedObjectTimeoutUsesDeadline() throws InterruptedException {
+        long objectId = prepareOneObject(100L);
+
+        TestUtils.waitForCondition(
+            () -> manager.waitingDeadlineCheckPreparedObjects.contains(objectId),
+            5_000L,
+            "Prepared object timeout was not delivered near its deadline"
+        );
     }
 
     private synchronized void replay(S3ObjectControlManager manager, List<ApiMessageAndVersion> records) {


### PR DESCRIPTION
## Why

Prepared S3 objects store their TTL expiration as an absolute deadline. The timer delay currently subtracts that deadline from the current time and applies a 30-minute lower bound, so future and already-expired objects are not checked at the intended time.

The existing expiration test invokes the timeout handler directly and therefore does not cover timer scheduling.

## What

Schedule each prepared-object timeout from the remaining time until its absolute deadline:

```java
Math.max(deadline - time.milliseconds(), 0L)
```

Short TTLs are delivered near their deadline, while already-expired objects are scheduled immediately. The metadata format, public API, and lifecycle event architecture remain unchanged.

## How

The existing per-object timer still owns delivery, and its callback still only enqueues the object ID for controller-event processing. A regression test prepares an object with a short TTL and waits for the real timer callback to enqueue it without invoking `handlePreparedObjectTimeout` manually.

## Reviewer notes

Review `S3ObjectControlManager.newPreparedObjectTimeout` for the delay calculation and `S3ObjectControlManagerTest.testPreparedObjectTimeoutUsesDeadline` for the timer-path regression coverage.

Fixes #3523