### PR TITLE
fix(deps): backport security upgrades from #3568

### DIFF
--- a/automq-shell/build.gradle
+++ b/automq-shell/build.gradle
@@ -44,7 +44,7 @@ dependencies {
         exclude(group: 'io.opentelemetry.proto', module: '*')
         exclude(group: 'com.github.luben', module: '*')
         exclude(group: 'org.xerial.snappy', module: '*')
-        exclude(group: 'org.lz4', module: '*')
+        exclude(group: 'at.yawk.lz4', module: '*')
         exclude(group: 'org.apache.kafka.shaded', module: '*')
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -981,6 +981,33 @@ project(':core') {
     implementation libs.jacksonJDK8Datatypes
     implementation libs.joptSimple
     implementation libs.jose4j
+
+    // AutoMQ inject start
+    // Keep table-topic transitive dependencies on supported patch versions at the core runtime boundary.
+    constraints {
+      implementation("org.slf4j:slf4j-api:${versions.slf4j}") {
+        version {
+          strictly versions.slf4j
+        }
+        because('Kafka uses the SLF4J 1.7.x reload4j binding')
+      }
+      implementation "org.apache.parquet:parquet-avro:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-column:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-common:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-encoding:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-format-structures:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-hadoop:${versions.parquet}"
+      implementation "org.apache.parquet:parquet-jackson:${versions.parquetJackson}"
+      implementation "org.apache.thrift:libthrift:${versions.thrift}"
+      implementation "org.apache.ant:ant:${versions.ant}"
+      implementation "org.apache.ant:ant-launcher:${versions.ant}"
+      implementation "io.airlift:aircompressor:${versions.aircompressor}"
+      implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
+      implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
+      implementation "commons-beanutils:commons-beanutils:${versions.beanutils}"
+      implementation "org.bouncycastle:bcprov-jdk18on:${versions.bcprov}"
+    }
+    // AutoMQ inject end
     implementation libs.metrics
     implementation libs.scalaCollectionCompat
     implementation libs.scalaJava8Compat
@@ -3641,6 +3668,12 @@ project(':connect:runtime') {
     implementation libs.reflections
     implementation libs.mavenArtifact
     implementation libs.swaggerAnnotations
+
+    // AutoMQ inject start
+    constraints {
+      implementation "org.codehaus.plexus:plexus-utils:${versions.plexusUtils}"
+    }
+    // AutoMQ inject end
 
     // We use this library to generate OpenAPI docs for the REST API, but we don't want or need it at compile
     // or run time. So, we add it to a separate configuration, which we use later on during docs generation

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -86,6 +86,7 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.75",
+  bcprov: "1.84",
   caffeine: "2.9.3", // 3.x supports JDK 11 and above
   // when updating checkstyle, check whether the exclusion of
   // CVE-2023-2976 and CVE-2020-8908 can be dropped from
@@ -99,16 +100,15 @@ versions += [
   grgit: "4.1.1",
   httpclient: "4.5.14",
   // AutoMQ inject start
-  jackson: "2.20.0",
-  // jackson-annotations uses "2.20" instead of "2.20.0"
-  jacksonAnnotationsVersion: "2.20",
+  jackson: "2.21.5",
+  // jackson-annotations uses a short version instead of the full Jackson version
+  jacksonAnnotationsVersion: "2.21",
   // AutoMQ inject end
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "9.4.58.v20250814",
   jersey: "2.39.1",
-  jline: "3.25.1",
-  jline: "3.25.1",
+  jline: "3.30.14",
   jmh: "1.37",
   hamcrest: "2.2",
   scalaLogging: "3.9.5",
@@ -118,7 +118,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.4",
+  jose4j: "0.9.6",
   junit: "5.10.2",
   jqwik: "1.8.3",
   kafka_0100: "0.10.0.1",
@@ -146,8 +146,9 @@ versions += [
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
-  lz4: "1.8.0",
+  lz4: "1.10.1",
   mavenArtifact: "3.9.6",
+  plexusUtils: "3.6.1",
   metrics: "2.2.0",
   netty: "4.1.137.Final",
   opentelemetryProto: "1.0.0-alpha",
@@ -174,10 +175,17 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.8.6",
   zinc: "1.9.2",
-  zookeeper: "3.8.4",
+  zookeeper: "3.8.6",
 
   // AutoMQ inject start
-  commonLang: "3.12.0",
+  commonLang: "3.18.0",
+  parquet: "1.15.2",
+  parquetJackson: "1.18.0",
+  thrift: "0.23.0",
+  ant: "1.10.15",
+  aircompressor: "2.0.3",
+  httpcore5: "5.4.3",
+  beanutils: "1.11.0",
   commonio: "2.15.1",
   commonMath3: "3.6.1",
   opentelemetrySDK: "1.40.0",
@@ -282,7 +290,7 @@ libs += [
   kafkaStreams_36: "org.apache.kafka:kafka-streams:$versions.kafka_36",
   kafkaStreams_37: "org.apache.kafka:kafka-streams:$versions.kafka_37",
   kafkaStreams_38: "org.apache.kafka:kafka-streams:$versions.kafka_38",
-  lz4: "org.lz4:lz4-java:$versions.lz4",
+  lz4: "at.yawk.lz4:lz4-java:$versions.lz4",
   metrics: "com.yammer.metrics:metrics-core:$versions.metrics",
   dropwizardMetrics: "io.dropwizard.metrics:metrics-core:$versions.dropwizardMetrics",
   mockitoCore: "org.mockito:$mockitoArtifactName:$mockitoVersion",

--- a/licenses/LICENSE-binary
+++ b/licenses/LICENSE-binary
@@ -3,40 +3,40 @@ License Version 2.0:
 
 audience-annotations-0.12.0
 caffeine-2.9.3
-commons-beanutils-1.9.4
+commons-beanutils-1.11.0
 commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
 commons-io-2.11.0
-commons-lang3-3.12.0
+commons-lang3-3.18.0
 commons-logging-1.2
 commons-validator-1.7
 error_prone_annotations-2.10.0
-jackson-annotations-2.16.1
-jackson-core-2.16.1
-jackson-databind-2.16.1
-jackson-dataformat-csv-2.16.1
-jackson-datatype-jdk8-2.16.1
-jackson-jaxrs-base-2.16.1
-jackson-jaxrs-json-provider-2.16.1
-jackson-module-afterburner-2.16.1
-jackson-module-jaxb-annotations-2.16.1
-jackson-module-scala_2.13-2.16.1
-jackson-module-scala_2.12-2.16.1
+jackson-annotations-2.21
+jackson-core-2.21.5
+jackson-databind-2.21.5
+jackson-dataformat-csv-2.21.5
+jackson-datatype-jdk8-2.21.5
+jackson-jaxrs-base-2.21.5
+jackson-jaxrs-json-provider-2.21.5
+jackson-module-afterburner-2.21.5
+jackson-module-jaxb-annotations-2.21.5
+jackson-module-scala_2.13-2.21.5
+jackson-module-scala_2.12-2.21.5
 jakarta.validation-api-2.0.2
 javassist-3.29.2-GA
-jetty-client-9.4.53.v20231009
-jetty-continuation-9.4.53.v20231009
-jetty-http-9.4.53.v20231009
-jetty-io-9.4.53.v20231009
-jetty-security-9.4.53.v20231009
-jetty-server-9.4.53.v20231009
-jetty-servlet-9.4.53.v20231009
-jetty-servlets-9.4.53.v20231009
-jetty-util-9.4.53.v20231009
-jetty-util-ajax-9.4.53.v20231009
-jose4j-0.9.4
-lz4-java-1.8.0
+jetty-client-9.4.58.v20250814
+jetty-continuation-9.4.58.v20250814
+jetty-http-9.4.58.v20250814
+jetty-io-9.4.58.v20250814
+jetty-security-9.4.58.v20250814
+jetty-server-9.4.58.v20250814
+jetty-servlet-9.4.58.v20250814
+jetty-servlets-9.4.58.v20250814
+jetty-util-9.4.58.v20250814
+jetty-util-ajax-9.4.58.v20250814
+jose4j-0.9.6
+lz4-java-1.10.1
 maven-artifact-3.9.6
 metrics-core-4.1.12.1
 metrics-core-2.2.0
@@ -50,7 +50,7 @@ netty-transport-classes-epoll-4.1.137.Final
 netty-transport-native-epoll-4.1.137.Final
 netty-transport-native-unix-common-4.1.137.Final
 opentelemetry-proto-1.0.0-alpha
-plexus-utils-3.5.1
+plexus-utils-3.6.1
 reflections-0.10.2
 reload4j-1.2.25
 rocksdbjni-7.9.2
@@ -66,8 +66,8 @@ scala-java8-compat_2.12-1.0.2
 scala-java8-compat_2.13-1.0.2
 snappy-java-1.1.10.5
 swagger-annotations-2.2.8
-zookeeper-3.8.4
-zookeeper-jute-3.8.4
+zookeeper-3.8.6
+zookeeper-jute-3.8.6
 
 ===============================================================================
 This product bundles various third-party components under other open source
@@ -129,7 +129,7 @@ zstd-jni-1.5.5-11 see: licenses/zstd-jni-BSD-2-clause
 ---------------------------------------
 BSD 3-Clause
 
-jline-3.25.1, see: licenses/jline-BSD-3-clause
+jline-3.30.14, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 protobuf-java-3.23.4, see: licenses/protobuf-java-BSD-3-clause


### PR DESCRIPTION
## Why

Backport the dependency security upgrades from AutoMQ/automq#3568 to the `1.8` branch.

## What

- Cherry-pick source commit `6e5ce2eefd708c310b7d638684a5df1acfbf7d79`.
- Apply the OSS dependency upgrades, runtime constraints, LZ4 coordinate migration, and synchronized `licenses/LICENSE-binary`.
- Preserve branch-specific Kafka dependency baselines.

## Verification

- `./gradlew --no-daemon --build-cache :core:compileJava :connect:runtime:compileJava`
