### PR TITLE
feat(release): prepare 1.7.5-rc0

### DIFF
--- a/chart/bitnami/demo-values.yaml
+++ b/chart/bitnami/demo-values.yaml
@@ -4,7 +4,7 @@ global:
 image:
   registry: automqinc
   repository: automq
-  tag: 1.7.4-bitnami
+  tag: 1.7.5-rc0-bitnami
   pullPolicy: Always
 extraEnvVars:
   - name: AWS_ACCESS_KEY_ID

--- a/docker/docker-compose-cluster.yaml
+++ b/docker/docker-compose-cluster.yaml
@@ -68,7 +68,7 @@ services:
   # Three nodes for AutoMQ cluster
   server1:
     container_name: "automq-server1"
-    image: automqinc/automq:1.7.4
+    image: automqinc/automq:1.7.5-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env
@@ -94,7 +94,7 @@ services:
 
   server2:
     container_name: "automq-server2"
-    image: automqinc/automq:1.7.4
+    image: automqinc/automq:1.7.5-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env
@@ -120,7 +120,7 @@ services:
 
   server3:
     container_name: "automq-server3"
-    image: automqinc/automq:1.7.4
+    image: automqinc/automq:1.7.5-rc0
     stop_grace_period: 1m
     environment:
       <<: *common-env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
   # Single node with combined controller and broker roles
   server1:
     container_name: "automq-single-server"
-    image: automqinc/automq:1.7.4
+    image: automqinc/automq:1.7.5-rc0
     stop_grace_period: 1m
     environment:
       - KAFKA_S3_ACCESS_KEY=minioadmin

--- a/docker/table_topic/docker-compose.yml
+++ b/docker/table_topic/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       "
   automq:
     container_name: "automq"
-    image: automqinc/automq:1.7.4
+    image: automqinc/automq:1.7.5-rc0
     stop_grace_period: 1m
     networks:
       iceberg_net:


### PR DESCRIPTION
## Why

Prepare the OSS `1.7.5-rc0` release candidate after the security dependency upgrades merged into the `1.7` branch for CVE remediation.

## What

Update the Docker Compose and Bitnami example image tags to `1.7.5-rc0`.

## Verification

- `git diff --check`
- `yq` parsing for all four changed YAML files

## Scope

Release metadata only; no runtime or test behavior changes.
