### PR TITLE
fix(zerozone): advertise proxy leader in KIP-951 responses (#3546)

### DIFF
--- a/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
+++ b/core/src/main/scala/kafka/server/streamaspect/ElasticKafkaApis.scala
@@ -247,7 +247,8 @@ class ElasticKafkaApis(
           case None => (-1, -1)
         }
     }
-    LeaderNode(leaderId, leaderEpoch, OptionConverters.toScala(trafficInterceptor.getLeaderNode(leaderId, clientIdMetadata, ln.value())))
+    val node = OptionConverters.toScala(trafficInterceptor.getLeaderNode(leaderId, clientIdMetadata, ln.value()))
+    LeaderNode(node.map(_.id()).getOrElse(leaderId), leaderEpoch, node)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import kafka.api.LeaderAndIsr
+import kafka.automq.interceptor.NoopTrafficInterceptor
 import kafka.cluster.{Broker, Partition}
 import kafka.controller.{ControllerContext, KafkaController}
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
@@ -2614,6 +2615,17 @@ class KafkaApisTest extends Logging {
       when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
         any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
       kafkaApis = createKafkaApis()
+      // AutoMQ inject start
+      val expectedLeaderNode = kafkaApis match {
+        case elasticKafkaApis: ElasticKafkaApis =>
+          val proxyNode = new Node(1, "proxy", 9092)
+          val trafficInterceptor = spy(new NoopTrafficInterceptor(elasticKafkaApis, metadataCache))
+          doReturn(Optional.of(proxyNode)).when(trafficInterceptor).getLeaderNode(anyInt(), any(), anyString())
+          elasticKafkaApis.setTrafficInterceptor(trafficInterceptor)
+          proxyNode
+        case _ => new Node(newLeaderId, "broker2", 9092)
+      }
+      // AutoMQ inject end
       kafkaApis.handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
 
       val response = verifyNoThrottling[ProduceResponse](request)
@@ -2623,12 +2635,12 @@ class KafkaApisTest extends Logging {
       assertEquals(1, topicProduceResponse.partitionResponses.size)
       val partitionProduceResponse = topicProduceResponse.partitionResponses.asScala.head
       assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, Errors.forCode(partitionProduceResponse.errorCode))
-      assertEquals(newLeaderId, partitionProduceResponse.currentLeader.leaderId())
+      assertEquals(expectedLeaderNode.id(), partitionProduceResponse.currentLeader.leaderId())
       assertEquals(newLeaderEpoch, partitionProduceResponse.currentLeader.leaderEpoch())
       assertEquals(1, response.data.nodeEndpoints.size)
       val node = response.data.nodeEndpoints.asScala.head
-      assertEquals(2, node.nodeId)
-      assertEquals("broker2", node.host)
+      assertEquals(expectedLeaderNode.id(), node.nodeId)
+      assertEquals(expectedLeaderNode.host(), node.host)
     }
   }
 


### PR DESCRIPTION
KIP-951 responses returned the proxy endpoint while keeping the real partition leader ID. Clients such as franz-go trusted the ID and routed requests back to the wrong broker, causing repeated NOT_LEADER_OR_FOLLOWER errors.

Use the routed endpoint ID as the advertised leader and cover the case where proxy and partition leader IDs differ.