### PR TITLE
fix(deps): align Jetty with Kafka 3.9

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -105,7 +105,7 @@ versions += [
   // AutoMQ inject end
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "9.4.57.v20241219",
+  jetty: "9.4.58.v20250814",
   jersey: "2.39.1",
   jline: "3.25.1",
   jline: "3.25.1",


### PR DESCRIPTION
## Why

Backport the merged Jetty dependency alignment from #3560 to the maintained 1.8 branch.

## What

Update Jetty from version 9.4.57.v20241219 to 9.4.58.v20250814, matching the version used by the Kafka 3.9 upstream line.

This is a dependency alignment backport only. It does not claim that all Jetty security findings are resolved by this version.

## Testing

- Command: ./gradlew --no-daemon --max-workers=4 --build-cache rat checkstyleMain checkstyleTest spotlessJavaCheck :connect:runtime:compileJava
- Result: BUILD SUCCESSFUL (349 actionable tasks)

## Backport

- Source PR: #3560
- Source commit: a707879637
- Pick for #3560.
