### PR TITLE
fix(metadata): clear pending topic configs on replay

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
@@ -74,7 +74,7 @@ public final class ConfigurationsDelta {
         // AutoMQ inject start
         if (image.resourceData().containsKey(resource) || changes.containsKey(resource)) {
             ConfigurationImage configImage = image.resourceData().getOrDefault(resource,
-                new ConfigurationImage(resource, Collections.emptyMap()));
+                new ConfigurationImage(resource, new HashMap<>()));
             ConfigurationDelta delta = changes.computeIfAbsent(resource,
                 __ -> new ConfigurationDelta(configImage));
             delta.deleteAll();

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
@@ -71,12 +71,15 @@ public final class ConfigurationsDelta {
     public void replay(RemoveTopicRecord record, String topicName) {
         ConfigResource resource =
             new ConfigResource(Type.TOPIC, topicName);
-        if (image.resourceData().containsKey(resource)) {
-            ConfigurationImage configImage = image.resourceData().get(resource);
+        // AutoMQ inject start
+        if (image.resourceData().containsKey(resource) || changes.containsKey(resource)) {
+            ConfigurationImage configImage = image.resourceData().getOrDefault(resource,
+                new ConfigurationImage(resource, Collections.emptyMap()));
             ConfigurationDelta delta = changes.computeIfAbsent(resource,
                 __ -> new ConfigurationDelta(configImage));
             delta.deleteAll();
         }
+        // AutoMQ inject end
     }
 
     public ConfigurationsImage apply() {

--- a/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.kafka.image;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -35,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -116,6 +120,39 @@ public class ConfigurationsImageTest {
     @Test
     public void testImage2RoundTrip() {
         testToImage(IMAGE2);
+    }
+
+    /** Verifies that removing a topic clears pending configuration before same-name recreation. */
+    @Tag("S3Unit")
+    @Test
+    public void testRemoveTopicRecordClearsPendingTopicConfig() {
+        String topicName = "topic";
+        ConfigurationsDelta delta = new ConfigurationsDelta(ConfigurationsImage.EMPTY);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("old.key").setValue("old-value"));
+        delta.replay(new RemoveTopicRecord().setTopicId(Uuid.ZERO_UUID), topicName);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("new.key").setValue("new-value"));
+
+        assertEquals(Collections.singletonMap("new.key", "new-value"),
+            delta.apply().configMapForResource(new ConfigResource(TOPIC, topicName)));
+    }
+
+    /** Verifies that removing a topic still clears configuration already present in the image. */
+    @Tag("S3Unit")
+    @Test
+    public void testRemoveTopicRecordClearsBaseTopicConfig() {
+        String topicName = "topic";
+        ConfigResource resource = new ConfigResource(TOPIC, topicName);
+        ConfigurationsImage baseImage = new ConfigurationsImage(Collections.singletonMap(resource,
+            new ConfigurationImage(resource, Collections.singletonMap("old.key", "old-value"))));
+        ConfigurationsDelta delta = new ConfigurationsDelta(baseImage);
+        delta.replay(new RemoveTopicRecord().setTopicId(Uuid.ZERO_UUID), topicName);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("new.key").setValue("new-value"));
+
+        assertEquals(Collections.singletonMap("new.key", "new-value"),
+            delta.apply().configMapForResource(resource));
     }
 
     private static void testToImage(ConfigurationsImage image) {


### PR DESCRIPTION
## Summary

- clear topic configurations already accumulated in the current `ConfigurationsDelta` when replaying `RemoveTopicRecord`
- preserve the existing base-image cleanup path while avoiding stale configs leaking into a same-name recreated topic
- add focused regression coverage for both pending-delta and base-image configurations

## Testing

- `./gradlew :metadata:test --tests org.apache.kafka.image.ConfigurationsImageTest --no-daemon`
- `./gradlew :metadata:S3UnitTest --tests org.apache.kafka.image.ConfigurationsImageTest --no-daemon`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest :metadata:S3UnitTest --no-daemon`

The full local `:metadata:test` task also ran, but the branch baseline reports 159 unrelated failures across existing tests, including `FormatterTest`, `ProducerIdControlManagerTest`, `MetadataLoaderTest`, and `SnapshotGeneratorTest`. The focused tests and required tagged/checkstyle gates pass. The `1.7` build does not define a `spotlessJavaCheck` task.

Related to #3556