### PR TITLE
chore: clarify callback responsibility and remove redundant topic cleanup logic

### DIFF
--- a/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
@@ -1181,6 +1181,8 @@ class ElasticReplicaManager(
    *
    * @param delta    The delta to apply.
    * @param newImage The new metadata image.
+   * @param callback Invoked after applying a local partition state change that requires
+   *                 immediate per-partition notification.
    */
   def asyncApplyDelta(delta: TopicsDelta, newImage: MetadataImage,
     callback: TopicPartition => Unit): CompletableFuture[Void] = {
@@ -1214,19 +1216,6 @@ class ElasticReplicaManager(
         }
 
         doPartitionDeletion()
-
-        // Clean up the consumption offset for the deleted partitions that do not belong to the current broker.
-        delta.deletedTopicIds().forEach { id =>
-          val topicImage = delta.image().getTopic(id)
-          topicImage.partitions().entrySet().forEach { entry => {
-            val partitionId = entry.getKey
-            val partition = entry.getValue
-            if (partition.leader != config.nodeId) {
-              callback(new TopicPartition(topicImage.name(), partitionId))
-            }
-          }
-          }
-        }
 
       }
 

--- a/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticReplicaManager.scala
@@ -1127,6 +1127,8 @@ class ElasticReplicaManager(
    *
    * @param delta    The delta to apply.
    * @param newImage The new metadata image.
+   * @param callback Invoked for local partition operations that require
+                     immediate per-partition notification before the full delta completes.
    */
   def asyncApplyDelta(delta: TopicsDelta, newImage: MetadataImage,
     callback: TopicPartition => Unit): CompletableFuture[Void] = {
@@ -1160,19 +1162,6 @@ class ElasticReplicaManager(
         }
 
         doPartitionDeletion()
-
-        // Clean up the consumption offset for the deleted partitions that do not belong to the current broker.
-        delta.deletedTopicIds().forEach { id =>
-          val topicImage = delta.image().getTopic(id)
-          topicImage.partitions().entrySet().forEach { entry => {
-            val partitionId = entry.getKey
-            val partition = entry.getValue
-            if (partition.leader != config.nodeId) {
-              callback(new TopicPartition(topicImage.name(), partitionId))
-            }
-          }
-          }
-        }
 
       }
 

--- a/core/src/test/scala/unit/kafka/server/streamaspect/ElasticReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/streamaspect/ElasticReplicaManagerTest.scala
@@ -21,6 +21,8 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.FetchRequest
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{DirectoryId, Node, TopicPartition, Uuid}
+import org.apache.kafka.common.metadata.{PartitionRecord, RemoveTopicRecord, TopicRecord}
+import org.apache.kafka.image.{MetadataImage, TopicsDelta, TopicsImage}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.server.common.automq.AutoMQVersion
 import org.apache.kafka.server.common.{DirectoryEventHandler, OffsetAndEpoch}
@@ -28,7 +30,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.util.timer.MockTimer
 import org.apache.kafka.server.util.{MockScheduler, Scheduler}
 import org.apache.kafka.storage.internals.log._
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Disabled, Tag, Test, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -38,8 +40,8 @@ import org.mockito.Mockito.{mock, when}
 
 import java.io.File
 import java.nio.file.Files
-import java.util.Properties
-import java.util.concurrent.CountDownLatch
+import java.util.{Collections, Properties}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.{Map, Seq}
 import scala.compat.java8.OptionConverters.RichOptionForJava8
@@ -770,6 +772,68 @@ class ElasticReplicaManagerTest extends ReplicaManagerTest {
   @ValueSource(booleans = Array(true, false))
   @Disabled
   override def testPartitionFetchStateUpdatesWithTopicIdChanges(startsWithTopicId: Boolean): Unit = {
+  }
+
+  @Test
+  def testAsyncApplyDeltaDoesNotCallbackForNonLocalPartitionsOfDeletedTopic(): Unit = {
+    val localId = 1
+    val otherId = 2
+    val thirdId = 3
+    val topicId = Uuid.randomUuid()
+
+    val localPartition = new TopicPartition("foo", 0)
+    val nonLocalPartition = new TopicPartition("foo", 1)
+
+    val createDelta = new TopicsDelta(TopicsImage.EMPTY)
+    createDelta.replay(new TopicRecord()
+      .setName("foo")
+      .setTopicId(topicId))
+
+    createDelta.replay(new PartitionRecord()
+      .setPartitionId(0)
+      .setTopicId(topicId)
+      .setReplicas(java.util.Arrays.asList[Integer](localId, otherId))
+      .setIsr(java.util.Arrays.asList[Integer](localId, otherId))
+      .setRemovingReplicas(Collections.emptyList())
+      .setAddingReplicas(Collections.emptyList())
+      .setLeader(localId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0))
+
+    createDelta.replay(new PartitionRecord()
+      .setPartitionId(1)
+      .setTopicId(topicId)
+      .setReplicas(java.util.Arrays.asList[Integer](otherId, thirdId))
+      .setIsr(java.util.Arrays.asList[Integer](otherId, thirdId))
+      .setRemovingReplicas(Collections.emptyList())
+      .setAddingReplicas(Collections.emptyList())
+      .setLeader(otherId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0))
+
+    val deleteDelta = new TopicsDelta(createDelta.apply())
+    deleteDelta.replay(new RemoveTopicRecord().setTopicId(topicId))
+
+    val replicaManager = setupReplicaManagerWithMockedPurgatories(
+      new MockTimer(time),
+      localId,
+      aliveBrokerIds = Seq(localId, otherId, thirdId),
+      shouldMockLog = true
+    )
+
+    val callbacks = ConcurrentHashMap.newKeySet[TopicPartition]()
+
+    try {
+      replicaManager
+        .asyncApplyDelta(deleteDelta, MetadataImage.EMPTY, tp => callbacks.add(tp))
+        .get()
+
+      assertTrue(callbacks.contains(localPartition))
+      assertFalse(callbacks.contains(nonLocalPartition))
+      assertEquals(1, callbacks.size())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changed

- Remove the redundant deleted-topic traversal from `ElasticReplicaManager#asyncApplyDelta`.
- Preserve callbacks for actual local partition deletion and partition state transitions.
- Document the callback's immediate per-partition notification responsibility.

## Why

Global deleted-topic cleanup is already handled by `BrokerMetadataPublisher#notifyGroupCoordinatorOfDeletedPartitions` after `asyncApplyDelta` completes. The additional `deletedTopicIds()` traversal in `ElasticReplicaManager` therefore caused redundant cleanup notifications.

Fixes #2721

## Testing

- `:core:compileScala` — passed
- `:core:S3UnitTest --tests unit.kafka.server.streamaspect.ElasticReplicaManagerTest` — passed