### PR TITLE
docs: fix typos and add link to contributor guidance in GSoC ideas

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -92,7 +92,7 @@ Pull Request reviews are done on a regular basis.
 > Note: At least 8GB RAM is recommended for local development and debugging.
 
 
-> Tips: You can refer the [document](https://www.scala-lang.org/download/2.13.12.html) to install Scala 2.13
+> Tips: You can refer to the [document](https://www.scala-lang.org/download/2.13.12.html) to install Scala 2.13
 
 ## Local Debug with IDEA
 

--- a/community/gsoc/2026/AutoMQ_ideas_list.md
+++ b/community/gsoc/2026/AutoMQ_ideas_list.md
@@ -1,6 +1,6 @@
 # AutoMQ Project Ideas
 
-If you are a GSoC candidate, please check out our **Contributor Guidance** to learn more about our project requirements, communication channels, and how to submit a successful proposal.
+If you are a GSoC candidate, please check out our [Contributor Guidance](./Contributor_Guidance_for_Google_Summer_of_Code.md) to learn more about our project requirements, communication channels, and how to submit a successful proposal.
 
 If a project is successfully selected, you will be allocated a primary mentor and supported by the rest of the team. If you are interested in learning more about a particular project idea please contact us using kaiming.wan@automq.com or on our [AutoMQ Slack channel](https://go.automq.com/slack).
 

--- a/release/README.md
+++ b/release/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 
 # Usage
 
-To start a release, first activate the virutalenv, and then run
+To start a release, first activate the virtualenv, and then run
 the release script.
 
 ```


### PR DESCRIPTION
## Why
- In `release/README.md`, there was a typo (`virutalenv` instead of `virtualenv`).
- In `community/gsoc/2026/AutoMQ_ideas_list.md`, the mention of `Contributor Guidance` was plain text without a link to `Contributor_Guidance_for_Google_Summer_of_Code.md`.
- In `CONTRIBUTING_GUIDE.md`, fixed minor phrasing (`refer the document` -> `refer to the document`).

## What
- Fixed `virutalenv` -> `virtualenv` in `release/README.md`.
- Linked `[Contributor Guidance](./Contributor_Guidance_for_Google_Summer_of_Code.md)` in `community/gsoc/2026/AutoMQ_ideas_list.md`.
- Updated preposition in `CONTRIBUTING_GUIDE.md`.

## Testing
- Verified relative markdown links resolve correctly.
- Checked formatting across modified files.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)