### PR TITLE
fix: handle channel removal gracefully in processCompletedReceives

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1215,8 +1215,13 @@ private[kafka] class Processor(
               }
             }
           case None =>
-            // This should never happen since completed receives are processed immediately after `poll()`
-            throw new IllegalStateException(s"Channel ${receive.source} removed from selector before processing completed receive")
+            // AutoMQ inject start
+            // Channel was removed from selector before processing completed receive.
+            // This can happen when client disconnects abruptly or connection was expired/closed.
+            debug(s"Channel ${receive.source} removed from selector before processing completed receive")
+            removeChannelContext(receive.source)
+            CoreUtils.swallow(receive.close(), this, Level.WARN)
+            // AutoMQ inject end
         }
       } catch {
         // note that even though we got an exception, we can assume that receive.source is valid.

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1719,6 +1719,32 @@ class SocketServerTest {
   }
 
   /**
+   * AutoMQ test for Issue #2094:
+   * Tests that when a completed receive exists for a channel that has already been removed
+   * from the selector (e.g. client abrupt disconnect or timeout), processCompletedReceives
+   * handles it gracefully without throwing an IllegalStateException or killing the processor.
+   */
+  @Test
+  def testCompletedReceiveWithRemovedChannel(): Unit = {
+    withTestableServer(testWithServer = { testableServer =>
+      val (socket, _) = connectAndProcessRequest(testableServer)
+      val testableSelector = testableServer.testableSelector
+
+      // Inject a completed receive for an unknown/already-removed connection ID
+      val removedConnectionId = "127.0.0.1:9092-127.0.0.1:65535-999"
+      val dummyReceive = new NetworkReceive(removedConnectionId, ByteBuffer.allocate(100))
+      testableSelector.cachedCompletedReceives.deferredValues += dummyReceive
+      testableSelector.cachedCompletedReceives.minPerPoll = 1
+
+      // Trigger a poll cycle to process the completed receive
+      testableSelector.waitForOperations(SelectorOperation.Poll, 1)
+
+      // Processor remains healthy and no uncaught exceptions occurred
+      assertProcessorHealthy(testableServer, Seq(socket))
+    })
+  }
+
+  /**
    * Tests exception handling in [[Processor.processCompletedSends]]. Exception is
    * injected into [[Selector.unmute]] which is used to unmute the channel after send is complete.
    * Test creates two completed sends in a single iteration by caching completed sends until two
@@ -2324,8 +2350,7 @@ class SocketServerTest {
         val currentReceives = update(selector.completedReceives.asScala.toBuffer)
         completedReceivesMap.clear()
         currentReceives.foreach { receive =>
-          val channelOpt = Option(selector.channel(receive.source)).orElse(Option(selector.closingChannel(receive.source)))
-          channelOpt.foreach { channel => completedReceivesMap.put(channel.id, receive) }
+          completedReceivesMap.put(receive.source, receive)
         }
       }
     }


### PR DESCRIPTION
 Fixes #2094

### Problem
When a client disconnects abruptly, times out, or closes during request processing:
1. The channel is closed and removed from `Selector`.
2. Any completed receives buffered during the same poll loop still get processed in `processCompletedReceives`.
3. In `SocketServer.scala`, `openOrClosingChannel(receive.source)` returns `None`, which previously threw `IllegalStateException(s"Channel ${receive.source} removed from selector before processing completed receive")`.
4. This exception was caught and logged as a loud, severe `ERROR` stack trace by `processChannelException`, flooding broker logs in production.
5. More importantly, `receive.close()` was never invoked on the orphaned receive, causing any allocated buffer in `MemoryPool` to leak until GC.

### Solution
1. **Graceful Handling in `SocketServer.scala`**:
   - In `processCompletedReceives()`, when `openOrClosingChannel` returns `None`, log at `debug` level instead of throwing `IllegalStateException`.
   - Explicitly invoke `CoreUtils.swallow(receive.close(), this, Level.WARN)` to safely release `receive.payload` buffer back to `MemoryPool`.
   - Clean up any associated `channelContexts` via `removeChannelContext(receive.source)`.
2. **Unit Test in `SocketServerTest.scala`**:
   - Added `testCompletedReceiveWithRemovedChannel()` verifying that an orphaned completed receive whose channel was removed from selector is processed cleanly without throwing an `IllegalStateException` or recording uncaught exceptions, keeping the processor healthy.

### Verification
- Ran unit test locally:
  ```bash
  ./gradlew :core:test --tests "kafka.network.SocketServerTest.testCompletedReceiveWithRemovedChannel" -x checkstyleTest -x checkstyleMain -x spotbugsMain -x spotbugsTest