### PR TITLE
fix(metadata): clear pending topic configs on replay

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
@@ -71,12 +71,15 @@ public final class ConfigurationsDelta {
     public void replay(RemoveTopicRecord record, String topicName) {
         ConfigResource resource =
             new ConfigResource(Type.TOPIC, topicName);
-        if (image.resourceData().containsKey(resource)) {
-            ConfigurationImage configImage = image.resourceData().get(resource);
+        // AutoMQ inject start
+        if (image.resourceData().containsKey(resource) || changes.containsKey(resource)) {
+            ConfigurationImage configImage = image.resourceData().getOrDefault(resource,
+                new ConfigurationImage(resource, new HashMap<>()));
             ConfigurationDelta delta = changes.computeIfAbsent(resource,
                 __ -> new ConfigurationDelta(configImage));
             delta.deleteAll();
         }
+        // AutoMQ inject end
     }
 
     public ConfigurationsImage apply() {

--- a/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.kafka.image;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -35,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -116,6 +120,39 @@ public class ConfigurationsImageTest {
     @Test
     public void testImage2RoundTrip() {
         testToImage(IMAGE2);
+    }
+
+    /** Verifies that removing a topic clears pending configuration before same-name recreation. */
+    @Tag("S3Unit")
+    @Test
+    public void testRemoveTopicRecordClearsPendingTopicConfig() {
+        String topicName = "topic";
+        ConfigurationsDelta delta = new ConfigurationsDelta(ConfigurationsImage.EMPTY);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("old.key").setValue("old-value"));
+        delta.replay(new RemoveTopicRecord().setTopicId(Uuid.ZERO_UUID), topicName);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("new.key").setValue("new-value"));
+
+        assertEquals(Collections.singletonMap("new.key", "new-value"),
+            delta.apply().configMapForResource(new ConfigResource(TOPIC, topicName)));
+    }
+
+    /** Verifies that removing a topic still clears configuration already present in the image. */
+    @Tag("S3Unit")
+    @Test
+    public void testRemoveTopicRecordClearsBaseTopicConfig() {
+        String topicName = "topic";
+        ConfigResource resource = new ConfigResource(TOPIC, topicName);
+        ConfigurationsImage baseImage = new ConfigurationsImage(Collections.singletonMap(resource,
+            new ConfigurationImage(resource, Collections.singletonMap("old.key", "old-value"))));
+        ConfigurationsDelta delta = new ConfigurationsDelta(baseImage);
+        delta.replay(new RemoveTopicRecord().setTopicId(Uuid.ZERO_UUID), topicName);
+        delta.replay(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName(topicName).
+            setName("new.key").setValue("new-value"));
+
+        assertEquals(Collections.singletonMap("new.key", "new-value"),
+            delta.apply().configMapForResource(resource));
     }
 
     private static void testToImage(ConfigurationsImage image) {


### PR DESCRIPTION
## Why

`ConfigurationsDelta.replay(RemoveTopicRecord, topicName)` only checks the base image for topic configuration. If an old topic configuration exists only in the current pending delta, replay skips cleanup and can leak stale configuration into a same-name recreated topic.

This cherry-picks the fix merged by #3575 from `1.7` into `main`.

## What

Clear topic configuration when the resource exists in either the base image or the pending changes. Preserve the existing base-image path and use a mutable empty map for a pending-only resource.

Add regression coverage for pending-delta cleanup and the existing base-image cleanup behavior.

## How

`RemoveTopicRecord` now recognizes a `ConfigurationDelta` already accumulated for the topic. `deleteAll()` clears those pending changes before any configuration for a same-name recreated topic is replayed.

## Reviewer notes

Review `ConfigurationsDelta` for the replay condition and `ConfigurationsImageTest` for the two protected state transitions.

## Testing

- `./gradlew :metadata:S3UnitTest --tests org.apache.kafka.image.ConfigurationsImageTest --no-daemon`
- `./gradlew --build-cache rat checkstyleMain checkstyleTest --no-daemon`

The repository does not define the documented `spotlessJavaCheck` task.