### PR TITLE
fix(s3stream): retry block index load after compaction race

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
@@ -426,7 +426,8 @@ import static com.automq.stream.utils.FutureUtil.exec;
             return CompletableFuture.completedFuture(null);
         }
         long currentBlocksEpoch = blocksEpoch;
-        inflightLoadIndexCf = new CompletableFuture<>();
+        CompletableFuture<Void> loadIndexCf = new CompletableFuture<>();
+        inflightLoadIndexCf = loadIndexCf;
         long nextLoadingOffset = calWindowBlocksEndOffset();
         AtomicLong nextFindStartOffset = new AtomicLong(nextLoadingOffset);
         TimerUtil time = new TimerUtil();
@@ -467,16 +468,15 @@ import static com.automq.stream.utils.FutureUtil.exec;
             return prevCf;
         }, eventLoop);
         findBlockIndexesCf.whenCompleteAsync((nil, ex) -> {
+            inflightLoadIndexCf = null;
             if (ex != null) {
-                inflightLoadIndexCf.completeExceptionally(ex);
+                loadIndexCf.completeExceptionally(ex);
                 return;
             }
             GET_INDICES_TIME_FIND_INDEX_STATS.record(time.elapsedAs(TimeUnit.NANOSECONDS));
-            CompletableFuture<Void> cf = inflightLoadIndexCf;
-            inflightLoadIndexCf = null;
-            cf.complete(null);
+            loadIndexCf.complete(null);
         }, eventLoop);
-        return inflightLoadIndexCf;
+        return loadIndexCf;
     }
 
     private static DeltaHistogram readBlockCacheStats(boolean isCacheHit) {

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,6 +59,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -127,6 +129,58 @@ public class StreamReaderTest {
         };
         dataBlockCache = spy(new DataBlockCache(Long.MAX_VALUE, eventLoops));
         streamReader = new StreamReader(STREAM_ID, 0, eventLoops[0], objectManager, objectReaderFactory, dataBlockCache);
+    }
+
+    /**
+     * Given a block-index load made discontinuous by an object compaction race, when the reader retries, then it
+     * reloads the object metadata and completes the original read.
+     */
+    @Test
+    public void testReadRetryAfterDiscontinuousBlockIndexLoad() throws Exception {
+        MockObject compactedObject = MockObject.builder(8L, BLOCK_SIZE_THRESHOLD).write(STREAM_ID, List.of(
+            StreamRecordBatch.of(STREAM_ID, 0, 0, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 1, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 2, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 3, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE),
+            StreamRecordBatch.of(STREAM_ID, 0, 4, 1, TestUtils.random(1), DefaultByteBufSupplier.INSTANCE)
+        )).build();
+        objects.put(8L, compactedObject);
+        when(objectManager.getObjects(STREAM_ID, 0L, 4L, GET_OBJECT_STEP))
+            .thenReturn(CompletableFuture.completedFuture(List.of(
+                objects.get(0L).metadata,
+                objects.get(1L).metadata)));
+        when(objectManager.getObjects(STREAM_ID, 4L, 5L, GET_OBJECT_STEP))
+            .thenReturn(CompletableFuture.completedFuture(List.of(compactedObject.metadata)));
+        when(objectManager.getObjects(STREAM_ID, 1L, 5L, GET_OBJECT_STEP))
+            .thenReturn(CompletableFuture.completedFuture(List.of(compactedObject.metadata)));
+
+        AtomicReference<CompletableFuture<ReadDataBlock>> readCf = new AtomicReference<>();
+        eventLoops[0].submit(() -> streamReader.readahead.reset()).get();
+        eventLoops[0].submit(() -> readCf.set(streamReader.read(0L, 4L, 1))).get();
+
+        ReadDataBlock firstRead = readCf.get().get(5, TimeUnit.SECONDS);
+        assertEquals(List.of(0L), firstRead.getRecords().stream()
+            .map(StreamRecordBatch::getBaseOffset)
+            .toList());
+        firstRead.getRecords().forEach(StreamRecordBatch::release);
+        eventLoops[0].submit(() -> {
+            assertEquals(List.of(1L, 2L, 3L), new ArrayList<>(streamReader.blocksMap.keySet()));
+            assertEquals(4L, streamReader.loadedBlockIndexEndOffset);
+        }).get();
+
+        eventLoops[0].submit(() -> readCf.set(streamReader.read(1L, 5L, Integer.MAX_VALUE))).get();
+
+        ReadDataBlock result = readCf.get().get(5, TimeUnit.SECONDS);
+        assertEquals(List.of(1L, 2L, 3L, 4L), result.getRecords().stream()
+            .map(StreamRecordBatch::getBaseOffset)
+            .toList());
+        result.getRecords().forEach(StreamRecordBatch::release);
+
+        InOrder metadataLoads = inOrder(objectManager);
+        metadataLoads.verify(objectManager).getObjects(STREAM_ID, 0L, 4L, GET_OBJECT_STEP);
+        metadataLoads.verify(objectManager).getObjects(STREAM_ID, 4L, 5L, GET_OBJECT_STEP);
+        metadataLoads.verify(objectManager).getObjects(STREAM_ID, 1L, 5L, GET_OBJECT_STEP);
+        verify(objectManager, times(3)).getObjects(anyLong(), anyLong(), anyLong(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Why

Forward-port the fix from #3551 to main.

After object compaction, StreamReader can temporarily combine block indexes from different metadata images and raise BlockNotContinuousException.

The exception is recoverable, but the failed inflightLoadIndexCf remains assigned. The retry therefore reuses the exceptionally completed future instead of loading the converged metadata image.

Fixes #3550.

## What

Allow a recoverable block-index load failure to start a fresh metadata load during the same read.

This forward-ports #3551 to main together with its regression coverage.

## How

Each block-index load owns a local CompletableFuture.

The completion callback clears the shared inflightLoadIndexCf slot before completing the load-owned future on both success and failure. This prevents the retry from observing and reusing an already-completed failed future.

## Verification

- ./gradlew :s3stream:test --tests com.automq.stream.s3.cache.blockcache.StreamReaderTest.testReadRetryAfterDiscontinuousBlockIndexLoad
- ./gradlew :s3stream:test --tests com.automq.stream.s3.cache.blockcache.StreamReaderTest
- ./gradlew :s3stream:checkstyleMain :s3stream:checkstyleTest :s3stream:spotlessJavaCheck
- git diff HEAD^ HEAD --check

All passed locally.

## Reviewer notes

This is a direct forward-port of the reviewed and merged 1.8 fix in #3551 with no main-specific changes.