### PR TITLE
fix(security): upgrade Wire to 6.3.0

### DIFF
--- a/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/FileDescriptorConverter.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/FileDescriptorConverter.java
@@ -219,7 +219,7 @@ public class FileDescriptorConverter implements DynamicSchemaConverter<Descripto
         for (DescriptorProtos.DescriptorProto.ExtensionRange range : descriptor.getExtensionRangeList()) {
             List<Object> values = new ArrayList<>();
             values.add(new IntRange(range.getStart(), range.getEnd() - 1));
-            builder.addExtension(new ExtensionsElement(DEFAULT_LOCATION, "", values));
+            builder.addExtension(new ExtensionsElement(DEFAULT_LOCATION, "", values, Collections.emptyList()));
         }
     }
 

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/parse/template/ProtoSchemaTemplate.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/parse/template/ProtoSchemaTemplate.java
@@ -67,6 +67,7 @@ public abstract class ProtoSchemaTemplate<T> {
             syntax,
             imports.build(),
             publicImports.build(),
+            Collections.emptyList(), // weak imports
             types.build(),
             services.build(),
             Collections.emptyList(), // extends

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -190,7 +190,7 @@ versions += [
   avro: "1.11.4",
   confluentSchema: "7.8.0",
   iceberg: "1.6.1",
-  wire: "4.9.1",
+  wire: "6.3.0",
   oshi: "6.8.1",
   cloudevents: "4.0.1",
   // AutoMQ inject end


### PR DESCRIPTION
## Why

AutoMQ currently uses Wire `4.9.1`, which is affected by `CVE-2026-45799`. The Wire security advisory identifies `6.3.0` as the first patched release. This PR addresses the open-source dependency and source compatibility work tracked in `AutoMQ/automq-workspace#356`.

## What

Upgrade the shared Wire version from `4.9.1` to `6.3.0` for both schema and runtime artifacts. Adapt the two internal parser constructor calls to the Wire 6.x API while preserving the existing behavior for weak imports and extension options by passing empty lists, as the current converters do not model those fields.

This PR intentionally does not upgrade to the Wire `7.x` alpha line, change the Enterprise submodule pointer, or claim that the Enterprise image release gate has passed.

## How

Wire `6.3.0` adds `weakImports` to `ProtoFileElement` and `options` to `ExtensionsElement`. The compatibility changes supply empty collections for both fields, retaining the behavior of the previous Wire version while allowing the patched schema parser and runtime artifacts to resolve consistently.

## Testing

- `./gradlew --no-daemon --build-cache :core:test --tests kafka.automq.table.deserializer.proto.parse.ProtobufSchemaWellKnownTypesTest --tests kafka.automq.table.process.convert.ProtobufRegistryConverterUnitTest --tests kafka.automq.table.process.convert.ProtobufRegistryConverterTest --tests kafka.automq.table.process.convert.ProtoToAvroConverterTest`
- `./gradlew --no-daemon --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck`
- `./gradlew :core:dependencyInsight --dependency com.squareup.wire --configuration runtimeClasspath`

All commands passed. The focused test run covered protobuf schema parsing, registry conversion, and Proto-to-Avro conversion. Dependency resolution confirmed `wire-schema`, `wire-runtime`, `wire-schema-jvm`, and `wire-runtime-jvm` resolve to `6.3.0`.

## Reviewer notes

Suggested reading order:

1. `gradle/dependencies.gradle` for the dependency version change.
2. `core/src/main/java/kafka/automq/table/deserializer/proto/parse/template/ProtoSchemaTemplate.java` for the `ProtoFileElement` API adaptation.
3. `core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/FileDescriptorConverter.java` for the `ExtensionsElement` API adaptation.