### PR TITLE
fix(deps): align Jetty with Kafka 3.9

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -104,7 +104,7 @@ versions += [
   // AutoMQ inject end
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "9.4.54.v20240208",
+  jetty: "9.4.58.v20250814",
   jersey: "2.39.1",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
## Why

AutoMQ OSS main currently declares Jetty `9.4.54.v20240208`, while the Apache Kafka 3.9 dependency line uses `9.4.58.v20250814`. Enterprise builds already override the Jetty family to `9.4.58.v20250814`, so the OSS default is unnecessarily inconsistent.

## What

Update the shared Jetty version to `9.4.58.v20250814` so the existing Jetty server, client, servlet, and servlet container dependencies resolve to the same version as Kafka 3.9 and the Enterprise build.

This is a dependency-alignment change only. It does not claim that Jetty 9.4.58 is free of all known vulnerabilities; the follow-up Jetty security remediation remains tracked separately.

## How

All existing Jetty dependency aliases reference `versions.jetty`, so changing this single version entry updates the existing dependency graph without source or API changes.

Validation:
- `./gradlew --no-daemon :connect:runtime:dependencies --configuration runtimeClasspath`
- `./gradlew --no-daemon --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck :connect:runtime:compileJava`

## Reviewer notes

Review `gradle/dependencies.gradle` and the existing Jetty aliases in the Gradle dependency map. The change intentionally does not alter module declarations or runtime code.