### PR TITLE
docs: fix broken links, redundant onboarding content, and release URL

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -3,13 +3,11 @@
 Thank you for your interest in contributing! We love community contributions.
 Read on to learn how to contribute to AutoMQ.
 We appreciate first-time contributors, and we are happy to assist you in getting started. In case of questions, just
-reach out to us via [Wechat Group](https://www.automq.com/img/----------------------------1.png)
+reach out to us via [Wechat Group](docs/images/automq-wechat.png)
 or [Slack](https://join.slack.com/t/automq/shared_invite/zt-29h17vye9-thf31ebIVL9oXuRdACnOIA)!
 
 Before getting started, please review AutoMQ's Code of Conduct. Everyone interacting in Slack or WeChat
 follow [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Suggested Onboarding Path for New Contributors
 
 ## Quick Start for First-Time Contributors (Recommended)
 
@@ -37,20 +35,12 @@ If you are new to AutoMQ, we recommend starting with the simplest path before di
 
 > Tip: If you encounter setup issues, check [devkit/README.md](devkit/README.md), “Local Debug with IDEA”, and S3 configuration sections below.
 
-
-If you are new to AutoMQ, it is recommended to first deploy and run AutoMQ using Docker as described in the README.
-This helps you quickly understand AutoMQ’s core concepts and behavior without local environment complexity.
-
-After gaining familiarity, contributors who want to work on code can follow the steps in this guide to build and run AutoMQ locally.
-For most contributors, we recommend starting with DevKit (`devkit/README.md`) and using the manual setup only when deeper environment customization is needed.
-
-
 ## Code Contributions
 
 ### Finding or Reporting Issues
 
 -   **Find an existing issue:** Look through the [existing issues](https://github.com/AutoMQ/automq/issues). Issues open for contributions are often tagged with `good first issue`. To claim an issue, simply reply with '/assign', and the GitHub bot will assign it to you. Start with
-    this [tagged good first issue](https://github.com/AutoMQ/automq-for-kafka/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+    this [tagged good first issue](https://github.com/AutoMQ/automq/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 -   **Report a new issue:** If you've found a bug or have a feature request, please [create a new issue](https://github.com/AutoMQ/automq/issues/new/choose). Select the appropriate template (Bug Report or Feature Request) and fill out the form provided.
 
 If you have any questions about an issue, please feel free to ask in the issue comments. We will do our best to clarify any doubts you may have.
@@ -92,7 +82,7 @@ Pull Request reviews are done on a regular basis.
 > Note: At least 8GB RAM is recommended for local development and debugging.
 
 
-> Tips: You can refer the [document](https://www.scala-lang.org/download/2.13.12.html) to install Scala 2.13
+> Tips: You can refer to the [documentation](https://www.scala-lang.org/download/2.13.12.html) to install Scala 2.13
 
 ## Local Debug with IDEA
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Before running AutoMQ locally, please ensure:
 
 The `docker/docker-compose.yaml` file provides a simple single-node setup for quick evaluation and development:
 ```shell
-curl -O https://raw.githubusercontent.com/AutoMQ/automq/refs/tags/1.5.5/docker/docker-compose.yaml && docker compose -f docker-compose.yaml up -d
+curl -O https://raw.githubusercontent.com/AutoMQ/automq/main/docker/docker-compose.yaml && docker compose -f docker-compose.yaml up -d
 ```
 This setup features a single AutoMQ node serving as both controller and broker, alongside MinIO for S3 storage. All services operate within a Docker bridge network called `automq_net`, allowing you to start a Kafka producer in this network to test AutoMQ:
 ```shell

--- a/automq_release.py
+++ b/automq_release.py
@@ -196,4 +196,4 @@ if __name__ == '__main__':
     branch = do_release(tag, s3stream_tag)
     print(f"=== release {tag} done ===")
     print(f"Please create a PR to merge release branch to {main_branch} visiting:")
-    print(f"    https://github.com/AutoMQ/automq-for-kafka/pull/new/{main_branch}...{branch}")
+    print(f"    https://github.com/AutoMQ/automq/pull/new/{main_branch}...{branch}")


### PR DESCRIPTION
## Why
- Malformed WeChat group link and outdated repository links in CONTRIBUTING_GUIDE.md and automq_release.py.
- Duplicated introductory paragraphs in CONTRIBUTING_GUIDE.md.
- Outdated docker-compose tag URL in README.md.

## What
- Fixed WeChat image path to docs/images/automq-wechat.png.
- Updated repository URLs from automq-for-kafka to automq.
- Cleaned up duplicated onboarding text and headings.
- Updated docker-compose quickstart link to main branch.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

###  Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
