### PR TITLE
fix(s3stream): prevent closed reader from restoring blocks

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/blockcache/StreamReader.java
@@ -186,6 +186,7 @@ import static com.automq.stream.utils.FutureUtil.exec;
 
     public void close() {
         closed = true;
+        blocksEpoch++;
         List<Block> blocks = new ArrayList<>(blocksMap.values());
         // The Block#markRead will immediately invoke after the Block is removed.
         blocksMap.clear();
@@ -421,6 +422,9 @@ import static com.automq.stream.utils.FutureUtil.exec;
     }
 
     private CompletableFuture<Void> loadMoreBlocksWithoutData0(long endOffset) {
+        if (closed) {
+            return CompletableFuture.completedFuture(null);
+        }
         if (inflightLoadIndexCf != null) {
             return inflightLoadIndexCf.thenCompose(rst -> loadMoreBlocksWithoutData0(endOffset));
         }

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/blockcache/StreamReaderTest.java
@@ -131,6 +131,42 @@ public class StreamReaderTest {
         streamReader = new StreamReader(STREAM_ID, 0, eventLoops[0], objectManager, objectReaderFactory, dataBlockCache);
     }
 
+    @Test
+    public void testClosePreventsInflightReadaheadFromRestoringBlocks() throws Exception {
+        CompletableFuture<List<S3ObjectMetadata>> getObjectsCf = new CompletableFuture<>();
+        when(objectManager.getObjects(STREAM_ID, 0L, -1L, GET_OBJECT_STEP))
+            .thenReturn(getObjectsCf);
+
+        eventLoops[0].submit(() -> streamReader.readahead.tryReadahead(false)).get();
+
+        CompletableFuture<Void> readaheadCf = streamReader.getReadaheadInflightReadaheadCf();
+        Assertions.assertNotNull(readaheadCf);
+
+        eventLoops[0].submit(streamReader::close).get();
+        eventLoops[0].submit(() -> Assertions.assertTrue(streamReader.blocksMap.isEmpty())).get();
+
+        getObjectsCf.complete(List.of(
+            objects.get(0L).metadata,
+            objects.get(1L).metadata,
+            objects.get(2L).metadata));
+
+        readaheadCf.get(5, TimeUnit.SECONDS);
+
+        eventLoops[0].submit(() -> Assertions.assertTrue(streamReader.blocksMap.isEmpty())).get();
+    }
+
+    @Test
+    public void testClosedReaderDoesNotStartNewReadaheadLoad() throws Exception {
+        eventLoops[0].submit(streamReader::close).get();
+
+        eventLoops[0].submit(() -> streamReader.readahead.tryReadahead(false)).get();
+
+        verify(objectManager, times(0))
+            .getObjects(eq(STREAM_ID), anyLong(), anyLong(), eq(GET_OBJECT_STEP));
+
+        Assertions.assertTrue(streamReader.blocksMap.isEmpty());
+    }
+
     /**
      * Given a block-index load made discontinuous by an object compaction race, when the reader retries, then it
      * reloads the object metadata and completes the original read.


### PR DESCRIPTION
## Why

StreamReader.close() clears the current block state, but block-index/readahead work can still continue around the close lifecycle boundary.

There are two cases:

1. An in-flight block-index/readahead load can complete after close().
2. Queued or follow-up readahead work can start a new block-index load after close().

For work that started before close(), the load can still see the same blocksEpoch and add blocks back into a reader that has already been closed.

For work that starts after close(), epoch invalidation alone is not sufficient because the new load observes the updated epoch.

## What

Prevent both in-flight and post-close block-index loads from restoring block state after a StreamReader is closed.

## How

Increment blocksEpoch in close() before clearing the current blocks.

Existing block-index loading already checks the captured epoch before continuing and before inserting blocks, so changing the epoch prevents work started before close() from restoring stale state.

Additionally, prevent loadMoreBlocksWithoutData0() from starting a new block-index load once the StreamReader is closed. This covers queued readahead and follow-up load continuations that begin after close().

Together, these checks ensure that a closed StreamReader cannot repopulate its block state through either existing in-flight work or newly started readahead work.

## Verification

Added regression coverage for both cases:

- testClosePreventsInflightReadaheadFromRestoringBlocks
  - Starts readahead with a delayed metadata load.
  - Closes the reader before the load completes.
  - Completes the delayed load and verifies that blocksMap remains empty.

- testClosedReaderDoesNotStartNewReadaheadLoad
  - Closes the reader before starting readahead.
  - Attempts readahead after close().
  - Verifies that ObjectManager#getObjects is not invoked and blocksMap remains empty.

Local verification:

- ./gradlew :s3stream:test --tests com.automq.stream.s3.cache.blockcache.StreamReaderTest
- ./gradlew :s3stream:checkstyleMain :s3stream:checkstyleTest :s3stream:spotlessJavaCheck
- git diff --check

All passed locally.