### PR TITLE
fix(config): use quorum voter endpoint for wildcard controller listener

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -872,13 +872,35 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   }
 
   def effectiveAdvertisedControllerListeners: Seq[EndPoint] = {
-    val controllerAdvertisedListeners = advertisedListeners.filter(l => controllerListenerNames.contains(l.listenerName.value()))
+    val controllerAdvertisedListeners = Option(getString(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG))
+      .map(CoreUtils.listenerListToEndPoints(_, effectiveListenerSecurityProtocolMap, requireDistinctPorts = false))
+      .getOrElse(Seq.empty)
+      .filter(l => controllerListenerNames.contains(l.listenerName.value()))
     val controllerListenersValue = controllerListeners
 
-    controllerListenerNames.flatMap { name =>
+    controllerListenerNames.zipWithIndex.flatMap { case (name, index) =>
       controllerAdvertisedListeners
         .find(endpoint => endpoint.listenerName.equals(ListenerName.normalised(name)))
-        .orElse(controllerListenersValue.find(endpoint => endpoint.listenerName.equals(ListenerName.normalised(name))))
+        .orElse {
+          controllerListenersValue
+            .find(endpoint => endpoint.listenerName.equals(ListenerName.normalised(name)))
+            .map { endpoint =>
+              if (index == 0 && (endpoint.host == null || endpoint.host == "0.0.0.0")) {
+                Option(QuorumConfig.parseVoterConnections(quorumVoters).get(nodeId))
+                  .map { voterAddress =>
+                    EndPoint(
+                      voterAddress.getHostString,
+                      voterAddress.getPort,
+                      endpoint.listenerName,
+                      endpoint.securityProtocol
+                    )
+                  }
+                  .getOrElse(endpoint)
+              } else {
+                endpoint
+              }
+            }
+        }
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -46,7 +46,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.MetricConfigs
 import org.apache.kafka.storage.internals.log.CleanerConfig
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.function.Executable
 
 import scala.annotation.nowarn
@@ -388,6 +388,25 @@ class KafkaConfigTest {
     val config = KafkaConfig.fromProps(props)
     assertEquals(
       Seq(EndPoint("localhost", 9093, ListenerName.normalised("CONTROLLER"), SecurityProtocol.PLAINTEXT)),
+      config.effectiveAdvertisedControllerListeners
+    )
+  }
+
+  @Test
+  @Tag("S3Unit")
+  def testEffectAdvertiseControllerListenerUsesQuorumVoterEndpointForWildcardListener(): Unit = {
+    // Given a wildcard controller listener and a matching quorum voter endpoint,
+    // when no explicit advertised listener is configured, use the voter endpoint.
+    val props = new Properties()
+    props.setProperty(KRaftConfigs.PROCESS_ROLES_CONFIG, "controller")
+    props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "CONTROLLER://:9093")
+    props.setProperty(KRaftConfigs.NODE_ID_CONFIG, "2")
+    props.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "2@10.20.1.32:9092")
+    props.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER")
+
+    val config = KafkaConfig.fromProps(props)
+    assertEquals(
+      Seq(EndPoint("10.20.1.32", 9092, ListenerName.normalised("CONTROLLER"), SecurityProtocol.PLAINTEXT)),
       config.effectiveAdvertisedControllerListeners
     )
   }


### PR DESCRIPTION
## Summary

When a controller listener uses a wildcard host and no explicit controller dvertised.listeners is configured, use the current node's endpoint from controller.quorum.voters as the effective advertised controller listener.

This avoids resolving the wildcard listener to a canonical hostname that may not be reachable by other nodes.

Explicit dvertised.listeners remains authoritative.

## Changes

- Parse explicitly configured advertised controller listeners separately from the listener fallback.
- For the first wildcard controller listener, use the matching local node endpoint from controller.quorum.voters.
- Preserve the existing behavior for explicitly advertised and non-wildcard controller listeners.
- Add a regression test verifying both the voter hostname and port are used.

## Testing

- :core:S3UnitTest regression test passed.
- All related KafkaConfigTest.testEffectAdvertiseControllerListener* tests passed.
- at passed.
- :core:checkstyleMain passed.
- git diff --check passed.

This behavior is consistent with the controller advertised-listener fallback addressed upstream in Apache Kafka KAFKA-20380.

Related to #2833