### PR TITLE
fix(security): upgrade Wire to 6.3.0

### DIFF
--- a/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/FileDescriptorConverter.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/parse/converter/FileDescriptorConverter.java
@@ -219,7 +219,7 @@ public class FileDescriptorConverter implements DynamicSchemaConverter<Descripto
         for (DescriptorProtos.DescriptorProto.ExtensionRange range : descriptor.getExtensionRangeList()) {
             List<Object> values = new ArrayList<>();
             values.add(new IntRange(range.getStart(), range.getEnd() - 1));
-            builder.addExtension(new ExtensionsElement(DEFAULT_LOCATION, "", values));
+            builder.addExtension(new ExtensionsElement(DEFAULT_LOCATION, "", values, Collections.emptyList()));
         }
     }
 

--- a/core/src/main/java/kafka/automq/table/deserializer/proto/parse/template/ProtoSchemaTemplate.java
+++ b/core/src/main/java/kafka/automq/table/deserializer/proto/parse/template/ProtoSchemaTemplate.java
@@ -67,6 +67,7 @@ public abstract class ProtoSchemaTemplate<T> {
             syntax,
             imports.build(),
             publicImports.build(),
+            Collections.emptyList(), // weak imports
             types.build(),
             services.build(),
             Collections.emptyList(), // extends

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -193,7 +193,7 @@ versions += [
   avro: "1.11.4",
   confluentSchema: "7.8.0",
   iceberg: "1.6.1",
-  wire: "4.9.1",
+  wire: "6.3.0",
   oshi: "6.8.1",
   cloudevents: "4.0.1",
   // AutoMQ inject end


### PR DESCRIPTION
## Why

Backport the Wire security fix from #3557 to the 1.7 maintenance branch. The branch currently uses Wire 4.9.1, which is affected by CVE-2026-45799.

## What

Upgrade wire-schema and wire-runtime to 6.3.0 and adapt the two internal parser constructor calls to the Wire 6.x API. No unrelated changes are included.

## How

This PR is a clean cherry-pick of the security fix from #3557:

- Source PR: #3557
- Source commit: 465d3e0176e33edc0b972acfcca1cd56b9641d49
- Target branch: 1.7

Pick for #3557.
