### PR TITLE
feat: encode ElasticLogMeta with Avro

### DIFF
--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogManager.scala
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogManager.scala
@@ -31,15 +31,19 @@ import kafka.server.{BrokerServer, BrokerTopicStats, KafkaConfig}
 import kafka.utils.Logging
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.server.common.automq.AutoMQVersion
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.log.{LogConfig, LogDirFailureChannel, LogOffsetsListener, ProducerStateManagerConfig}
 import org.slf4j.LoggerFactory
 
 import java.io.File
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
+import java.util.function.Supplier
 import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 
-class ElasticLogManager(val client: Client, val openStreamChecker: OpenStreamChecker) extends Logging {
+class ElasticLogManager(val client: Client,
+  val openStreamChecker: OpenStreamChecker,
+  val autoMQVersionSupplier: Supplier[AutoMQVersion] = () => AutoMQVersion.V0) extends Logging {
   this.logIdent = s"[ElasticLogManager] "
   private val elasticLogs = new ConcurrentHashMap[TopicPartition, ElasticUnifiedLog]()
 
@@ -125,7 +129,7 @@ class ElasticLogManager(val client: Client, val openStreamChecker: OpenStreamChe
 
 object ElasticLogManager {
   val LOGGER = LoggerFactory.getLogger(ElasticLogManager.getClass)
-  var INSTANCE: Option[ElasticLogManager] = None
+  @volatile var INSTANCE: Option[ElasticLogManager] = None
   var NAMESPACE = ""
   val INIT_FUTURE: CompletableFuture[Void] = new CompletableFuture[Void]()
   private var isEnabled = false
@@ -146,7 +150,13 @@ object ElasticLogManager {
     } else {
       OpenStreamChecker.NOOP
     }
-    INSTANCE = Some(new ElasticLogManager(ClientFactoryProxy.get(context), openStreamChecker))
+    val autoMQVersionSupplier: Supplier[AutoMQVersion] = if (broker == null) {
+      () => AutoMQVersion.V0
+    } else {
+      () => broker.metadataCache.autoMQVersion()
+    }
+    INSTANCE = Some(new ElasticLogManager(ClientFactoryProxy.get(context), openStreamChecker,
+      autoMQVersionSupplier))
     INSTANCE.foreach(_.startup())
     ElasticLogSegment.txnCache = new FileCache(config.logDirs.head + "/" + "txnindex-cache", 100 * 1024 * 1024)
     ElasticLogSegment.timeCache = new FileCache(config.logDirs.head + "/" + "timeindex-cache", 100 * 1024 * 1024)
@@ -156,6 +166,10 @@ object ElasticLogManager {
   def instance(): Option[ElasticLogManager] = {
     INIT_FUTURE.get()
     INSTANCE
+  }
+
+  def autoMQVersionSupplier(): Supplier[AutoMQVersion] = {
+    () => INSTANCE.map(_.autoMQVersionSupplier.get()).getOrElse(AutoMQVersion.V0)
   }
 
   def enable(shouldEnable: Boolean): Unit = {

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogMeta.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogMeta.java
@@ -20,16 +20,7 @@
 package kafka.log.streamaspect;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,11 +31,6 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ElasticLogMeta {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final ObjectWriter WRITER = OBJECT_MAPPER.writer();
-    private static final ObjectReader READER = OBJECT_MAPPER.readerFor(ElasticLogMeta.class);
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticLogMeta.class);
     /**
      * KV map for segment file suffix -> streamId.
      */
@@ -55,25 +41,6 @@ public class ElasticLogMeta {
     private List<ElasticStreamSegmentMeta> segmentMetas = new LinkedList<>();
 
     public ElasticLogMeta() {
-    }
-
-    public static ByteBuffer encode(ElasticLogMeta meta) {
-        try {
-            return ByteBuffer.wrap(WRITER.writeValueAsBytes(meta));
-        } catch (JsonProcessingException e) {
-            LOGGER.error("encode ElasticLogMeta {} failed", meta, e);
-            throw new IllegalArgumentException(e);
-        }
-    }
-
-    public static ElasticLogMeta decode(ByteBuffer buf) {
-        String metaStr = StandardCharsets.UTF_8.decode(buf).toString();
-        try {
-            return READER.readValue(metaStr);
-        } catch (JsonProcessingException e) {
-            LOGGER.error("decode ElasticLogMeta {} failed", metaStr, e);
-            throw new RuntimeException(e);
-        }
     }
 
     public List<ElasticStreamSegmentMeta> getSegmentMetas() {

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogMetaCodec.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogMetaCodec.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2025 AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log.streamaspect;
+
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdException;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Encodes and decodes the persistent representation of {@link ElasticLogMeta}.
+ * New values use a versioned Avro envelope while legacy JSON remains readable.
+ */
+final class ElasticLogMetaCodec {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final ObjectWriter JSON_WRITER = JSON_MAPPER.writer();
+    private static final ObjectReader JSON_READER = JSON_MAPPER.readerFor(ElasticLogMeta.class);
+    static final int MAGIC = 0x454C4D00;
+    static final int HEADER_SIZE = 13;
+    static final int COMPRESSION_MASK = 0x07;
+    static final int COMPRESSION_THRESHOLD = 16 * 1024;
+    static final int ZSTD_LEVEL = 3;
+    static final int ENCODING_VERSION_V0 = 0;
+
+    private static final String SCHEMA_NAMESPACE = "kafka.log.streamaspect";
+
+    private static final Schema SLICE_RANGE_SCHEMA = SchemaBuilder.record("SliceRange")
+        .namespace(SCHEMA_NAMESPACE)
+        .fields()
+        .requiredLong("start")
+        .requiredLong("end")
+        .endRecord();
+
+    private static final Schema TIMESTAMP_OFFSET_SCHEMA = SchemaBuilder.record("TimestampOffset")
+        .namespace(SCHEMA_NAMESPACE)
+        .fields()
+        .requiredLong("timestamp")
+        .requiredLong("offset")
+        .endRecord();
+
+    private static final Schema SEGMENT_META_SCHEMA = SchemaBuilder.record("SegmentMeta")
+        .namespace(SCHEMA_NAMESPACE)
+        .fields()
+        .requiredLong("baseOffset")
+        .requiredLong("createTimestamp")
+        .requiredLong("lastModifiedTimestamp")
+        .requiredString("streamSuffix")
+        .requiredInt("logSize")
+        .name("log").type(SLICE_RANGE_SCHEMA).noDefault()
+        .name("time").type(SLICE_RANGE_SCHEMA).noDefault()
+        .name("txn").type(SLICE_RANGE_SCHEMA).noDefault()
+        .requiredLong("firstBatchTimestamp")
+        .name("timeIndexLastEntry").type(TIMESTAMP_OFFSET_SCHEMA).noDefault()
+        .endRecord();
+
+    static final Schema SCHEMA_V0 = SchemaBuilder.record("ElasticLogMeta")
+        .namespace(SCHEMA_NAMESPACE)
+        .fields()
+        .name("streamMap").type().map().values().longType().noDefault()
+        .name("segmentMetas").type().array().items(SEGMENT_META_SCHEMA).noDefault()
+        .endRecord();
+
+    private ElasticLogMetaCodec() {
+    }
+
+    /** Encodes metadata using the legacy JSON representation. */
+    static ByteBuffer encodeJson(ElasticLogMeta meta) {
+        try {
+            return ByteBuffer.wrap(JSON_WRITER.writeValueAsBytes(meta));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to encode ElasticLogMeta as JSON", e);
+        }
+    }
+
+    /** Decodes metadata using the legacy JSON representation. */
+    static ElasticLogMeta decodeJson(ByteBuffer encoded) {
+        try {
+            return JSON_READER.readValue(StandardCharsets.UTF_8.decode(encoded).toString());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to decode ElasticLogMeta JSON", e);
+        }
+    }
+
+    /**
+     * Encodes metadata according to the finalized AutoMQ feature version.
+     */
+    static ByteBuffer encode(ElasticLogMeta meta, AutoMQVersion version) {
+        if (!version.isElasticLogMetaAvroSupported()) {
+            return encodeJson(meta);
+        }
+        byte[] rawPayload = encodeAvro(meta);
+        CompressionType compressionType = compressionTypeForSize(rawPayload.length);
+        byte[] payload = compressionType == CompressionType.NONE
+            ? rawPayload
+            : Zstd.compress(rawPayload, ZSTD_LEVEL);
+
+        ByteBuf envelope = Unpooled.wrappedBuffer(new byte[HEADER_SIZE + payload.length]);
+        envelope.clear();
+        envelope.writeInt(MAGIC);
+        envelope.writeByte(ENCODING_VERSION_V0);
+        envelope.writeInt(compressionType.id);
+        envelope.writeInt(rawPayload.length);
+        envelope.writeBytes(payload);
+        return envelope.nioBuffer(0, envelope.writerIndex());
+    }
+
+    static CompressionType compressionTypeForSize(int rawPayloadSize) {
+        return rawPayloadSize < COMPRESSION_THRESHOLD ? CompressionType.NONE : CompressionType.ZSTD;
+    }
+
+    /**
+     * Decodes either a legacy JSON value or a self-identifying Avro envelope.
+     */
+    static ElasticLogMeta decode(ByteBuffer encoded) {
+        ByteBuffer input = encoded.slice();
+        if (input.remaining() < Integer.BYTES || input.getInt(input.position()) != MAGIC) {
+            return decodeJson(input);
+        }
+        return decodeEnvelope(Unpooled.wrappedBuffer(input));
+    }
+
+    private static ElasticLogMeta decodeEnvelope(ByteBuf envelope) {
+        if (envelope.readableBytes() < HEADER_SIZE) {
+            throw new IllegalArgumentException("Truncated ElasticLogMeta envelope header");
+        }
+        envelope.readInt();
+        int encodingVersion = envelope.readUnsignedByte();
+        if (encodingVersion != ENCODING_VERSION_V0) {
+            throw new IllegalArgumentException("Unsupported ElasticLogMeta encoding version: " + encodingVersion);
+        }
+
+        int attributes = envelope.readInt();
+        if ((attributes & ~COMPRESSION_MASK) != 0) {
+            throw new IllegalArgumentException("Unsupported ElasticLogMeta attributes: " + attributes);
+        }
+        int compressionId = attributes & COMPRESSION_MASK;
+        if (compressionId != CompressionType.NONE.id && compressionId != CompressionType.ZSTD.id) {
+            throw new IllegalArgumentException("Unsupported ElasticLogMeta compression type: " + compressionId);
+        }
+        CompressionType compressionType = CompressionType.forId(compressionId);
+
+        int uncompressedSize = envelope.readInt();
+        if (uncompressedSize < 0) {
+            throw new IllegalArgumentException("Negative ElasticLogMeta uncompressed size: " + uncompressedSize);
+        }
+        return compressionType == CompressionType.NONE
+            ? decodeUncompressed(envelope, uncompressedSize)
+            : decodeCompressed(envelope, uncompressedSize);
+    }
+
+    private static ElasticLogMeta decodeUncompressed(ByteBuf payload, int uncompressedSize) {
+        if (payload.readableBytes() != uncompressedSize) {
+            throw new IllegalArgumentException("ElasticLogMeta payload size does not match uncompressed size");
+        }
+        return decodeAvro(payload);
+    }
+
+    private static ElasticLogMeta decodeCompressed(ByteBuf payload, int uncompressedSize) {
+        byte[] compressedPayload = new byte[payload.readableBytes()];
+        payload.readBytes(compressedPayload);
+        byte[] rawPayload = new byte[uncompressedSize];
+        long actualSize;
+        try {
+            actualSize = Zstd.decompress(rawPayload, compressedPayload);
+        } catch (ZstdException e) {
+            throw new IllegalArgumentException("Failed to decompress ElasticLogMeta", e);
+        }
+        if (Zstd.isError(actualSize)) {
+            throw new IllegalArgumentException("Failed to decompress ElasticLogMeta: " + Zstd.getErrorName(actualSize));
+        }
+        if (actualSize != uncompressedSize) {
+            throw new IllegalArgumentException("ElasticLogMeta decompressed size " + actualSize
+                + " does not match declared size " + uncompressedSize);
+        }
+        return decodeAvro(rawPayload);
+    }
+
+    private static byte[] encodeAvro(ElasticLogMeta meta) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+            new GenericDatumWriter<GenericRecord>(SCHEMA_V0).write(toRecord(meta), encoder);
+            encoder.flush();
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to encode ElasticLogMeta as Avro", e);
+        }
+    }
+
+    private static ElasticLogMeta decodeAvro(ByteBuf payload) {
+        try {
+            BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(new ByteBufInputStream(payload), null);
+            return readAvro(decoder);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to decode ElasticLogMeta Avro payload", e);
+        }
+    }
+
+    private static ElasticLogMeta decodeAvro(byte[] payload) {
+        return decodeAvro(Unpooled.wrappedBuffer(payload));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ElasticLogMeta readAvro(BinaryDecoder decoder) throws IOException {
+        GenericRecord record = new GenericDatumReader<GenericRecord>(SCHEMA_V0).read(null, decoder);
+        if (!decoder.isEnd()) {
+            throw new IllegalArgumentException("Trailing bytes in ElasticLogMeta Avro payload");
+        }
+        ElasticLogMeta meta = new ElasticLogMeta();
+        Map<String, Long> streamMap = new HashMap<>();
+        ((Map<CharSequence, Long>) record.get("streamMap"))
+            .forEach((key, value) -> streamMap.put(key.toString(), value));
+        meta.setStreamMap(streamMap);
+
+        List<ElasticStreamSegmentMeta> segmentMetas = new ArrayList<>();
+        for (GenericRecord segmentRecord : (List<GenericRecord>) record.get("segmentMetas")) {
+            segmentMetas.add(segmentMetaFromRecord(segmentRecord));
+        }
+        meta.setSegmentMetas(segmentMetas);
+        return meta;
+    }
+
+    private static GenericRecord toRecord(ElasticLogMeta meta) {
+        GenericRecord record = new GenericData.Record(SCHEMA_V0);
+        record.put("streamMap", meta.getStreamMap());
+        List<GenericRecord> segmentRecords = new ArrayList<>(meta.getSegmentMetas().size());
+        for (ElasticStreamSegmentMeta segmentMeta : meta.getSegmentMetas()) {
+            segmentRecords.add(toRecord(segmentMeta));
+        }
+        record.put("segmentMetas", segmentRecords);
+        return record;
+    }
+
+    private static GenericRecord toRecord(ElasticStreamSegmentMeta meta) {
+        GenericRecord record = new GenericData.Record(SEGMENT_META_SCHEMA);
+        record.put("baseOffset", meta.baseOffset());
+        record.put("createTimestamp", meta.createTimestamp());
+        record.put("lastModifiedTimestamp", meta.lastModifiedTimestamp());
+        record.put("streamSuffix", meta.streamSuffix());
+        record.put("logSize", meta.logSize());
+        record.put("log", toRecord(meta.log()));
+        record.put("time", toRecord(meta.time()));
+        record.put("txn", toRecord(meta.txn()));
+        record.put("firstBatchTimestamp", meta.firstBatchTimestamp());
+        record.put("timeIndexLastEntry", toRecord(meta.timeIndexLastEntry()));
+        return record;
+    }
+
+    private static GenericRecord toRecord(SliceRange range) {
+        GenericRecord record = new GenericData.Record(SLICE_RANGE_SCHEMA);
+        record.put("start", range.start());
+        record.put("end", range.end());
+        return record;
+    }
+
+    private static GenericRecord toRecord(ElasticStreamSegmentMeta.TimestampOffsetData timestampOffset) {
+        GenericRecord record = new GenericData.Record(TIMESTAMP_OFFSET_SCHEMA);
+        record.put("timestamp", timestampOffset.timestamp());
+        record.put("offset", timestampOffset.offset());
+        return record;
+    }
+
+    private static ElasticStreamSegmentMeta segmentMetaFromRecord(GenericRecord record) {
+        ElasticStreamSegmentMeta meta = new ElasticStreamSegmentMeta();
+        meta.baseOffset((Long) record.get("baseOffset"));
+        meta.createTimestamp((Long) record.get("createTimestamp"));
+        meta.lastModifiedTimestamp((Long) record.get("lastModifiedTimestamp"));
+        meta.streamSuffix(record.get("streamSuffix").toString());
+        meta.logSize((Integer) record.get("logSize"));
+        meta.log(sliceRangeFromRecord((GenericRecord) record.get("log")));
+        meta.time(sliceRangeFromRecord((GenericRecord) record.get("time")));
+        meta.txn(sliceRangeFromRecord((GenericRecord) record.get("txn")));
+        meta.firstBatchTimestamp((Long) record.get("firstBatchTimestamp"));
+        meta.timeIndexLastEntry(timestampOffsetFromRecord((GenericRecord) record.get("timeIndexLastEntry")));
+        return meta;
+    }
+
+    private static SliceRange sliceRangeFromRecord(GenericRecord record) {
+        return SliceRange.of((Long) record.get("start"), (Long) record.get("end"));
+    }
+
+    private static ElasticStreamSegmentMeta.TimestampOffsetData timestampOffsetFromRecord(GenericRecord record) {
+        return ElasticStreamSegmentMeta.TimestampOffsetData.of(
+            (Long) record.get("timestamp"), (Long) record.get("offset"));
+    }
+}

--- a/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
+++ b/core/src/main/scala/kafka/log/streamaspect/ElasticLogSegmentManager.java
@@ -21,6 +21,7 @@ package kafka.log.streamaspect;
 
 import kafka.cluster.LogEventListener;
 
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 import org.apache.kafka.storage.internals.log.LogSegment;
 
 import com.automq.stream.api.Stream;
@@ -41,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class ElasticLogSegmentManager {
@@ -58,13 +60,30 @@ public class ElasticLogSegmentManager {
     private final MetaStream metaStream;
     private final ElasticLogStreamManager streamManager;
     private final String logIdent;
+    private final Supplier<AutoMQVersion> autoMQVersionSupplier;
 
     private volatile ElasticLogMeta logMeta;
 
     public ElasticLogSegmentManager(MetaStream metaStream, ElasticLogStreamManager streamManager, String logIdent) {
+        this(metaStream, streamManager, logIdent,
+            ElasticLogManager$.MODULE$.autoMQVersionSupplier());
+    }
+
+    /**
+     * Creates a manager whose writer policy follows the live finalized AutoMQ version.
+     * The supplier is evaluated for every metadata persistence and must be safe to call concurrently.
+     *
+     * @param metaStream metadata stream receiving complete log metadata values
+     * @param streamManager owner of the streams referenced by the metadata
+     * @param logIdent log prefix identifying the owning Partition
+     * @param autoMQVersionSupplier live finalized AutoMQ version supplier
+     */
+    public ElasticLogSegmentManager(MetaStream metaStream, ElasticLogStreamManager streamManager, String logIdent,
+        Supplier<AutoMQVersion> autoMQVersionSupplier) {
         this.metaStream = metaStream;
         this.streamManager = streamManager;
         this.logIdent = logIdent;
+        this.autoMQVersionSupplier = autoMQVersionSupplier;
     }
 
     public void put(long baseOffset, ElasticLogSegment segment) {
@@ -167,7 +186,8 @@ public class ElasticLogSegmentManager {
             segmentLock.unlock();
         }
 
-        MetaKeyValue kv = MetaKeyValue.of(MetaStream.LOG_META_KEY, ElasticLogMeta.encode(meta));
+        MetaKeyValue kv = MetaKeyValue.of(MetaStream.LOG_META_KEY,
+            ElasticLogMetaCodec.encode(meta, autoMQVersionSupplier.get()));
         return metaStream.append(kv).thenApply(nil -> {
             LOGGER.info("{} save log meta {}", logIdent, meta);
             if (trimStreams) {

--- a/core/src/main/scala/kafka/log/streamaspect/MetaStream.java
+++ b/core/src/main/scala/kafka/log/streamaspect/MetaStream.java
@@ -438,7 +438,7 @@ public class MetaStream implements Stream {
         metadataCache.forEach((key, value) -> {
             switch (key) {
                 case LOG_META_KEY:
-                    metaMap.put(key, ElasticLogMeta.decode(value.value()));
+                    metaMap.put(key, ElasticLogMetaCodec.decode(value.value()));
                     break;
                 case PARTITION_META_KEY:
                     metaMap.put(key, ElasticPartitionMeta.decode(value.value()));

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogMetaCodecTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogMetaCodecTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 AutoMQ HK Limited.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log.streamaspect;
+
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
+
+import org.apache.avro.SchemaNormalization;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the persistent ElasticLogMeta wire contract and legacy compatibility boundary.
+ */
+@Tag("S3Unit")
+public class ElasticLogMetaCodecTest {
+
+    /**
+     * Given V5, encoding must retain the legacy JSON representation and remain dual-readable.
+     */
+    @Test
+    public void testV5WritesLegacyJson() {
+        ElasticLogMeta expected = exampleMeta();
+
+        ByteBuffer encoded = ElasticLogMetaCodec.encode(expected, AutoMQVersion.V5);
+
+        assertEquals('{', encoded.get(encoded.position()));
+        assertMetaEquals(expected, ElasticLogMetaCodec.decode(encoded));
+    }
+
+    /**
+     * Given a small V6 value, encoding must use an uncompressed V0 envelope with the fixed golden bytes.
+     */
+    @Test
+    public void testV6EmptyMetaGoldenEnvelope() {
+        ByteBuffer encoded = ElasticLogMetaCodec.encode(new ElasticLogMeta(), AutoMQVersion.V6);
+        byte[] actual = new byte[encoded.remaining()];
+        encoded.get(actual);
+
+        byte[] expected = new byte[] {
+            0x45, 0x4c, 0x4d, 0x00,
+            0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00
+        };
+        assertArrayEquals(expected, actual);
+    }
+
+    /**
+     * Given every SegmentMeta field, the published V0 Avro field order and binary encoding must remain stable.
+     */
+    @Test
+    public void testV0FullSegmentMetaGoldenPayload() {
+        ElasticLogMeta meta = new ElasticLogMeta();
+        meta.setSegmentMetas(List.of(exampleSegmentMeta()));
+
+        ByteBuffer encoded = ElasticLogMetaCodec.encode(meta, AutoMQVersion.V6);
+        byte[] actual = new byte[encoded.remaining()];
+        encoded.get(actual);
+
+        assertEquals("RUxNAAAAAAAAAAAAGQAC9gGQB6oMAjCAEAIEBggKDIIFnAq2DwA=",
+            Base64.getEncoder().encodeToString(actual));
+    }
+
+    /**
+     * Given complete nested metadata, the V0 Avro mapping must preserve every domain field.
+     */
+    @Test
+    public void testV6AvroRoundTrip() {
+        ElasticLogMeta expected = exampleMeta();
+
+        ByteBuffer encoded = ElasticLogMetaCodec.encode(expected, AutoMQVersion.V6);
+
+        assertMetaEquals(expected, ElasticLogMetaCodec.decode(encoded));
+    }
+
+    /**
+     * Given raw Avro at or above the threshold, V6 must use Zstd and retain its exact raw size.
+     */
+    @Test
+    public void testV6UsesZstdForLargeMeta() {
+        ElasticLogMeta expected = exampleMeta();
+        List<ElasticStreamSegmentMeta> segmentMetas = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            ElasticStreamSegmentMeta segmentMeta = exampleSegmentMeta();
+            segmentMeta.baseOffset(i * 1024L);
+            segmentMeta.streamSuffix("segment-suffix-" + i);
+            segmentMetas.add(segmentMeta);
+        }
+        expected.setSegmentMetas(segmentMetas);
+
+        ByteBuffer encoded = ElasticLogMetaCodec.encode(expected, AutoMQVersion.V6);
+        ByteBuf envelope = Unpooled.wrappedBuffer(encoded.duplicate());
+        assertEquals(ElasticLogMetaCodec.MAGIC, envelope.readInt());
+        assertEquals(ElasticLogMetaCodec.ENCODING_VERSION_V0, envelope.readUnsignedByte());
+        assertEquals(CompressionType.ZSTD.id, envelope.readInt());
+        int uncompressedSize = envelope.readInt();
+        assertTrue(uncompressedSize >= ElasticLogMetaCodec.COMPRESSION_THRESHOLD);
+        assertEquals(ElasticLogMetaCodec.HEADER_SIZE, envelope.readerIndex());
+        assertMetaEquals(expected, ElasticLogMetaCodec.decode(encoded));
+    }
+
+    /**
+     * Given the writer threshold, only raw Avro payloads of at least 16 KiB must use Zstd.
+     */
+    @Test
+    public void testCompressionThresholdBoundary() {
+        assertEquals(CompressionType.NONE,
+            ElasticLogMetaCodec.compressionTypeForSize(ElasticLogMetaCodec.COMPRESSION_THRESHOLD - 1));
+        assertEquals(CompressionType.ZSTD,
+            ElasticLogMetaCodec.compressionTypeForSize(ElasticLogMetaCodec.COMPRESSION_THRESHOLD));
+    }
+
+    /**
+     * Given a published V0 schema, its parsing fingerprint must remain immutable.
+     */
+    @Test
+    public void testV0SchemaFingerprint() {
+        assertEquals(3460547824240030597L,
+            SchemaNormalization.parsingFingerprint64(ElasticLogMetaCodec.SCHEMA_V0));
+    }
+
+    /**
+     * Given a recognized magic, malformed envelopes must fail closed instead of falling back to JSON.
+     */
+    @Test
+    public void testMalformedEnvelopesFailClosed() {
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(1, 0, 0, new byte[0])));
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(0, 0x08, 0, new byte[0])));
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(0, CompressionType.GZIP.id, 0, new byte[0])));
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(0, CompressionType.NONE.id, -1, new byte[0])));
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(0, CompressionType.NONE.id, 1, new byte[0])));
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(
+            envelope(0, CompressionType.ZSTD.id, 32, new byte[] {1, 2, 3})));
+
+        ByteBuffer truncatedHeader = ByteBuffer.allocate(Integer.BYTES).putInt(ElasticLogMetaCodec.MAGIC);
+        truncatedHeader.flip();
+        assertThrows(IllegalArgumentException.class, () -> ElasticLogMetaCodec.decode(truncatedHeader));
+    }
+
+    private static ByteBuffer envelope(int version, int attributes, int uncompressedSize, byte[] payload) {
+        ByteBuffer buffer = ByteBuffer.allocate(ElasticLogMetaCodec.HEADER_SIZE + payload.length);
+        buffer.putInt(ElasticLogMetaCodec.MAGIC);
+        buffer.put((byte) version);
+        buffer.putInt(attributes);
+        buffer.putInt(uncompressedSize);
+        buffer.put(payload);
+        buffer.flip();
+        return buffer;
+    }
+
+    private static ElasticLogMeta exampleMeta() {
+        ElasticLogMeta meta = new ElasticLogMeta();
+        Map<String, Long> streamMap = new HashMap<>();
+        streamMap.put("log0", 11L);
+        streamMap.put("tim0", 12L);
+        streamMap.put("txn0", 13L);
+        meta.setStreamMap(streamMap);
+        meta.setSegmentMetas(List.of(exampleSegmentMeta()));
+        return meta;
+    }
+
+    private static ElasticStreamSegmentMeta exampleSegmentMeta() {
+        ElasticStreamSegmentMeta meta = new ElasticStreamSegmentMeta();
+        meta.baseOffset(123L);
+        meta.createTimestamp(456L);
+        meta.lastModifiedTimestamp(789L);
+        meta.streamSuffix("0");
+        meta.logSize(1024);
+        meta.log(SliceRange.of(1L, 2L));
+        meta.time(SliceRange.of(3L, 4L));
+        meta.txn(SliceRange.of(5L, 6L));
+        meta.firstBatchTimestamp(321L);
+        meta.timeIndexLastEntry(ElasticStreamSegmentMeta.TimestampOffsetData.of(654L, 987L));
+        return meta;
+    }
+
+    private static void assertMetaEquals(ElasticLogMeta expected, ElasticLogMeta actual) {
+        assertEquals(expected.getStreamMap(), actual.getStreamMap());
+        assertEquals(expected.getSegmentMetas().size(), actual.getSegmentMetas().size());
+        for (int i = 0; i < expected.getSegmentMetas().size(); i++) {
+            assertSegmentMetaEquals(expected.getSegmentMetas().get(i), actual.getSegmentMetas().get(i));
+        }
+    }
+
+    private static void assertSegmentMetaEquals(ElasticStreamSegmentMeta expected, ElasticStreamSegmentMeta actual) {
+        assertEquals(expected.baseOffset(), actual.baseOffset());
+        assertEquals(expected.createTimestamp(), actual.createTimestamp());
+        assertEquals(expected.lastModifiedTimestamp(), actual.lastModifiedTimestamp());
+        assertEquals(expected.streamSuffix(), actual.streamSuffix());
+        assertEquals(expected.logSize(), actual.logSize());
+        assertSliceRangeEquals(expected.log(), actual.log());
+        assertSliceRangeEquals(expected.time(), actual.time());
+        assertSliceRangeEquals(expected.txn(), actual.txn());
+        assertEquals(expected.firstBatchTimestamp(), actual.firstBatchTimestamp());
+        assertEquals(expected.timeIndexLastEntry().timestamp(), actual.timeIndexLastEntry().timestamp());
+        assertEquals(expected.timeIndexLastEntry().offset(), actual.timeIndexLastEntry().offset());
+    }
+
+    private static void assertSliceRangeEquals(SliceRange expected, SliceRange actual) {
+        assertEquals(expected.start(), actual.start());
+        assertEquals(expected.end(), actual.end());
+    }
+}

--- a/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/ElasticLogSegmentManagerTest.java
@@ -19,19 +19,27 @@
 
 package kafka.log.streamaspect;
 
+import org.apache.kafka.server.common.automq.AutoMQVersion;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import scala.Option;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -48,6 +56,61 @@ import static org.mockito.Mockito.when;
 @Timeout(60)
 @Tag("S3Unit")
 public class ElasticLogSegmentManagerTest {
+
+    /**
+     * Given a live version supplier, the next normal persistence must switch from JSON to the V6 envelope.
+     */
+    @Test
+    public void testPersistReadsAutoMQVersionDynamically() {
+        MetaStream metaStream = mock(MetaStream.class);
+        when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
+        ElasticLogStreamManager streamManager = mock(ElasticLogStreamManager.class);
+        when(streamManager.streams()).thenReturn(Map.of());
+        AtomicReference<AutoMQVersion> version = new AtomicReference<>(AutoMQVersion.V5);
+        ElasticLogSegmentManager manager = new ElasticLogSegmentManager(
+            metaStream, streamManager, "testPersistReadsAutoMQVersionDynamically", version::get);
+
+        manager.persistLogMeta();
+        version.set(AutoMQVersion.V6);
+        manager.persistLogMeta();
+
+        ArgumentCaptor<MetaKeyValue> values = ArgumentCaptor.forClass(MetaKeyValue.class);
+        verify(metaStream, times(2)).append(values.capture());
+        assertNotEquals(ElasticLogMetaCodec.MAGIC, values.getAllValues().get(0).getValue().getInt());
+        assertEquals(ElasticLogMetaCodec.MAGIC, values.getAllValues().get(1).getValue().getInt());
+        assertEquals(MetaStream.LOG_META_KEY, values.getAllValues().get(0).getKey());
+        assertEquals(MetaStream.LOG_META_KEY, values.getAllValues().get(1).getKey());
+    }
+
+    /**
+     * Given a default manager created before ElasticLogManager initialization, its writer policy must become V6
+     * after the live manager is published.
+     */
+    @Test
+    public void testDefaultManagerObservesLateElasticLogManagerInitialization() {
+        Option<ElasticLogManager> originalManager = ElasticLogManager$.MODULE$.INSTANCE();
+        try {
+            ElasticLogManager$.MODULE$.INSTANCE_$eq(Option.empty());
+            MetaStream metaStream = mock(MetaStream.class);
+            when(metaStream.append(any(MetaKeyValue.class))).thenReturn(CompletableFuture.completedFuture(null));
+            ElasticLogStreamManager streamManager = mock(ElasticLogStreamManager.class);
+            when(streamManager.streams()).thenReturn(Map.of());
+            ElasticLogSegmentManager manager = new ElasticLogSegmentManager(
+                metaStream, streamManager, "testDefaultManagerObservesLateElasticLogManagerInitialization");
+
+            ElasticLogManager liveManager = new ElasticLogManager(
+                null, null, () -> AutoMQVersion.V6);
+            ElasticLogManager$.MODULE$.INSTANCE_$eq(Option.apply(liveManager));
+            manager.persistLogMeta();
+
+            ArgumentCaptor<MetaKeyValue> value = ArgumentCaptor.forClass(MetaKeyValue.class);
+            verify(metaStream).append(value.capture());
+            assertEquals(ElasticLogMetaCodec.MAGIC, value.getValue().getValue().getInt());
+        } finally {
+            ElasticLogManager$.MODULE$.INSTANCE_$eq(originalManager);
+        }
+    }
+
     @Test
     public void testSegmentDelete() {
         ElasticLogMeta logMeta = mock(ElasticLogMeta.class);

--- a/core/src/test/java/kafka/log/streamaspect/MetaStreamTest.java
+++ b/core/src/test/java/kafka/log/streamaspect/MetaStreamTest.java
@@ -28,6 +28,7 @@ import kafka.log.streamaspect.reassignment.PartitionHandoffSendException;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.server.common.automq.AutoMQVersion;
 
 import com.automq.stream.DefaultRecordBatch;
 import com.automq.stream.api.AppendResult;
@@ -170,6 +171,25 @@ public class MetaStreamTest {
         assertArrayEquals(new byte[] {7, 8}, bytes((ByteBuffer) replayed.get("UNKNOWN_FUTURE_KEY")));
         assertTrue(metaStream.get(MetaStream.PARTITION_META_KEY).isPresent());
         assertArrayEquals(new byte[] {7, 8}, bytes(metaStream.get("UNKNOWN_FUTURE_KEY").orElseThrow()));
+    }
+
+    /**
+     * Given V6 ElasticLog metadata in the stream, replay must decode the envelope without a version-side channel.
+     */
+    @Test
+    public void testReplayDecodesV6ElasticLogMeta() throws Exception {
+        ElasticLogMeta expected = new ElasticLogMeta();
+        expected.setStreamMap(Map.of("log0", 42L));
+        MemoryClient.StreamImpl innerStream = new MemoryClient.StreamImpl(1L);
+        appendRaw(innerStream, MetaKeyValue.of(MetaStream.LOG_META_KEY,
+            ElasticLogMetaCodec.encode(expected, AutoMQVersion.V6)));
+        MetaStream metaStream = ordinaryMetaStream(innerStream);
+
+        Map<String, Object> replayed = metaStream.replay();
+
+        ElasticLogMeta actual = (ElasticLogMeta) replayed.get(MetaStream.LOG_META_KEY);
+        assertEquals(expected.getStreamMap(), actual.getStreamMap());
+        assertEquals(0, actual.getSegmentMetas().size());
     }
 
     /**

--- a/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
+++ b/core/src/test/scala/kafka/log/streamaspect/ElasticLogTest.scala
@@ -1238,7 +1238,7 @@ class ElasticLogTest {
         val partitionMeta = new ElasticPartitionMeta(startOffset, startOffset + 1, startOffset + 2)
         partitionMeta.setCleanedShutdown(true)
         val records = List(
-            handoffRecord(0L, MetaKeyValue.of(MetaStream.LOG_META_KEY, ElasticLogMeta.encode(new ElasticLogMeta()))),
+            handoffRecord(0L, MetaKeyValue.of(MetaStream.LOG_META_KEY, ElasticLogMetaCodec.encodeJson(new ElasticLogMeta()))),
             handoffRecord(1L, MetaKeyValue.of(MetaStream.PARTITION_META_KEY, ElasticPartitionMeta.encode(partitionMeta))),
             handoffRecord(2L, MetaKeyValue.of(MetaStream.LEADER_EPOCH_CHECKPOINT_KEY,
                 ByteBuffer.wrap(new ElasticLeaderEpochCheckpointMeta(0, Collections.emptyList()).encode()))))

--- a/server-common/src/main/java/org/apache/kafka/server/common/automq/AutoMQVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/automq/AutoMQVersion.java
@@ -45,6 +45,7 @@ public enum AutoMQVersion implements FeatureVersion {
     V5((short) 6, MetadataVersion.IBP_3_9_IV0),
     // Support fast partition reassignment
     // Support Infinite Storage Stream Archive
+    // Support Avro-encoded ElasticLog metadata
     V6((short) 7, MetadataVersion.IBP_3_9_IV0);
 
     public static final String FEATURE_NAME = "automq.version";
@@ -147,6 +148,13 @@ public enum AutoMQVersion implements FeatureVersion {
      * Returns whether the finalized feature level supports Stream Archive metadata and protocol.
      */
     public boolean isStreamArchiveSupported() {
+        return isAtLeast(V6);
+    }
+
+    /**
+     * Returns whether ElasticLog metadata may be written using the Avro envelope.
+     */
+    public boolean isElasticLogMetaAvroSupported() {
         return isAtLeast(V6);
     }
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/automq/AutoMQVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/automq/AutoMQVersionTest.java
@@ -55,4 +55,13 @@ public class AutoMQVersionTest {
         assertSame(Version.V1, AutoMQVersion.V5.s3streamVersion());
         assertSame(Version.V2, AutoMQVersion.V6.s3streamVersion());
     }
+
+    /**
+     * Given adjacent AutoMQ feature levels, Avro ElasticLog metadata starts at V6.
+     */
+    @Test
+    public void testElasticLogMetaAvroCapabilityStartsAtV6() {
+        assertFalse(AutoMQVersion.V5.isElasticLogMetaAvroSupported());
+        assertTrue(AutoMQVersion.V6.isElasticLogMetaAvroSupported());
+    }
 }


### PR DESCRIPTION
## Why

`ElasticLogMeta` is currently persisted as verbose JSON. As the number of logical segments grows for infinite-storage partitions, this metadata becomes unnecessarily large and expensive to persist and recover. The optimization is already available on the `1.8` branch and needs to be carried forward to `main` while retaining compatibility with metadata written by V5 and earlier versions.

## What

Add `ElasticLogMetaCodec` with a versioned Avro envelope for `AutoMQVersion` V6 and newer, while retaining legacy JSON writes for V5 and earlier versions. Readers continue to use the existing `LOG` metadata key and support both formats; JSON fallback occurs only when the Avro magic does not match, while malformed recognized envelopes fail closed.

The Avro schema preserves the existing array-of-structs (`AoS`) metadata shape. Payloads at or above 16 KiB use Zstd level 3 and smaller payloads remain uncompressed. The envelope records the encoding version, compression attributes, and uncompressed payload size.

For a representative 100 TiB partition with the default 1 GiB logical segment size, the metadata contains approximately 102,400 logical segments. The measured serialized size is approximately 26.06 MiB with the current JSON representation, 7.57 MiB with Avro binary, and 2.42 MiB with Avro plus Zstd level 3. This reduces the persisted metadata footprint by about 71% compared with JSON before compression and about 91% after compression.

`ElasticLogManager` provides a live version supplier, evaluated by `ElasticLogSegmentManager` on each metadata persistence. This allows JSON metadata to migrate naturally on the next V6 persistence without changing the key or adding a proactive rewrite.

## Reviewer notes

This change cherry-picks the implementation merged into `1.8` by #3574.

Start with `core/src/main/scala/kafka/log/streamaspect/ElasticLogMetaCodec.java` for the wire format, schema, compression, and compatibility rules. Then read `ElasticLogSegmentManager.java` and `ElasticLogManager.scala` for persistence ownership and live version propagation. `MetaStream.java` contains the dual-read integration point. The corresponding tests are `ElasticLogMetaCodecTest.java`, `ElasticLogSegmentManagerTest.java`, and `MetaStreamTest.java`.
